### PR TITLE
fix(apple): validate appAccountToken UUID format before purchase

### DIFF
--- a/packages/apple/Sources/Helpers/StoreKitTypesBridge.swift
+++ b/packages/apple/Sources/Helpers/StoreKitTypesBridge.swift
@@ -370,11 +370,12 @@ enum StoreKitTypesBridge {
                 // If a non-UUID value is provided, Apple silently returns null for this field.
                 // Fail fast with a clear error message so developers can identify the issue.
                 // Reference: https://openiap.dev/docs/types/request
-                OpenIapLog.error("❌ Invalid appAccountToken format: '\(token)'. Must be a valid UUID (e.g., '550e8400-e29b-41d4-a716-446655440000')")
+                // Note: We intentionally do NOT log the token value as it may contain sensitive data.
+                OpenIapLog.error("❌ Invalid appAccountToken format. Must be a valid UUID (e.g., '550e8400-e29b-41d4-a716-446655440000')")
                 throw PurchaseError.make(
                     code: .developerError,
                     productId: props.sku,
-                    message: "appAccountToken must be a valid UUID format (e.g., '550e8400-e29b-41d4-a716-446655440000'). Received: '\(token)'. Apple silently returns null for non-UUID values."
+                    message: "appAccountToken must be a valid UUID format (e.g., '550e8400-e29b-41d4-a716-446655440000'). Apple silently returns null for non-UUID values."
                 )
             }
             options.insert(.appAccountToken(uuid))

--- a/packages/apple/Tests/OpenIapTests/AppAccountTokenTests.swift
+++ b/packages/apple/Tests/OpenIapTests/AppAccountTokenTests.swift
@@ -83,7 +83,7 @@ final class AppAccountTokenTests: XCTestCase {
             XCTAssertEqual(purchaseError.code, .developerError)
             XCTAssertEqual(purchaseError.productId, "dev.hyo.premium")
             XCTAssertTrue(purchaseError.message.contains("UUID"))
-            XCTAssertTrue(purchaseError.message.contains("user-123"))
+            // Note: Error message intentionally does not include the token value for security reasons
         }
     }
 
@@ -224,11 +224,10 @@ final class AppAccountTokenTests: XCTestCase {
     // MARK: - Error Message Content Tests
 
     func testAppAccountToken_ErrorMessage_ContainsGuidance() throws {
-        let invalidToken = "my-custom-user-id"
         let props = RequestPurchaseIosProps(
             advancedCommerceData: nil,
             andDangerouslyFinishTransactionAutomatically: nil,
-            appAccountToken: invalidToken,
+            appAccountToken: "my-custom-user-id",
             quantity: nil,
             sku: "dev.hyo.premium",
             withOffer: nil
@@ -241,7 +240,8 @@ final class AppAccountTokenTests: XCTestCase {
             }
             // Error message should contain helpful information
             XCTAssertTrue(purchaseError.message.contains("UUID"), "Error should mention UUID requirement")
-            XCTAssertTrue(purchaseError.message.contains(invalidToken), "Error should show the invalid value")
+            // Note: Error message intentionally does NOT include the token value for security reasons
+            // (developers may mistakenly pass PII or sensitive identifiers)
             XCTAssertTrue(purchaseError.message.lowercased().contains("apple"), "Error should mention Apple behavior")
         }
     }


### PR DESCRIPTION
## Summary
- Add UUID format validation for `appAccountToken` in `StoreKitTypesBridge.purchaseOptions`
- Throw `developerError` with descriptive message when non-UUID value is provided
- Add 13 test cases covering valid/invalid UUID formats

## Problem
Apple requires `appAccountToken` to be a valid UUID format. When a non-UUID value is provided (e.g., `"user-123"`), Apple's StoreKit silently returns `null` for this field in the transaction response, making debugging difficult.

## Solution
Validate the UUID format before passing to StoreKit and throw a clear error with:
- The invalid value received
- Example of valid UUID format
- Explanation that Apple silently returns null for non-UUID values

## Test plan
- [x] All 64 tests pass (`swift test`)
- [x] New `AppAccountTokenTests` with 13 test cases
- [x] Valid UUID formats accepted (lowercase, uppercase, generated)
- [x] Invalid formats throw `developerError` with helpful message

Closes hyochan/expo-iap#128

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account token handling now fails fast for invalid formats and shows clear, user-facing error messages explaining UUID requirements while avoiding leaking token values.

* **Tests**
  * Added a test suite covering valid and invalid account token scenarios to ensure consistent validation and error messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->