### PR TITLE
fix(apple): add podspec symlink to root for CocoaPods compatibility

### DIFF
--- a/openiap.podspec
+++ b/openiap.podspec
@@ -1,0 +1,1 @@
+packages/apple/openiap.podspec


### PR DESCRIPTION
## Summary
Add symlink for `openiap.podspec` at repository root to enable CocoaPods compatibility.

## Problem
CocoaPods requires the podspec file to be at the repository root when using git source (`:git => 'url'`). Currently, the podspec is only located in `packages/apple/`, which causes CocoaPods to fail with:
```
[!] Unable to find a specification for 'openiap'.
```

## Solution
Created a symlink at the root pointing to `packages/apple/openiap.podspec`. This allows:
- CocoaPods to find the podspec when using git source
- The actual podspec file to remain in the proper location within the monorepo structure

## Testing
- ✅ Symlink created successfully
- ✅ Git tracks the symlink correctly
- Will test with Kotlin Multiplatform CocoaPods plugin after merge

## Related
- Fixes compatibility with kmp-iap project
- Required for v1.2.24 release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CocoaPods support for iOS integration, enabling seamless package installation in iOS projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->