### PR TITLE
fix: handle camelCase error codes in iOS for compatibility

### DIFF
--- a/packages/apple/Sources/Models/Types.swift
+++ b/packages/apple/Sources/Models/Types.swift
@@ -55,6 +55,84 @@ public enum ErrorCode: String, Codable, CaseIterable {
     case billingUnavailable = "billing-unavailable"
     case featureNotSupported = "feature-not-supported"
     case emptySkuList = "empty-sku-list"
+
+    /// Custom initializer to handle both kebab-case and camelCase error codes
+    /// This ensures compatibility with react-native-iap and other libraries that may send camelCase
+    public init?(rawValue: String) {
+        // Try direct match first (kebab-case)
+        switch rawValue {
+        case "unknown", "Unknown":
+            self = .unknown
+        case "user-cancelled", "UserCancelled":
+            self = .userCancelled
+        case "user-error", "UserError":
+            self = .userError
+        case "item-unavailable", "ItemUnavailable":
+            self = .itemUnavailable
+        case "remote-error", "RemoteError":
+            self = .remoteError
+        case "network-error", "NetworkError":
+            self = .networkError
+        case "service-error", "ServiceError":
+            self = .serviceError
+        case "receipt-failed", "ReceiptFailed":
+            self = .receiptFailed
+        case "receipt-finished", "ReceiptFinished":
+            self = .receiptFinished
+        case "receipt-finished-failed", "ReceiptFinishedFailed":
+            self = .receiptFinishedFailed
+        case "not-prepared", "NotPrepared":
+            self = .notPrepared
+        case "not-ended", "NotEnded":
+            self = .notEnded
+        case "already-owned", "AlreadyOwned":
+            self = .alreadyOwned
+        case "developer-error", "DeveloperError":
+            self = .developerError
+        case "billing-response-json-parse-error", "BillingResponseJsonParseError":
+            self = .billingResponseJsonParseError
+        case "deferred-payment", "DeferredPayment":
+            self = .deferredPayment
+        case "interrupted", "Interrupted":
+            self = .interrupted
+        case "iap-not-available", "IapNotAvailable":
+            self = .iapNotAvailable
+        case "purchase-error", "PurchaseError":
+            self = .purchaseError
+        case "sync-error", "SyncError":
+            self = .syncError
+        case "transaction-validation-failed", "TransactionValidationFailed":
+            self = .transactionValidationFailed
+        case "activity-unavailable", "ActivityUnavailable":
+            self = .activityUnavailable
+        case "already-prepared", "AlreadyPrepared":
+            self = .alreadyPrepared
+        case "pending", "Pending":
+            self = .pending
+        case "connection-closed", "ConnectionClosed":
+            self = .connectionClosed
+        case "init-connection", "InitConnection":
+            self = .initConnection
+        case "service-disconnected", "ServiceDisconnected":
+            self = .serviceDisconnected
+        case "query-product", "QueryProduct":
+            self = .queryProduct
+        case "sku-not-found", "SkuNotFound":
+            self = .skuNotFound
+        case "sku-offer-mismatch", "SkuOfferMismatch":
+            self = .skuOfferMismatch
+        case "item-not-owned", "ItemNotOwned":
+            self = .itemNotOwned
+        case "billing-unavailable", "BillingUnavailable":
+            self = .billingUnavailable
+        case "feature-not-supported", "FeatureNotSupported":
+            self = .featureNotSupported
+        case "empty-sku-list", "EmptySkuList":
+            self = .emptySkuList
+        default:
+            return nil
+        }
+    }
 }
 
 /// User actions on external purchase notice sheet (iOS 18.2+)

--- a/packages/apple/Tests/OpenIapTests.swift
+++ b/packages/apple/Tests/OpenIapTests.swift
@@ -239,6 +239,84 @@ final class OpenIapTests: XCTestCase {
         XCTAssertEqual(dictionaryPayAsYouGo["introductoryPriceSubscriptionPeriodIOS"] as? String, "month")
     }
 
