### PR TITLE
fix(apple): allow resubscription for cancelled subscriptions

### DIFF
--- a/packages/apple/Sources/OpenIapModule.swift
+++ b/packages/apple/Sources/OpenIapModule.swift
@@ -201,15 +201,47 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
                     }
 
                     if isActive {
-                        OpenIapLog.debug("""
-                            ⚠️ [requestPurchase] Subscription already owned:
-                            - SKU: \(sku)
-                            - Transaction ID: \(transaction.id)
-                            - Expiration: \(transaction.expirationDate?.description ?? "none")
-                            """)
-                        let error = makePurchaseError(code: .alreadyOwned, productId: sku)
-                        emitPurchaseError(error)
-                        throw error
+                        // Check if subscription is cancelled (will not auto-renew)
+                        // If cancelled, allow repurchase even though subscription is still active
+                        var willAutoRenew = true
+                        if let subscription = product.subscription {
+                            do {
+                                let statuses = try await subscription.status
+                                if let status = statuses.first {
+                                    switch status.renewalInfo {
+                                    case .verified(let info):
+                                        willAutoRenew = info.willAutoRenew
+                                    case .unverified:
+                                        willAutoRenew = true
+                                    }
+                                }
+                            } catch {
+                                OpenIapLog.debug("⚠️ Failed to check renewal status: \(error.localizedDescription)")
+                            }
+                        }
+
+                        // Only block purchase if subscription is active AND will auto-renew
+                        // Allow purchase if user has cancelled their subscription (willAutoRenew = false)
+                        if willAutoRenew {
+                            OpenIapLog.debug("""
+                                ⚠️ [requestPurchase] Subscription already owned:
+                                - SKU: \(sku)
+                                - Transaction ID: \(transaction.id)
+                                - Expiration: \(transaction.expirationDate?.description ?? "none")
+                                - Will Auto-Renew: \(willAutoRenew)
+                                """)
+                            let error = makePurchaseError(code: .alreadyOwned, productId: sku)
+                            emitPurchaseError(error)
+                            throw error
+                        } else {
+                            OpenIapLog.debug("""
+                                ✅ [requestPurchase] Allowing repurchase of cancelled subscription:
+                                - SKU: \(sku)
+                                - Transaction ID: \(transaction.id)
+                                - Expiration: \(transaction.expirationDate?.description ?? "none")
+                                - Will Auto-Renew: \(willAutoRenew)
+                                """)
+                        }
                     }
                 } catch let purchaseError as PurchaseError {
                     // Always emit error for library user to handle

--- a/packages/docs/src/pages/docs/apis.tsx
+++ b/packages/docs/src/pages/docs/apis.tsx
@@ -267,6 +267,49 @@ type RequestPurchaseProps =
           </p>
         </blockquote>
 
+        <AnchorLink id="handling-resubscription" level="h4">
+          Handling Resubscription (Cancelled Subscriptions)
+        </AnchorLink>
+        <p>
+          When a user cancels their subscription, it remains active until the
+          expiration date. During this period, the user can resubscribe.
+          Starting from openiap-apple 1.2.34, the library automatically allows
+          resubscription for cancelled subscriptions.
+        </p>
+        <CodeBlock language="typescript">{`// Check if subscription is cancelled but still active
+const subscriptions = await getActiveSubscriptions(['premium_monthly']);
+const subscription = subscriptions[0];
+
+if (subscription?.renewalInfoIOS?.willAutoRenew === false) {
+  // Subscription is cancelled - user can resubscribe
+  console.log('Subscription cancelled, showing resubscribe button');
+
+  try {
+    // This will now succeed even though subscription is still active
+    await requestPurchase({
+      params: { ios: { sku: 'premium_monthly' } },
+      type: 'subs'
+    });
+  } catch (error) {
+    if (error.code === 'already-owned') {
+      // Only thrown if subscription is active AND will auto-renew
+      console.log('Subscription is already active and will renew');
+    }
+  }
+} else if (subscription) {
+  // Subscription is active and will auto-renew
+  console.log('Subscription is active');
+}`}</CodeBlock>
+        <blockquote className="info-note">
+          <p>
+            <strong>Behavior:</strong> The <code>already-owned</code> error is
+            only thrown when a subscription is <strong>both</strong> active and
+            will auto-renew. If a user has cancelled their subscription (
+            <code>willAutoRenew = false</code>), they can resubscribe
+            immediately without waiting for expiration.
+          </p>
+        </blockquote>
+
         <AnchorLink id="android-alternative-billing" level="h4">
           Android Alternative Billing
         </AnchorLink>


### PR DESCRIPTION
Check willAutoRenew status before blocking duplicate subscription purchases. Users can now resubscribe even when their cancelled subscription is still active.

Resolve #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now resubscribe to previously cancelled subscriptions, while active auto-renewing subscriptions remain blocked from repurchase.

* **Documentation**
  * Added guidance on handling resubscription for cancelled subscriptions with code examples and behavior clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->