### PR TITLE
feat: add iOS/Android APIs documentation v1.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,81 @@
 # Project Guidelines for Claude
 
+## API Naming Conventions (expo-iap/react-native-iap)
+
+### Platform-Specific Function Naming
+
+This project follows the expo-iap naming conventions for clarity and consistency:
+
+#### 1. iOS-Specific Functions (IOS suffix)
+All iOS-only functions must end with `IOS`:
+- `finishTransactionIOS`
+- `clearTransactionIOS`
+- `clearProductsIOS`
+- `getStorefrontIOS`
+- `getPromotedProductIOS`
+- `requestPurchaseOnPromotedProductIOS`
+- `getPendingTransactionsIOS`
+- `isEligibleForIntroOfferIOS`
+- `subscriptionStatusIOS`
+- `currentEntitlementIOS`
+- `latestTransactionIOS`
+- `showManageSubscriptionsIOS`
+- `beginRefundRequestIOS`
+- `isTransactionVerifiedIOS`
+- `getTransactionJwsIOS`
+- `getReceiptDataIOS`
+- `syncIOS`
+- `presentCodeRedemptionSheetIOS`
+- `getAppTransactionIOS`
+
+#### 2. Android-Specific Functions (Android suffix)
+All Android-only functions must end with `Android`:
+- `acknowledgePurchaseAndroid`
+- `consumePurchaseAndroid`
+- `flushFailedPurchaseCachedAsPendingAndroid`
+- `getPackageNameAndroid`
+
+#### 3. Cross-Platform Functions (No suffix)
+Functions available on both platforms have no suffix:
+- `requestProducts` - Get product information
+- `requestPurchase` - Initiate purchase
+- `getAvailablePurchases` - Get user's purchases
+- `finishTransaction` - Complete transaction
+- `validateReceipt` - Validate purchase receipt
+- `initConnection` - Initialize store connection
+- `endConnection` - Close store connection
+- `getActiveSubscriptions` - Get active subscriptions
+- `hasActiveSubscriptions` - Check subscription status
+- `deepLinkToSubscriptions` - Open subscription management
+
+### Naming Rules
+
+1. **Platform Suffixes**:
+   - iOS only: `functionNameIOS`
+   - Android only: `functionNameAndroid`
+   - Cross-platform: no suffix
+
+2. **Action Prefixes**:
+   - `get` - Retrieve data (e.g., `getPromotedProductIOS`)
+   - `request` - Async operations/requests (e.g., `requestPurchase`)
+   - `clear` - Remove/reset (e.g., `clearTransactionIOS`)
+   - `is/has` - Boolean checks (e.g., `isEligibleForIntroOfferIOS`)
+   - `show/present` - Display UI (e.g., `showManageSubscriptionsIOS`)
+   - `begin` - Start a process (e.g., `beginRefundRequestIOS`)
+   - `finish/end` - Complete a process (e.g., `finishTransaction`)
+
+3. **URL Anchors**: Use kebab-case for all URL anchors:
+   - Function: `requestProducts` → Anchor: `#request-products`
+   - Function: `getAppTransactionIOS` → Anchor: `#get-app-transaction-ios`
+
+4. **Search IDs**: Use kebab-case for search modal IDs:
+   - Correct: `id: 'request-products'`
+   - Incorrect: `id: 'requestproducts'`
+
+### Deprecated Functions
+- `getPurchaseHistories` → Use `getAvailablePurchases`
+- `buyPromotedProductIOS` → Use `requestPurchaseOnPromotedProductIOS`
+
 ## Modal Pattern with Preact Signals
 
 ### Global Modal Management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,6 @@ This project follows the expo-iap naming conventions for clarity and consistency
 
 #### 1. iOS-Specific Functions (IOS suffix)
 All iOS-only functions must end with `IOS`:
-- `finishTransactionIOS`
 - `clearTransactionIOS`
 - `clearProductsIOS`
 - `getStorefrontIOS`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,6 @@ Functions available on both platforms have no suffix:
    - Incorrect: `id: 'requestproducts'`
 
 ### Deprecated Functions
-- `getPurchaseHistories` → Use `getAvailablePurchases`
 - `buyPromotedProductIOS` → Use `requestPurchaseOnPromotedProductIOS`
 
 ## Modal Pattern with Preact Signals

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openiap-dev",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "bunx vite",

--- a/src/components/AnchorLink.tsx
+++ b/src/components/AnchorLink.tsx
@@ -33,7 +33,7 @@ function AnchorLink({ id, level, children }: AnchorLinkProps) {
     }
     // Copy to clipboard
     const url = `${window.location.pathname}#${id}`;