+    func testErrorCodeKebabCaseInitialization() {
+        // Test kebab-case initialization (standard)
+        XCTAssertEqual(ErrorCode(rawValue: "already-owned"), .alreadyOwned)
+        XCTAssertEqual(ErrorCode(rawValue: "user-cancelled"), .userCancelled)
+        XCTAssertEqual(ErrorCode(rawValue: "item-not-owned"), .itemNotOwned)
+        XCTAssertEqual(ErrorCode(rawValue: "billing-unavailable"), .billingUnavailable)
+        XCTAssertEqual(ErrorCode(rawValue: "sku-not-found"), .skuNotFound)
+    }
+
+    func testErrorCodeCamelCaseInitialization() {
+        // Test camelCase initialization (react-native-iap compatibility)
+        XCTAssertEqual(ErrorCode(rawValue: "AlreadyOwned"), .alreadyOwned)
+        XCTAssertEqual(ErrorCode(rawValue: "UserCancelled"), .userCancelled)
+        XCTAssertEqual(ErrorCode(rawValue: "ItemNotOwned"), .itemNotOwned)
+        XCTAssertEqual(ErrorCode(rawValue: "BillingUnavailable"), .billingUnavailable)
+        XCTAssertEqual(ErrorCode(rawValue: "SkuNotFound"), .skuNotFound)
+    }
+
+    func testErrorCodeAllCasesWithBothFormats() throws {
+        // Test all error codes can be initialized with both formats
+        let testCases: [(kebab: String, camel: String, expected: ErrorCode)] = [
+            ("unknown", "Unknown", .unknown),
+            ("user-cancelled", "UserCancelled", .userCancelled),
+            ("user-error", "UserError", .userError),
+            ("item-unavailable", "ItemUnavailable", .itemUnavailable),
+            ("remote-error", "RemoteError", .remoteError),
+            ("network-error", "NetworkError", .networkError),
+            ("service-error", "ServiceError", .serviceError),
+            ("receipt-failed", "ReceiptFailed", .receiptFailed),
+            ("not-prepared", "NotPrepared", .notPrepared),
+            ("already-owned", "AlreadyOwned", .alreadyOwned),
+            ("developer-error", "DeveloperError", .developerError),
+            ("deferred-payment", "DeferredPayment", .deferredPayment),
+            ("purchase-error", "PurchaseError", .purchaseError),
+            ("sku-not-found", "SkuNotFound", .skuNotFound),
+            ("item-not-owned", "ItemNotOwned", .itemNotOwned),
+            ("billing-unavailable", "BillingUnavailable", .billingUnavailable),
+        ]
+
+        for (kebab, camel, expected) in testCases {
+            XCTAssertEqual(ErrorCode(rawValue: kebab), expected,
+                "kebab-case '\(kebab)' should map to \(expected)")
+            XCTAssertEqual(ErrorCode(rawValue: camel), expected,
+                "camelCase '\(camel)' should map to \(expected)")
+        }
+    }
+
+    func testErrorCodeInvalidValue() {
+        // Test that invalid error codes return nil
+        XCTAssertNil(ErrorCode(rawValue: "invalid-error"))
+        XCTAssertNil(ErrorCode(rawValue: "InvalidError"))
+        XCTAssertNil(ErrorCode(rawValue: "nonexistent"))
+    }
+
+    func testErrorCodeJSONDecoding() throws {
+        // Test decoding from JSON with camelCase (react-native-iap format)
+        let jsonCamel = """
+        {
+            "code": "AlreadyOwned",
+            "message": "Item is already owned"
+        }
+        """
+        let errorCamel = try JSONDecoder().decode(PurchaseError.self, from: jsonCamel.data(using: .utf8)!)
+        XCTAssertEqual(errorCamel.code, .alreadyOwned)
+        XCTAssertEqual(errorCamel.message, "Item is already owned")
+
+        // Test decoding from JSON with kebab-case (standard format)
+        let jsonKebab = """
+        {
+            "code": "already-owned",
+            "message": "Item is already owned"
+        }
+        """
+        let errorKebab = try JSONDecoder().decode(PurchaseError.self, from: jsonKebab.data(using: .utf8)!)
+        XCTAssertEqual(errorKebab.code, .alreadyOwned)
+        XCTAssertEqual(errorKebab.message, "Item is already owned")
+    }
+
     // MARK: - Helpers
 
     private func makeSampleProduct() -> ProductIOS {

--- a/packages/google/openiap/src/test/java/dev/hyo/openiap/OpenIapErrorTest.kt
+++ b/packages/google/openiap/src/test/java/dev/hyo/openiap/OpenIapErrorTest.kt
@@ -353,4 +353,52 @@ class OpenIapErrorTest {
         assertEquals("Purchase failed", OpenIapError.defaultMessage(ErrorCode.PurchaseError.rawValue))
         assertEquals("Unknown error occurred", OpenIapError.defaultMessage("non-existent-code"))
     }
+
+    @Test
+    fun `ErrorCode fromJson handles kebab-case format`() {
+        // Test kebab-case (standard format)
+        assertEquals(ErrorCode.AlreadyOwned, ErrorCode.fromJson("already-owned"))
+        assertEquals(ErrorCode.UserCancelled, ErrorCode.fromJson("user-cancelled"))
+        assertEquals(ErrorCode.ItemNotOwned, ErrorCode.fromJson("item-not-owned"))
+        assertEquals(ErrorCode.BillingUnavailable, ErrorCode.fromJson("billing-unavailable"))
+        assertEquals(ErrorCode.SkuNotFound, ErrorCode.fromJson("sku-not-found"))
+    }
+
+    @Test
+    fun `ErrorCode fromJson handles camelCase format for react-native-iap compatibility`() {
+        // Test camelCase (react-native-iap format)
+        assertEquals(ErrorCode.AlreadyOwned, ErrorCode.fromJson("AlreadyOwned"))
+        assertEquals(ErrorCode.UserCancelled, ErrorCode.fromJson("UserCancelled"))
+        assertEquals(ErrorCode.ItemNotOwned, ErrorCode.fromJson("ItemNotOwned"))
+        assertEquals(ErrorCode.BillingUnavailable, ErrorCode.fromJson("BillingUnavailable"))
+        assertEquals(ErrorCode.SkuNotFound, ErrorCode.fromJson("SkuNotFound"))
+    }
+
+    @Test
+    fun `ErrorCode fromJson handles all codes with both formats`() {
+        val testCases = listOf(
+            "unknown" to "Unknown",
+            "user-cancelled" to "UserCancelled",
+            "user-error" to "UserError",
+            "item-unavailable" to "ItemUnavailable",
+            "remote-error" to "RemoteError",
+            "network-error" to "NetworkError",
+            "service-error" to "ServiceError",
+            "receipt-failed" to "ReceiptFailed",
+            "not-prepared" to "NotPrepared",
+            "already-owned" to "AlreadyOwned",
+            "developer-error" to "DeveloperError",
+            "deferred-payment" to "DeferredPayment",
+            "purchase-error" to "PurchaseError",
+            "sku-not-found" to "SkuNotFound",
+            "item-not-owned" to "ItemNotOwned",
+            "billing-unavailable" to "BillingUnavailable"
+        )
+
+        for ((kebab, camel) in testCases) {
+            val fromKebab = ErrorCode.fromJson(kebab)
+            val fromCamel = ErrorCode.fromJson(camel)
+            assertEquals("Both formats should parse to same ErrorCode", fromKebab, fromCamel)
+        }
+    }
 }

