### PR TITLE
fix(apple): map StoreKitError.userCancelled to correct err code

### DIFF
--- a/packages/apple/Sources/OpenIapModule.swift
+++ b/packages/apple/Sources/OpenIapModule.swift
@@ -324,8 +324,11 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
                 emitPurchaseError(purchaseError)
                 throw purchaseError
             }
-            // Re-throw original error for non-promotional purchases
-            throw error
+
+            // Use PurchaseError.wrap to automatically map errors (including StoreKitError.userCancelled)
+            let purchaseError = PurchaseError.wrap(error, fallback: .purchaseError, productId: sku)
+            emitPurchaseError(purchaseError)
+            throw purchaseError
         }
 
         switch result {


### PR DESCRIPTION
Map StoreKitError to PurchaseError in wrap() method to ensure user cancellation returns 'user-cancelled' instead of 'purchase-error'.

Fixes hyochan/expo-iap#261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for purchase operations by providing more accurate error categorization for network failures, user cancellations, and store availability issues, enabling better error reporting and recovery experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->