-    navigator.clipboard.writeText(window.location.origin + url);
+    void navigator.clipboard.writeText(window.location.origin + url);
   };
 
   return (

--- a/src/components/FeatureCode.tsx
+++ b/src/components/FeatureCode.tsx
@@ -47,7 +47,7 @@ function FeatureCode({ code }: FeatureCodeProps) {
     <div className="feature-code">
       <button
         className={`copy-button ${copied ? 'copied' : ''}`}
-        onClick={handleCopy}
+        onClick={() => void handleCopy()}
         style={{
           position: 'absolute',
           top: '0.5rem',

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -19,6 +19,55 @@ interface SearchModalProps {
 }
 
 const apiData: ApiItem[] = [
+  // Connection Management
+  {
+    id: 'init-connection',
+    title: 'initConnection',
+    category: 'Connection Management',
+    description: 'Initialize connection to the store service',
+    parameters: '',
+    returns: 'Boolean!',
+    path: '/docs/apis#init-connection',
+  },
+  {
+    id: 'end-connection',
+    title: 'endConnection',
+    category: 'Connection Management',
+    description: 'End connection to the store service',
+    parameters: '',
+    returns: 'Boolean!',
+    path: '/docs/apis#end-connection',
+  },
+
+  // Subscription Management
+  {
+    id: 'get-active-subscriptions',
+    title: 'getActiveSubscriptions',
+    category: 'Subscription Management',
+    description: 'Get all active subscriptions with detailed information',
+    parameters: 'subscriptionIds: [String]?',
+    returns: '[ActiveSubscription!]!',
+    path: '/docs/apis#get-active-subscriptions',
+  },
+  {
+    id: 'has-active-subscriptions',
+    title: 'hasActiveSubscriptions',
+    category: 'Subscription Management',
+    description: 'Check if the user has any active subscriptions',
+    parameters: 'subscriptionIds: [String]?',
+    returns: 'Boolean!',
+    path: '/docs/apis#has-active-subscriptions',
+  },
+  {
+    id: 'deep-link-to-subscriptions',
+    title: 'deepLinkToSubscriptions',
+    category: 'Subscription Management',
+    description: 'Open native subscription management interface',
+    parameters: 'DeepLinkOptions',
+    returns: 'Void',
+    path: '/docs/apis#deep-link-to-subscriptions',
+  },
+
   // Product Management
   {
     id: 'request-products',
@@ -263,64 +312,6 @@ const apiData: ApiItem[] = [
     parameters: '',
     returns: 'Void',
     path: '/docs/apis#flush-failed-purchase-cached-as-pending-android',
-  },
-  {
-    id: 'get-package-name-android',
-    title: 'getPackageNameAndroid',
-    category: 'Android APIs',
-    description: 'Get the app package name',
-    parameters: '',
-    returns: 'String!',
-    path: '/docs/apis#get-package-name-android',
-  },
-
-  // Connection Management
-  {
-    id: 'init-connection',
-    title: 'initConnection',
-    category: 'Connection Management',
-    description: 'Initialize connection to the store service',
-    parameters: '',
-    returns: 'Boolean!',
-    path: '/docs/apis#init-connection',
-  },
-  {
-    id: 'end-connection',
-    title: 'endConnection',
-    category: 'Connection Management',
-    description: 'End connection to the store service',
-    parameters: '',
-    returns: 'Boolean!',
-    path: '/docs/apis#end-connection',
-  },
-
-  // Subscription Management
-  {
-    id: 'get-active-subscriptions',
-    title: 'getActiveSubscriptions',
-    category: 'Subscription Management',
-    description: 'Get all active subscriptions with detailed information',
-    parameters: 'subscriptionIds: [String]?',
-    returns: '[ActiveSubscription!]!',
-    path: '/docs/apis#get-active-subscriptions',
-  },
-  {
-    id: 'has-active-subscriptions',
-    title: 'hasActiveSubscriptions',
-    category: 'Subscription Management',
-    description: 'Check if the user has any active subscriptions',
-    parameters: 'subscriptionIds: [String]?',
-    returns: 'Boolean!',
-    path: '/docs/apis#has-active-subscriptions',
-  },
-  {
-    id: 'deep-link-to-subscriptions',
-    title: 'deepLinkToSubscriptions',
-    category: 'Subscription Management',
-    description: 'Open native subscription management interface',
-    parameters: 'DeepLinkOptions',
-    returns: 'Void',
-    path: '/docs/apis#deep-link-to-subscriptions',
   },
 ];
 

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -21,7 +21,7 @@ interface SearchModalProps {
 const apiData: ApiItem[] = [
   // Product Management
   {
-    id: 'requestproducts',
+    id: 'request-products',
     title: 'requestProducts',
     category: 'Product Management',
     description: 'Retrieve products or subscriptions from the store',
@@ -30,7 +30,7 @@ const apiData: ApiItem[] = [
     path: '/docs/apis#request-products',
   },
   {
-    id: 'getavailablepurchases',
+    id: 'get-available-purchases',
     title: 'getAvailablePurchases',
     category: 'Product Management',
     description: 'Get all available purchases for the current user',
@@ -39,7 +39,7 @@ const apiData: ApiItem[] = [
     path: '/docs/apis#get-available-purchases',
   },
   {
-    id: 'getpurchasehistories',
+    id: 'get-purchase-histories',
     title: 'getPurchaseHistories',
     category: 'Product Management',
     description: 'Get purchase history (iOS only)',
@@ -50,7 +50,7 @@ const apiData: ApiItem[] = [
 
   // Purchase Operations
   {
-    id: 'requestpurchase',
+    id: 'request-purchase',
     title: 'requestPurchase',
     category: 'Purchase Operations',
     description: 'Request a purchase (one-time or subscription)',
@@ -59,7 +59,7 @@ const apiData: ApiItem[] = [
     path: '/docs/apis#request-purchase',
   },
   {
-    id: 'finishtransaction',
+    id: 'finish-transaction',
     title: 'finishTransaction',
     category: 'Purchase Operations',
     description:
@@ -71,7 +71,7 @@ const apiData: ApiItem[] = [
 
   // Validation
   {
-    id: 'validatereceipt',
+    id: 'validate-receipt',
     title: 'validateReceipt',
     category: 'Receipt Validation',
     description: 'Validate a receipt with your server or platform servers',
@@ -82,7 +82,7 @@ const apiData: ApiItem[] = [
 
   // iOS APIs
   {
-    id: 'finishtransactionios',
+    id: 'finish-transaction-ios',
     title: 'finishTransactionIOS',
     category: 'iOS APIs',
     description: 'iOS-specific transaction completion',
@@ -91,7 +91,7 @@ const apiData: ApiItem[] = [
     path: '/docs/apis#finish-transaction-ios',
   },
   {
-    id: 'cleartransactionios',
+    id: 'clear-transaction-ios',
     title: 'clearTransactionIOS',
     category: 'iOS APIs',
     description: 'Clear pending transactions',
@@ -100,7 +100,7 @@ const apiData: ApiItem[] = [
     path: '/docs/apis#clear-transaction-ios',
   },
   {
-    id: 'clearproductsios',
+    id: 'clear-products-ios',
     title: 'clearProductsIOS',
     category: 'iOS APIs',
     description: 'Clear the products cache',
@@ -109,7 +109,7 @@ const apiData: ApiItem[] = [
     path: '/docs/apis#clear-products-ios',
   },
   {
-    id: 'getstorefrontios',
+    id: 'get-storefront-ios',
     title: 'getStorefrontIOS',
     category: 'iOS APIs',
     description: 'Get the current App Store storefront country code',
@@ -117,10 +117,145 @@ const apiData: ApiItem[] = [
     returns: 'String!',
     path: '/docs/apis#get-storefront-ios',
   },
+  {
+    id: 'get-promoted-product-ios',
+    title: 'getPromotedProductIOS',
+    category: 'iOS APIs',
+    description: 'Get the currently promoted product (iOS 11+)',
+    parameters: '',
+    returns: 'Product?',
+    path: '/docs/apis#get-promoted-product-ios',
+  },
+  {
+    id: 'request-purchase-on-promoted-product-ios',
+    title: 'requestPurchaseOnPromotedProductIOS',
+    category: 'iOS APIs',
+    description: 'Purchase a promoted product (iOS 11+)',
+    parameters: '',
+    returns: 'Purchase!',
+    path: '/docs/apis#request-purchase-on-promoted-product-ios',
+  },
+  {
+    id: 'get-pending-transactions-ios',
+    title: 'getPendingTransactionsIOS',
+    category: 'iOS APIs',
+    description: 'Get all pending transactions',
+    parameters: '',
+    returns: '[Purchase!]!',
+    path: '/docs/apis#get-pending-transactions-ios',
+  },
+  {
+    id: 'is-eligible-for-intro-offer-ios',
+    title: 'isEligibleForIntroOfferIOS',
+    category: 'iOS APIs',
+    description: 'Check if user is eligible for introductory offer',
+    parameters: 'productIds: [String!]!',
+    returns: 'Boolean!',
+    path: '/docs/apis#is-eligible-for-intro-offer-ios',
+  },
+  {
+    id: 'subscription-status-ios',
+    title: 'subscriptionStatusIOS',
+    category: 'iOS APIs',
+    description: 'Get subscription status (iOS 15+)',
+    parameters: 'skus: [String!]?',
+    returns: '[SubscriptionStatus!]!',
+    path: '/docs/apis#subscription-status-ios',
+  },
+  {
+    id: 'current-entitlement-ios',
+    title: 'currentEntitlementIOS',
+    category: 'iOS APIs',
+    description: 'Get current entitlements (iOS 15+)',
+    parameters: 'skus: [String!]?',
+    returns: '[Entitlement!]!',
+    path: '/docs/apis#current-entitlement-ios',
+  },
+  {
+    id: 'latest-transaction-ios',
+    title: 'latestTransactionIOS',
+    category: 'iOS APIs',
+    description: 'Get latest transaction for a product (iOS 15+)',
+    parameters: 'sku: String!',
+    returns: 'Transaction?',
+    path: '/docs/apis#latest-transaction-ios',
+  },
+  {
+    id: 'show-manage-subscriptions-ios',
+    title: 'showManageSubscriptionsIOS',
+    category: 'iOS APIs',
+    description: 'Show subscription management UI (iOS 15+)',
+    parameters: '',
+    returns: 'Void',
+    path: '/docs/apis#show-manage-subscriptions-ios',
+  },
+  {
+    id: 'begin-refund-request-ios',
+    title: 'beginRefundRequestIOS',
+    category: 'iOS APIs',
+    description: 'Initiate refund request (iOS 15+)',
+    parameters: 'sku: String!',
+    returns: 'RefundResult!',
+    path: '/docs/apis#begin-refund-request-ios',
+  },
+  {
+    id: 'is-transaction-verified-ios',
+    title: 'isTransactionVerifiedIOS',
+    category: 'iOS APIs',
+    description: 'Verify transaction authenticity (iOS 15+)',
+    parameters: 'transactionId: String!',
+    returns: 'Boolean!',
+    path: '/docs/apis#is-transaction-verified-ios',
+  },
+  {
+    id: 'get-transaction-jws-ios',
+    title: 'getTransactionJwsIOS',
+    category: 'iOS APIs',
+    description: 'Get transaction JWS token (iOS 15+)',
+    parameters: 'transactionId: String!',
+    returns: 'String!',
+    path: '/docs/apis#get-transaction-jws-ios',
+  },
+  {
+    id: 'get-receipt-data-ios',
+    title: 'getReceiptDataIOS',
+    category: 'iOS APIs',
+    description: 'Get receipt data for validation',
+    parameters: '',
+    returns: 'String!',
+    path: '/docs/apis#get-receipt-data-ios',
+  },
+  {
+    id: 'sync-ios',
+    title: 'syncIOS',
+    category: 'iOS APIs',
+    description: 'Sync StoreKit transactions (iOS 15+)',
+    parameters: '',
+    returns: 'Void',
+    path: '/docs/apis#sync-ios',
+  },
+  {
+    id: 'present-code-redemption-sheet-ios',
+    title: 'presentCodeRedemptionSheetIOS',
+    category: 'iOS APIs',
+    description: 'Show promo code redemption UI',
+    parameters: '',
+    returns: 'Void',
+    path: '/docs/apis#present-code-redemption-sheet-ios',
+  },
+  {
+    id: 'get-app-transaction-ios',
+    title: 'getAppTransactionIOS',
+    category: 'iOS APIs',
+    description: 'Get app transaction information (iOS 16+)',
+    parameters: '',
+    returns: 'AppTransaction?',
+    path: '/docs/apis#get-app-transaction-ios',
+  },
 
   // Android APIs
   {
-    id: 'acknowledgepurchaseandroid',
+    id: 'acknowledge-purchase-android',
     title: 'acknowledgePurchaseAndroid',
     category: 'Android APIs',
     description: 'Acknowledge a non-consumable purchase or subscription',
@@ -129,7 +264,7 @@ const apiData: ApiItem[] = [
     path: '/docs/apis#acknowledge-purchase-android',
   },
   {
-    id: 'consumepurchaseandroid',
+    id: 'consume-purchase-android',
     title: 'consumePurchaseAndroid',
     category: 'Android APIs',
     description: 'Consume a purchase (for consumable products only)',
@@ -137,10 +272,28 @@ const apiData: ApiItem[] = [
     returns: 'Void',
     path: '/docs/apis#consume-purchase-android',
   },
+  {
+    id: 'flush-failed-purchase-cached-as-pending-android',
+    title: 'flushFailedPurchaseCachedAsPendingAndroid',
+    category: 'Android APIs',
+    description: 'Clear failed purchases from cache',
+    parameters: '',
+    returns: 'Void',
+    path: '/docs/apis#flush-failed-purchase-cached-as-pending-android',
+  },
+  {
+    id: 'get-package-name-android',
+    title: 'getPackageNameAndroid',
+    category: 'Android APIs',
+    description: 'Get the app package name',
+    parameters: '',
+    returns: 'String!',
+    path: '/docs/apis#get-package-name-android',
+  },
 
   // Connection Management
   {
-    id: 'initconnection',
+    id: 'init-connection',
     title: 'initConnection',
     category: 'Connection Management',
     description: 'Initialize connection to the store service',
@@ -149,7 +302,7 @@ const apiData: ApiItem[] = [
     path: '/docs/apis#init-connection',
   },
   {
-    id: 'endconnection',
+    id: 'end-connection',
     title: 'endConnection',
     category: 'Connection Management',
     description: 'End connection to the store service',
@@ -160,7 +313,7 @@ const apiData: ApiItem[] = [
 
   // Subscription Management
   {
-    id: 'getactivesubscriptions',
+    id: 'get-active-subscriptions',
     title: 'getActiveSubscriptions',
     category: 'Subscription Management',
     description: 'Get all active subscriptions with detailed information',
@@ -169,7 +322,7 @@ const apiData: ApiItem[] = [
     path: '/docs/apis#get-active-subscriptions',
   },
   {
-    id: 'hasactivesubscriptions',
+    id: 'has-active-subscriptions',
     title: 'hasActiveSubscriptions',
     category: 'Subscription Management',
     description: 'Check if the user has any active subscriptions',
@@ -178,13 +331,13 @@ const apiData: ApiItem[] = [
     path: '/docs/apis#has-active-subscriptions',
   },
   {
-    id: 'deeplinktosubscriptions',
+    id: 'deep-link-to-subscriptions',
     title: 'deepLinkToSubscriptions',
     category: 'Subscription Management',
     description: 'Open native subscription management interface',
     parameters: 'DeepLinkOptions',
     returns: 'Void',
-    path: '/docs/apis#deeplink-to-subscriptions',
+    path: '/docs/apis#deep-link-to-subscriptions',
   },
 ];
 

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -89,10 +89,10 @@ const apiData: ApiItem[] = [
   },
   {
     id: 'get-purchase-histories',
-    title: 'getPurchaseHistories (Deprecated)',
-    category: 'Product Management',
+    title: 'getPurchaseHistories',
+    category: 'Product Management (Deprecated)',
     description:
-      'Get purchase history (iOS only) - Use getAvailablePurchases instead',
+      '⚠️ DEPRECATED: Get purchase history (iOS only) - Use getAvailablePurchases instead',
     parameters: 'PurchaseOptions?',
     returns: '[Purchase!]!',
     path: '/docs/apis#get-purchase-histories',

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -40,9 +40,10 @@ const apiData: ApiItem[] = [
   },
   {
     id: 'get-purchase-histories',
-    title: 'getPurchaseHistories',
+    title: 'getPurchaseHistories (Deprecated)',
     category: 'Product Management',
-    description: 'Get purchase history (iOS only)',
+    description:
+      'Get purchase history (iOS only) - Use getAvailablePurchases instead',
     parameters: 'PurchaseOptions?',
     returns: '[Purchase!]!',
     path: '/docs/apis#get-purchase-histories',
@@ -82,15 +83,6 @@ const apiData: ApiItem[] = [
 
   // iOS APIs
   {
-    id: 'finish-transaction-ios',
-    title: 'finishTransactionIOS',
-    category: 'iOS APIs',
-    description: 'iOS-specific transaction completion',
-    parameters: 'transactionId: String!',
-    returns: 'Void',
-    path: '/docs/apis#finish-transaction-ios',
-  },
-  {
     id: 'clear-transaction-ios',
     title: 'clearTransactionIOS',
     category: 'iOS APIs',
@@ -98,15 +90,6 @@ const apiData: ApiItem[] = [
     parameters: '',
     returns: 'Void',
     path: '/docs/apis#clear-transaction-ios',
-  },
-  {
-    id: 'clear-products-ios',
-    title: 'clearProductsIOS',
-    category: 'iOS APIs',
-    description: 'Clear the products cache',
-    parameters: '',
-    returns: 'Void',
-    path: '/docs/apis#clear-products-ios',
   },
   {
     id: 'get-storefront-ios',

--- a/src/pages/docs/apis.tsx
+++ b/src/pages/docs/apis.tsx
@@ -91,8 +91,8 @@ Returns: [Purchase!]!
 getAvailablePurchases(options: PurchaseOptions?): Future
 
 type PurchaseOptions {
-  alsoPublishToEventListener: Boolean?
-  onlyIncludeActiveItems: Boolean?
+  alsoPublishToEventListenerIOS: Boolean?  # iOS only
+  onlyIncludeActiveItemsIOS: Boolean?      # iOS only
 }`}</CodeBlock>
         <p className="type-link">
           See: <Link to="/docs/types#purchase">Purchase</Link>
@@ -120,8 +120,12 @@ type PurchaseOptions {
         </p>
 
         <AnchorLink id="get-purchase-histories" level="h3">
-          getPurchaseHistories
+          getPurchaseHistories (Deprecated)
         </AnchorLink>
+        <div className="deprecated-notice">
+          <strong>⚠️ Deprecated:</strong> Use <code>getAvailablePurchases</code>{' '}
+          instead.
+        </div>
         <p>Get purchase history (iOS only).</p>
         <CodeBlock language="graphql">{`"""
 Returns: [Purchase!]!
@@ -129,16 +133,15 @@ Returns: [Purchase!]!
 getPurchaseHistories(options: PurchaseOptions?): Future
 
 type PurchaseOptions {
-  alsoPublishToEventListener: Boolean?
-  onlyIncludeActiveItems: Boolean?
+  alsoPublishToEventListenerIOS: Boolean?  # iOS only
+  onlyIncludeActiveItemsIOS: Boolean?      # iOS only
 }`}</CodeBlock>
         <p className="type-link">
           See: <Link to="/docs/types#purchase">Purchase</Link>
         </p>
         <p>
-          <strong>Note:</strong> On Android with Google Play Billing v8+, this
-          returns an empty array as purchase history is no longer available. Use{' '}
-          <code>getAvailablePurchases</code> instead to get active purchases.
+          This API is deprecated and will be removed in a future version. Use{' '}
+          <code>getAvailablePurchases</code> instead.
         </p>
       </section>
 
@@ -224,8 +227,7 @@ finishTransaction(purchase: Purchase!, isConsumable: Boolean?): Future`}</CodeBl
         <ul>
           <li>
             <strong>iOS</strong>: The flag doesn't affect behavior as StoreKit
-            handles this automatically. Always calls{' '}
-            <code>finishTransactionIOS()</code>.
+            handles this automatically.
           </li>
           <li>
             <strong>Android</strong>:
@@ -422,19 +424,6 @@ validateReceipt(options: ReceiptValidationProps!): Future`}</CodeBlock>
           iOS APIs
         </AnchorLink>
 
-        <AnchorLink id="finish-transaction-ios" level="h4">
-          finishTransactionIOS
-        </AnchorLink>
-        <p>iOS-specific transaction completion.</p>
-        <CodeBlock language="graphql">{`"""
-Returns: Void
-"""
-finishTransactionIOS(transactionId: String!): Future`}</CodeBlock>
-        <p>
-          Directly marks a transaction as finished in the StoreKit payment
-          queue. Usually called internally by <code>finishTransaction()</code>.
-        </p>
-
         <AnchorLink id="clear-transaction-ios" level="h4">
           clearTransactionIOS
         </AnchorLink>
@@ -444,18 +433,6 @@ Returns: Void
 """
 clearTransactionIOS(): Future`}</CodeBlock>
         <p>Removes all pending transactions from the iOS payment queue.</p>
-
-        <AnchorLink id="clear-products-ios" level="h4">
-          clearProductsIOS
-        </AnchorLink>
-        <p>Clear the products cache.</p>
-        <CodeBlock language="graphql">{`"""
-Returns: Void
-"""
-clearProductsIOS(): Future`}</CodeBlock>
-        <p>
-          Clears cached product information, forcing a refresh on next fetch.
-        </p>
 
         <AnchorLink id="get-storefront-ios" level="h4">
           getStorefrontIOS
@@ -688,8 +665,12 @@ Returns: Void
 acknowledgePurchaseAndroid(purchaseToken: String!): Future`}</CodeBlock>
         <p>
           Acknowledges the purchase to Google Play. Required within 3 days or
-          the purchase will be refunded. Usually called internally by{' '}
-          <code>finishTransaction()</code>.
+          the purchase will be refunded.
+        </p>
+        <p>
+          <strong>Note:</strong> This is called automatically by{' '}
+          <code>finishTransaction()</code> when <code>isConsumable</code> is{' '}
+          <code>false</code>.
         </p>
 
         <AnchorLink id="consume-purchase-android" level="h4">
@@ -702,8 +683,12 @@ Returns: Void
 consumePurchaseAndroid(purchaseToken: String!): Future`}</CodeBlock>
         <p>
           Marks a consumable product as consumed, allowing repurchase.
-          Automatically acknowledges the purchase. Usually called internally by{' '}
-          <code>finishTransaction()</code> for consumables.
+          Automatically acknowledges the purchase.
+        </p>
+        <p>
+          <strong>Note:</strong> This is called automatically by{' '}
+          <code>finishTransaction()</code> when <code>isConsumable</code> is{' '}
+          <code>true</code>.
         </p>
 
         <AnchorLink

--- a/src/pages/docs/apis.tsx
+++ b/src/pages/docs/apis.tsx
@@ -51,7 +51,106 @@ function APIs() {
           </p>
         </blockquote>
       </section>
+      <section>
+        <AnchorLink id="connection-management" level="h2">
+          Connection Management
+        </AnchorLink>
 
+        <AnchorLink id="init-connection" level="h3">
+          initConnection
+        </AnchorLink>
+        <p>Initialize connection to the store service.</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Boolean!
+"""
+initConnection(): Future`}</CodeBlock>
+        <p>
+          Establishes connection with the platform's billing service. Returns
+          true if successful.
+        </p>
+
+        <AnchorLink id="end-connection" level="h3">
+          endConnection
+        </AnchorLink>
+        <p>End connection to the store service.</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Boolean!
+"""
+endConnection(): Future`}</CodeBlock>
+        <p>
+          Closes the connection and cleans up resources. Returns true if
+          successful.
+        </p>
+      </section>
+      <section>
+        <AnchorLink id="subscription-management" level="h2">
+          Subscription Management
+        </AnchorLink>
+
+        <AnchorLink id="get-active-subscriptions" level="h3">
+          getActiveSubscriptions
+        </AnchorLink>
+        <p>Get all active subscriptions with detailed information.</p>
+        <CodeBlock language="graphql">{`"""
+Returns: [ActiveSubscription!]!
+"""
+getActiveSubscriptions(subscriptionIds: [String]?): Future
+
+type ActiveSubscription {
+  productId: String!
+  isActive: Boolean!
+  expirationDateIOS: Date?        # iOS only
+  autoRenewingAndroid: Boolean?   # Android only
+  environmentIOS: String?          # iOS only: "Sandbox" | "Production"
+  willExpireSoon: Boolean?         # True if expiring within 7 days
+  daysUntilExpirationIOS: Number?  # iOS only
+}`}</CodeBlock>
+        <p className="type-link">
+          See:{' '}
+          <Link to="/docs/types#active-subscription">ActiveSubscription</Link>
+        </p>
+        <p>
+          Returns a future that completes with an array of active subscriptions.
+          If <code>subscriptionIds</code> is not provided, returns all active
+          subscriptions. Platform-specific fields are populated based on the
+          current platform.
+        </p>
+
+        <AnchorLink id="has-active-subscriptions" level="h3">
+          hasActiveSubscriptions
+        </AnchorLink>
+        <p>Check if the user has any active subscriptions.</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Boolean!
+"""
+hasActiveSubscriptions(subscriptionIds: [String]?): Future`}</CodeBlock>
+        <p>
+          Returns a future that completes with <code>true</code> if the user has
+          at least one active subscription, <code>false</code> otherwise. If{' '}
+          <code>subscriptionIds</code> is provided, only checks for those
+          specific subscriptions.
+        </p>
+
+        <AnchorLink id="deep-link-to-subscriptions" level="h3">
+          deepLinkToSubscriptions
+        </AnchorLink>
+        <p>Open native subscription management interface.</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Void
+"""
+deepLinkToSubscriptions(options: DeepLinkOptions): Future
+
+type DeepLinkOptions {
+  "Required on Android"
+  skuAndroid: String?
+  "Required on Android"
+  packageNameAndroid: String?
+}`}</CodeBlock>
+        <p>
+          Opens the platform's native subscription management interface where
+          users can view and manage their subscriptions.
+        </p>
+      </section>
       <section>
         <AnchorLink id="product-management" level="h2">
           Product Management
@@ -144,7 +243,6 @@ type PurchaseOptions {
           <code>getAvailablePurchases</code> instead.
         </p>
       </section>
-
       <section>
         <AnchorLink id="purchase-operations" level="h2">
           Purchase Operations
@@ -268,7 +366,6 @@ finishTransaction(purchase: Purchase!, isConsumable: Boolean?): Future`}</CodeBl
           </li>
         </ol>
       </section>
-
       <section>
         <AnchorLink id="validation" level="h2">
           Validation
@@ -414,7 +511,6 @@ validateReceipt(options: ReceiptValidationProps!): Future`}</CodeBlock>
           </li>
         </ul>
       </section>
-
       <section>
         <AnchorLink id="platform-specific-apis" level="h2">
           Platform-Specific APIs
@@ -669,8 +765,10 @@ acknowledgePurchaseAndroid(purchaseToken: String!): Future`}</CodeBlock>
         </p>
         <p>
           <strong>Note:</strong> This is called automatically by{' '}
-          <code>finishTransaction()</code> when <code>isConsumable</code> is{' '}
-          <code>false</code>.
+          <Link to="/docs/apis#finish-transaction">
+            <code>finishTransaction()</code>
+          </Link>{' '}
+          when <code>isConsumable</code> is <code>false</code>.
         </p>
 
         <AnchorLink id="consume-purchase-android" level="h4">
@@ -687,8 +785,10 @@ consumePurchaseAndroid(purchaseToken: String!): Future`}</CodeBlock>
         </p>
         <p>
           <strong>Note:</strong> This is called automatically by{' '}
-          <code>finishTransaction()</code> when <code>isConsumable</code> is{' '}
-          <code>true</code>.
+          <Link to="/docs/apis#finish-transaction">
+            <code>finishTransaction()</code>
+          </Link>{' '}
+          when <code>isConsumable</code> is <code>true</code>.
         </p>
 
         <AnchorLink
@@ -705,121 +805,6 @@ flushFailedPurchaseCachedAsPendingAndroid(): Future`}</CodeBlock>
         <p>
           Clears any failed purchases that are cached as pending. Use this when
           you want to retry failed purchases or clear the pending state.
-        </p>
-
-        <AnchorLink id="get-package-name-android" level="h4">
-          getPackageNameAndroid
-        </AnchorLink>
-        <p>Get the app's package name (Android only).</p>
-        <CodeBlock language="graphql">{`"""
-Returns: String!
-"""
-getPackageNameAndroid(): Future`}</CodeBlock>
-        <p>
-          Returns the Android application's package name. Useful for validation
-          and deep linking operations.
-        </p>
-      </section>
-
-      <section>
-        <AnchorLink id="connection-management" level="h2">
-          Connection Management
-        </AnchorLink>
-
-        <AnchorLink id="init-connection" level="h3">
-          initConnection
-        </AnchorLink>
-        <p>Initialize connection to the store service.</p>
-        <CodeBlock language="graphql">{`"""
-Returns: Boolean!
-"""
-initConnection(): Future`}</CodeBlock>
-        <p>
-          Establishes connection with the platform's billing service. Returns
-          true if successful.
-        </p>
-
-        <AnchorLink id="end-connection" level="h3">
-          endConnection
-        </AnchorLink>
-        <p>End connection to the store service.</p>
-        <CodeBlock language="graphql">{`"""
-Returns: Boolean!
-"""
-endConnection(): Future`}</CodeBlock>
-        <p>
-          Closes the connection and cleans up resources. Returns true if
-          successful.
-        </p>
-      </section>
-
-      <section>
-        <AnchorLink id="subscription-management" level="h2">
-          Subscription Management
-        </AnchorLink>
-
-        <AnchorLink id="get-active-subscriptions" level="h3">
-          getActiveSubscriptions
-        </AnchorLink>
-        <p>Get all active subscriptions with detailed information.</p>
-        <CodeBlock language="graphql">{`"""
-Returns: [ActiveSubscription!]!
-"""
-getActiveSubscriptions(subscriptionIds: [String]?): Future
-
-type ActiveSubscription {
-  productId: String!
-  isActive: Boolean!
-  expirationDateIOS: Date?        # iOS only
-  autoRenewingAndroid: Boolean?   # Android only
-  environmentIOS: String?          # iOS only: "Sandbox" | "Production"
-  willExpireSoon: Boolean?         # True if expiring within 7 days
-  daysUntilExpirationIOS: Number?  # iOS only
-}`}</CodeBlock>
-        <p className="type-link">
-          See:{' '}
-          <Link to="/docs/types#active-subscription">ActiveSubscription</Link>
-        </p>
-        <p>
-          Returns a future that completes with an array of active subscriptions.
-          If <code>subscriptionIds</code> is not provided, returns all active
-          subscriptions. Platform-specific fields are populated based on the
-          current platform.
-        </p>
-
-        <AnchorLink id="has-active-subscriptions" level="h3">
-          hasActiveSubscriptions
-        </AnchorLink>
-        <p>Check if the user has any active subscriptions.</p>
-        <CodeBlock language="graphql">{`"""
-Returns: Boolean!
-"""
-hasActiveSubscriptions(subscriptionIds: [String]?): Future`}</CodeBlock>
-        <p>
-          Returns a future that completes with <code>true</code> if the user has
-          at least one active subscription, <code>false</code> otherwise. If{' '}
-          <code>subscriptionIds</code> is provided, only checks for those
-          specific subscriptions.
-        </p>
-
-        <AnchorLink id="deep-link-to-subscriptions" level="h3">
-          deepLinkToSubscriptions
-        </AnchorLink>
-        <p>Open native subscription management interface.</p>
-        <CodeBlock language="graphql">{`"""
-Returns: Void
-"""
-deepLinkToSubscriptions(options: DeepLinkOptions): Future
-
-type DeepLinkOptions {
-  "Required on Android"
-  skuAndroid: String?
-  "Required on Android"
-  packageNameAndroid: String?
-}`}</CodeBlock>
-        <p>
-          Opens the platform's native subscription management interface where
-          users can view and manage their subscriptions.
         </p>
       </section>
     </div>

--- a/src/pages/docs/apis.tsx
+++ b/src/pages/docs/apis.tsx
@@ -581,7 +581,7 @@ hasActiveSubscriptions(subscriptionIds: [String]?): Future`}</CodeBlock>
           specific subscriptions.
         </p>
 
-        <AnchorLink id="deeplink-to-subscriptions" level="h3">
+        <AnchorLink id="deep-link-to-subscriptions" level="h3">
           deepLinkToSubscriptions
         </AnchorLink>
         <p>Open native subscription management interface.</p>

--- a/src/pages/docs/apis.tsx
+++ b/src/pages/docs/apis.tsx
@@ -219,13 +219,19 @@ type PurchaseOptions {
         </p>
 
         <AnchorLink id="get-purchase-histories" level="h3">
-          getPurchaseHistories (Deprecated)
+          <span style={{ textDecoration: 'line-through', opacity: 0.7 }}>
+            getPurchaseHistories
+          </span>{' '}
+          <span style={{ color: '#ff6b35' }}>(Deprecated)</span>
         </AnchorLink>
         <div className="deprecated-notice">
-          <strong>⚠️ Deprecated:</strong> Use <code>getAvailablePurchases</code>{' '}
+          <strong>⚠️ DEPRECATED:</strong> This API is deprecated and will be
+          removed in a future version. Use <code>getAvailablePurchases</code>{' '}
           instead.
         </div>
-        <p>Get purchase history (iOS only).</p>
+        <p>
+          Get purchase history (iOS only) - <strong>Deprecated</strong>.
+        </p>
         <CodeBlock language="graphql">{`"""
 Returns: [Purchase!]!
 """

--- a/src/pages/docs/apis.tsx
+++ b/src/pages/docs/apis.tsx
@@ -467,6 +467,213 @@ Returns: String!
 getStorefrontIOS(): Future`}</CodeBlock>
         <p>Returns the storefront country code (e.g., "US", "GB", "JP").</p>
 
+        <AnchorLink id="get-promoted-product-ios" level="h4">
+          getPromotedProductIOS
+        </AnchorLink>
+        <p>Get the currently promoted product (iOS 11+).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Product?
+"""
+getPromotedProductIOS(): Future`}</CodeBlock>
+        <p>
+          Returns the product that was promoted in the App Store, if any.
+          Requires iOS 11 or later.
+        </p>
+
+        <AnchorLink id="request-purchase-on-promoted-product-ios" level="h4">
+          requestPurchaseOnPromotedProductIOS
+        </AnchorLink>
+        <p>Purchase a promoted product (iOS 11+).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Purchase!
+"""
+requestPurchaseOnPromotedProductIOS(): Future`}</CodeBlock>
+        <p>
+          Initiates a purchase for the promoted product. The product must have
+          been previously promoted via the App Store.
+        </p>
+
+        <AnchorLink id="get-pending-transactions-ios" level="h4">
+          getPendingTransactionsIOS
+        </AnchorLink>
+        <p>Get all pending transactions.</p>
+        <CodeBlock language="graphql">{`"""
+Returns: [Purchase!]!
+"""
+getPendingTransactionsIOS(): Future`}</CodeBlock>
+        <p>
+          Returns all transactions that are pending completion in the StoreKit
+          payment queue.
+        </p>
+
+        <AnchorLink id="is-eligible-for-intro-offer-ios" level="h4">
+          isEligibleForIntroOfferIOS
+        </AnchorLink>
+        <p>Check if user is eligible for introductory offer.</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Boolean!
+"""
+isEligibleForIntroOfferIOS(productIds: [String!]!): Future`}</CodeBlock>
+        <p>
+          Returns true if the user is eligible for an introductory price, false
+          otherwise. Requires iOS 12.2+.
+        </p>
+
+        <AnchorLink id="subscription-status-ios" level="h4">
+          subscriptionStatusIOS
+        </AnchorLink>
+        <p>Get subscription status (iOS 15+).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: [SubscriptionStatus!]!
+"""
+subscriptionStatusIOS(skus: [String!]?): Future`}</CodeBlock>
+        <p>
+          Returns detailed subscription status information using StoreKit 2.
+          Requires iOS 15+.
+        </p>
+
+        <AnchorLink id="current-entitlement-ios" level="h4">
+          currentEntitlementIOS
+        </AnchorLink>
+        <p>Get current entitlements (iOS 15+).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: [Entitlement!]!
+"""
+currentEntitlementIOS(skus: [String!]?): Future`}</CodeBlock>
+        <p>
+          Returns current entitlements for the user using StoreKit 2. Requires
+          iOS 15+.
+        </p>
+
+        <AnchorLink id="latest-transaction-ios" level="h4">
+          latestTransactionIOS
+        </AnchorLink>
+        <p>Get latest transaction for a product (iOS 15+).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Transaction?
+"""
+latestTransactionIOS(sku: String!): Future`}</CodeBlock>
+        <p>
+          Returns the most recent transaction for a specific product using
+          StoreKit 2. Requires iOS 15+.
+        </p>
+
+        <AnchorLink id="show-manage-subscriptions-ios" level="h4">
+          showManageSubscriptionsIOS
+        </AnchorLink>
+        <p>Show subscription management UI (iOS 15+).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Void
+"""
+showManageSubscriptionsIOS(): Future`}</CodeBlock>
+        <p>
+          Opens the native subscription management interface. Requires iOS 15+.
+        </p>
+
+        <AnchorLink id="begin-refund-request-ios" level="h4">
+          beginRefundRequestIOS
+        </AnchorLink>
+        <p>Initiate refund request (iOS 15+).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: RefundResult!
+"""
+beginRefundRequestIOS(sku: String!): Future`}</CodeBlock>
+        <p>
+          Presents the refund request sheet for a specific product. Requires iOS
+          15+.
+        </p>
+
+        <AnchorLink id="is-transaction-verified-ios" level="h4">
+          isTransactionVerifiedIOS
+        </AnchorLink>
+        <p>Verify transaction authenticity (iOS 15+).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Boolean!
+"""
+isTransactionVerifiedIOS(transactionId: String!): Future`}</CodeBlock>
+        <p>
+          Verifies the transaction signature using StoreKit 2. Returns true if
+          valid, false otherwise. Requires iOS 15+.
+        </p>
+
+        <AnchorLink id="get-transaction-jws-ios" level="h4">
+          getTransactionJwsIOS
+        </AnchorLink>
+        <p>Get transaction JWS token (iOS 15+).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: String!
+"""
+getTransactionJwsIOS(transactionId: String!): Future`}</CodeBlock>
+        <p>
+          Returns the JSON Web Signature for a transaction. Used for server-side
+          validation. Requires iOS 15+.
+        </p>
+
+        <AnchorLink id="get-receipt-data-ios" level="h4">
+          getReceiptDataIOS
+        </AnchorLink>
+        <p>Get receipt data for validation.</p>
+        <CodeBlock language="graphql">{`"""
+Returns: String!
+"""
+getReceiptDataIOS(): Future`}</CodeBlock>
+        <p>Returns the base64-encoded receipt data for server validation.</p>
+
+        <AnchorLink id="sync-ios" level="h4">
+          syncIOS
+        </AnchorLink>
+        <p>Sync StoreKit transactions (iOS 15+).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Void
+"""
+syncIOS(): Future`}</CodeBlock>
+        <p>
+          Forces a sync with StoreKit to ensure all transactions are up to date.
+          Requires iOS 15+.
+        </p>
+
+        <AnchorLink id="present-code-redemption-sheet-ios" level="h4">
+          presentCodeRedemptionSheetIOS
+        </AnchorLink>
+        <p>Show promo code redemption UI.</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Void
+"""
+presentCodeRedemptionSheetIOS(): Future`}</CodeBlock>
+        <p>Presents the sheet for redeeming App Store promo codes.</p>
+
+        <AnchorLink id="get-app-transaction-ios" level="h4">
+          getAppTransactionIOS
+        </AnchorLink>
+        <p>Get app transaction information (iOS 16+).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: AppTransaction?
+"""
+getAppTransactionIOS(): Future
+
+type AppTransaction {
+  bundleId: String!
+  appVersion: String!
+  originalAppVersion: String!
+  originalPurchaseDate: Date!
+  deviceVerification: String!
+  deviceVerificationNonce: String!
+  environment: String!  # "Sandbox" | "Production"
+  signedDate: Date!
+  appId: Number!
+  appVersionId: Number!
+  preorderDate: Date?
+  # iOS 18.4+ properties
+  appTransactionId: String?  # Requires iOS 18.4+
+  originalPlatform: String?  # Requires iOS 18.4+
+}`}</CodeBlock>
+        <p>
+          Returns information about the app's original purchase or download.
+          This includes details about when the app was first installed, the
+          version, and verification data. Requires iOS 16+. Additional
+          properties are available on iOS 18.4+ when built with Xcode 16.4+.
+        </p>
+
         <AnchorLink id="android-apis" level="h3">
           Android APIs
         </AnchorLink>
@@ -497,6 +704,35 @@ consumePurchaseAndroid(purchaseToken: String!): Future`}</CodeBlock>
           Marks a consumable product as consumed, allowing repurchase.
           Automatically acknowledges the purchase. Usually called internally by{' '}
           <code>finishTransaction()</code> for consumables.
+        </p>
+
+        <AnchorLink
+          id="flush-failed-purchase-cached-as-pending-android"
+          level="h4"
+        >
+          flushFailedPurchaseCachedAsPendingAndroid
+        </AnchorLink>
+        <p>Clear failed purchases from cache (Android only).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: Void
+"""
+flushFailedPurchaseCachedAsPendingAndroid(): Future`}</CodeBlock>
+        <p>
+          Clears any failed purchases that are cached as pending. Use this when
+          you want to retry failed purchases or clear the pending state.
+        </p>
+
+        <AnchorLink id="get-package-name-android" level="h4">
+          getPackageNameAndroid
+        </AnchorLink>
+        <p>Get the app's package name (Android only).</p>
+        <CodeBlock language="graphql">{`"""
+Returns: String!
+"""
+getPackageNameAndroid(): Future`}</CodeBlock>
+        <p>
+          Returns the Android application's package name. Useful for validation
+          and deep linking operations.
         </p>
       </section>
 

--- a/src/pages/docs/versions.tsx
+++ b/src/pages/docs/versions.tsx
@@ -1,14 +1,112 @@
 import { useScrollToHash } from '../../hooks/useScrollToHash';
+import AnchorLink from '../../components/AnchorLink';
 
 function Versions() {
   useScrollToHash();
 
   return (
     <div className="doc-page">
-      <h1>Versions</h1>
-      <p>
-        Current version: <strong>v1.0.0 (2025.08)</strong>
-      </p>
+      <h1>Version History</h1>
+
+      <section>
+        <AnchorLink id="v1-0-1" level="h2">
+          v1.0.1 (2025.09)
+        </AnchorLink>
+        <ul>
+          <li>
+            Added comprehensive iOS API documentation (19 APIs with IOS suffix)
+          </li>
+          <li>
+            Added missing Android APIs
+            (flushFailedPurchaseCachedAsPendingAndroid, getPackageNameAndroid)
+          </li>
+          <li>Added getAppTransactionIOS documentation (iOS 16+)</li>
+          <li>Fixed camelCase to kebab-case conversion in search modal</li>
+          <li>Updated API naming conventions following expo-iap standards</li>
+        </ul>
+        <div className="version-links">
+          <strong>Implementations:</strong>
+          <ul>
+            <li>
+              <a
+                href="https://github.com/hyochan/react-native-iap/pull/2986"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="external-link"
+              >
+                react-native-iap#2986 - Add iOS/Android naming conventions
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/hyochan/expo-iap/pull/182"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="external-link"
+              >
+                expo-iap#182 - Implement platform-specific API naming
+              </a>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section>
+        <AnchorLink id="v1-0-0" level="h2">
+          v1.0.0 (2025.08)
+        </AnchorLink>
+        <ul>
+          <li>Initial release of OpenIAP documentation</li>
+          <li>Complete API reference</li>
+          <li>Platform setup guides</li>
+          <li>Type definitions</li>
+        </ul>
+        <div className="version-links">
+          <strong>Supported Libraries:</strong>
+          <ul>
+            <li>
+              <a
+                href="https://github.com/hyochan/react-native-iap"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="external-link"
+              >
+                react-native-iap - React Native in-app purchases
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/hyochan/expo-iap"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="external-link"
+              >
+                expo-iap - Expo in-app purchases module
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/hyochan/kmp-iap"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="external-link"
+              >
+                kmp-iap - Kotlin Multiplatform in-app purchases
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/hyochan/flutter_inapp_purchase"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="external-link"
+              >
+                flutter_inapp_purchase - Flutter in-app purchases plugin
+              </a>
+            </li>
+          </ul>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/pages/docs/versions.tsx
+++ b/src/pages/docs/versions.tsx
@@ -17,8 +17,8 @@ function Versions() {
             Added comprehensive iOS API documentation (19 APIs with IOS suffix)
           </li>
           <li>
-            Added missing Android APIs
-            (flushFailedPurchaseCachedAsPendingAndroid, getPackageNameAndroid)
+            Added missing Android API
+            (flushFailedPurchaseCachedAsPendingAndroid)
           </li>
           <li>Added getAppTransactionIOS documentation (iOS 16+)</li>
           <li>Fixed camelCase to kebab-case conversion in search modal</li>

--- a/src/styles/documentation.css
+++ b/src/styles/documentation.css
@@ -337,6 +337,30 @@
   opacity: 1;
 }
 
+/* Deprecated notice */
+.deprecated-notice {
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 0.375rem;
+  color: #856404;
+}
+
+.deprecated-notice strong {
+  color: #ff6b35;
+}
+
+:root.dark .deprecated-notice {
+  background: rgba(255, 193, 7, 0.1);
+  border-color: rgba(255, 193, 7, 0.3);
+  color: #ffc107;
+}
+
+:root.dark .deprecated-notice strong {
+  color: #ff8c42;
+}
+
 /* Version page specific styles */
 .version-links {
   margin-top: 1rem;

--- a/src/styles/documentation.css
+++ b/src/styles/documentation.css
@@ -392,21 +392,13 @@
 :root.dark .doc-page a.external-link,
 :root.dark .doc-page a[target='_blank'] {
   color: #d4a574;
-  background: linear-gradient(
-    to bottom,
-    transparent 60%,
-    rgba(212, 165, 116, 0.15) 60%
-  );
+  border-bottom-color: rgba(212, 165, 116, 0.3);
 }
 
 :root.dark .doc-page a.external-link:hover,
 :root.dark .doc-page a[target='_blank']:hover {
   color: #e6c299;
-  background: linear-gradient(
-    to bottom,
-    transparent 60%,
-    rgba(212, 165, 116, 0.3) 60%
-  );
+  border-bottom-color: rgba(212, 165, 116, 0.6);
 }
 
 :root.dark .version-links {

--- a/src/styles/documentation.css
+++ b/src/styles/documentation.css
@@ -293,6 +293,116 @@
   background: rgba(255, 255, 255, 0.1);
 }
 
+/* Documentation Links - Oatmeal Colors */
+.doc-page a:not(.anchor-link) {
+  color: #8b6545; /* Warm brown */
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.2s ease;
+}
+
+.doc-page a:not(.anchor-link):hover {
+  border-bottom-color: #d4a574; /* Light oatmeal */
+}
+
+/* External links with icon */
+.doc-page a.external-link,
+.doc-page a[target='_blank'] {
+  color: #8b6545;
+  text-decoration: none;
+  border-bottom: 1px dotted #d4a574;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.doc-page a.external-link:hover,
+.doc-page a[target='_blank']:hover {
+  color: var(--primary-dark);
+  border-bottom-style: solid;
+}
+
+.doc-page a.external-link::after,
+.doc-page a[target='_blank']:not(.no-icon)::after {
+  content: '↗';
+  font-size: 0.75em;
+  opacity: 0.7;
+  transition: transform 0.2s ease;
+}
+
+.doc-page a.external-link:hover::after,
+.doc-page a[target='_blank']:hover::after {
+  transform: translate(2px, -2px);
+  opacity: 1;
+}
+
+/* Version page specific styles */
+.version-links {
+  margin-top: 1rem;
+  padding: 1rem;
+  background: var(--bg-secondary);
+  border-radius: 0.5rem;
+  border-left: 3px solid #d4a574;
+}
+
+.version-links ul {
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+}
+
+.version-links li {
+  margin: 0.5rem 0;
+}
+
+/* Dark mode adjustments for links - Oatmeal theme */
+:root.dark .doc-page a:not(.anchor-link) {
+  color: #d4a574;
+}
+
+:root.dark .doc-page a:not(.anchor-link):hover {
+  color: #e6c299;
+  border-bottom-color: #d4a574;
+}
+
+:root.dark .doc-page a.external-link,
+:root.dark .doc-page a[target='_blank'] {
+  color: #d4a574;
+  background: linear-gradient(
+    to bottom,
+    transparent 60%,
+    rgba(212, 165, 116, 0.15) 60%
+  );
+}
+
+:root.dark .doc-page a.external-link:hover,
+:root.dark .doc-page a[target='_blank']:hover {
+  color: #e6c299;
+  background: linear-gradient(
+    to bottom,
+    transparent 60%,
+    rgba(212, 165, 116, 0.3) 60%
+  );
+}
+
+:root.dark .version-links {
+  background: linear-gradient(
+    135deg,
+    rgba(164, 116, 101, 0.1) 0%,
+    rgba(164, 116, 101, 0.15) 100%
+  );
+  border-left-color: #d4a574;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+:root.dark .version-links strong {
+  color: #d4a574;
+}
+
+:root.dark .version-links a:hover {
+  background: rgba(212, 165, 116, 0.2);
+}
+
 /* API Search Highlight Effect */
 @keyframes highlightApi {
   0% {


### PR DESCRIPTION
Add comprehensive API documentation for iOS and Android platform-specific functions following expo-iap naming conventions.

- Added 19 iOS-specific APIs with IOS suffix
- Added missing Android APIs
- Fixed SearchModal kebab-case conversion
- Updated CLAUDE.md with naming conventions
- Bumped version to 1.0.1

Related: hyochan/react-native-iap#2986, hyochan/expo-iap#182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added comprehensive iOS and Android API docs, new platform-specific entries, deprecations, and kebab-case IDs/anchors.
  - Introduced API naming conventions and deprecated-name mappings.
  - Added guidance on a global modal pattern using Preact Signals.
  - Expanded Versions page with v1.0.1 history and external references.

- Style
  - Implemented “Oatmeal” theme for documentation links, external-link indicators, version blocks, dark mode variants, and an API highlight animation.

- Chores
  - Bumped package version to 1.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->