--- a/packages/gql/scripts/generate-swift-types.mjs
+++ b/packages/gql/scripts/generate-swift-types.mjs
@@ -306,6 +306,28 @@ const printEnum = (enumType) => {
     lines.push(`    case ${caseName} = "${rawValue}"`);
     if (index === values.length - 1) return;
   });
+
+  // Add custom initializer for ErrorCode to handle both kebab-case and camelCase
+  if (enumType.name === 'ErrorCode') {
+    lines.push('');
+    lines.push('    /// Custom initializer to handle both kebab-case and camelCase error codes');
+    lines.push('    /// This ensures compatibility with react-native-iap and other libraries that may send camelCase');
+    lines.push('    public init?(rawValue: String) {');
+    lines.push('        // Try direct match first (kebab-case)');
+    lines.push('        switch rawValue {');
+    values.forEach((value) => {
+      const caseName = escapeSwiftName(lowerCamelCase(value.name));
+      const rawValue = toKebabCase(value.name);
+      const camelCaseName = value.name.charAt(0).toUpperCase() + value.name.slice(1);
+      lines.push(`        case "${rawValue}", "${camelCaseName}":`);
+      lines.push(`            self = .${caseName}`);
+    });
+    lines.push('        default:');
+    lines.push('            return nil');
+    lines.push('        }');
+    lines.push('    }');
+  }
+
   lines.push('}', '');
 };
 

--- a/packages/gql/src/generated/Types.swift
+++ b/packages/gql/src/generated/Types.swift
@@ -55,6 +55,84 @@ public enum ErrorCode: String, Codable, CaseIterable {
     case billingUnavailable = "billing-unavailable"
     case featureNotSupported = "feature-not-supported"
     case emptySkuList = "empty-sku-list"
+
+    /// Custom initializer to handle both kebab-case and camelCase error codes
+    /// This ensures compatibility with react-native-iap and other libraries that may send camelCase
+    public init?(rawValue: String) {
+        // Try direct match first (kebab-case)
+        switch rawValue {
+        case "unknown", "Unknown":
+            self = .unknown
+        case "user-cancelled", "UserCancelled":
+            self = .userCancelled
+        case "user-error", "UserError":
+            self = .userError
+        case "item-unavailable", "ItemUnavailable":
+            self = .itemUnavailable
+        case "remote-error", "RemoteError":
+            self = .remoteError
+        case "network-error", "NetworkError":
+            self = .networkError
+        case "service-error", "ServiceError":
+            self = .serviceError
+        case "receipt-failed", "ReceiptFailed":
+            self = .receiptFailed
+        case "receipt-finished", "ReceiptFinished":
+            self = .receiptFinished
+        case "receipt-finished-failed", "ReceiptFinishedFailed":
+            self = .receiptFinishedFailed
+        case "not-prepared", "NotPrepared":
+            self = .notPrepared
+        case "not-ended", "NotEnded":
+            self = .notEnded
+        case "already-owned", "AlreadyOwned":
+            self = .alreadyOwned
+        case "developer-error", "DeveloperError":
+            self = .developerError
+        case "billing-response-json-parse-error", "BillingResponseJsonParseError":
+            self = .billingResponseJsonParseError
+        case "deferred-payment", "DeferredPayment":
+            self = .deferredPayment
+        case "interrupted", "Interrupted":
+            self = .interrupted
+        case "iap-not-available", "IapNotAvailable":
+            self = .iapNotAvailable
+        case "purchase-error", "PurchaseError":
+            self = .purchaseError
+        case "sync-error", "SyncError":
+            self = .syncError
+        case "transaction-validation-failed", "TransactionValidationFailed":
+            self = .transactionValidationFailed
+        case "activity-unavailable", "ActivityUnavailable":
+            self = .activityUnavailable
+        case "already-prepared", "AlreadyPrepared":
+            self = .alreadyPrepared
+        case "pending", "Pending":
+            self = .pending
+        case "connection-closed", "ConnectionClosed":
+            self = .connectionClosed
+        case "init-connection", "InitConnection":
+            self = .initConnection
+        case "service-disconnected", "ServiceDisconnected":
+            self = .serviceDisconnected
+        case "query-product", "QueryProduct":
+            self = .queryProduct
+        case "sku-not-found", "SkuNotFound":
+            self = .skuNotFound
+        case "sku-offer-mismatch", "SkuOfferMismatch":
+            self = .skuOfferMismatch
+        case "item-not-owned", "ItemNotOwned":
+            self = .itemNotOwned
+        case "billing-unavailable", "BillingUnavailable":
+            self = .billingUnavailable
+        case "feature-not-supported", "FeatureNotSupported":
+            self = .featureNotSupported
+        case "empty-sku-list", "EmptySkuList":
+            self = .emptySkuList
+        default:
+            return nil
+        }
+    }
 }
 
 /// User actions on external purchase notice sheet (iOS 18.2+)


### PR DESCRIPTION
Resolve https://github.com/hyochan/react-native-iap/issues/3090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ErrorCode initialization now accepts and properly maps both kebab-case and camelCase string formats.

* **Tests**
  * Added comprehensive test coverage validating ErrorCode initialization and JSON decoding with both kebab-case and camelCase format support, including all known error codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->