### PR TITLE
feat: add libraries-versions.jsonc for testing published packages

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,7 +43,7 @@
             "type": "node",
             "request": "launch",
             "runtimeExecutable": "bash",
-            "runtimeArgs": ["-lc", "cd .. && yarn install && yarn prepare && cd example && yarn install && bundle install && yarn ios --device"],
+            "runtimeArgs": ["-lc", "npx kill-port 8081 || true && ./scripts/with-resolve.sh bash -c 'cd .. && yarn install && yarn prepare && cd example && yarn install && bundle install && yarn ios --device'"],
             "cwd": "${workspaceFolder}/libraries/react-native-iap/example",
             "console": "integratedTerminal"
         },
@@ -52,7 +52,7 @@
             "type": "node",
             "request": "launch",
             "runtimeExecutable": "bash",
-            "runtimeArgs": ["-lc", "cd .. && yarn install && yarn prepare && cd example && yarn install && yarn android"],
+            "runtimeArgs": ["-lc", "npx kill-port 8081 || true && adb uninstall dev.hyo.martie || true && ./scripts/with-resolve.sh bash -c 'cd .. && yarn install && yarn prepare && cd example && yarn install && yarn android'"],
             "cwd": "${workspaceFolder}/libraries/react-native-iap/example",
             "console": "integratedTerminal"
         },
@@ -61,8 +61,8 @@
             "type": "node",
             "request": "launch",
             "runtimeExecutable": "bash",
-            "runtimeArgs": ["-lc", "bun install && bun run prepare && cd example && bun install && bunx expo prebuild && bunx expo run:ios --device"],
-            "cwd": "${workspaceFolder}/libraries/expo-iap",
+            "runtimeArgs": ["-lc", "npx kill-port 8081 || true && node scripts/resolve-deps.js; bun install && bunx expo prebuild && bunx expo run:ios --device"],
+            "cwd": "${workspaceFolder}/libraries/expo-iap/example",
             "console": "integratedTerminal"
         },
         {
@@ -70,8 +70,8 @@
             "type": "node",
             "request": "launch",
             "runtimeExecutable": "bash",
-            "runtimeArgs": ["-lc", "bun install && bun run prepare && cd example && bun install && bunx expo prebuild && bunx expo run:android"],
-            "cwd": "${workspaceFolder}/libraries/expo-iap",
+            "runtimeArgs": ["-lc", "npx kill-port 8081 || true && adb uninstall dev.hyo.martie || true && node scripts/resolve-deps.js; bun install && bunx expo prebuild && bunx expo run:android"],
+            "cwd": "${workspaceFolder}/libraries/expo-iap/example",
             "console": "integratedTerminal"
         },
         // Flutter iOS debug: "flutter run" may fail to connect to Dart VM service
@@ -83,7 +83,7 @@
             "type": "node",
             "request": "launch",
             "runtimeExecutable": "bash",
-            "runtimeArgs": ["-lc", "cd .. && flutter pub get && cd example && flutter pub get && flutter run"],
+            "runtimeArgs": ["-lc", "node scripts/resolve-deps.js; cd .. && flutter pub get && cd example && flutter pub get && cd ios && pod install && cd .. && flutter run"],
             "cwd": "${workspaceFolder}/libraries/flutter_inapp_purchase/example",
             "console": "integratedTerminal"
         },
@@ -92,7 +92,7 @@
             "type": "node",
             "request": "launch",
             "runtimeExecutable": "bash",
-            "runtimeArgs": ["-lc", "cd .. && flutter pub get && cd example && flutter pub get && flutter run"],
+            "runtimeArgs": ["-lc", "adb uninstall dev.hyo.martie || true && node scripts/resolve-deps.js; cd .. && flutter pub get && cd example && flutter pub get && flutter run"],
             "cwd": "${workspaceFolder}/libraries/flutter_inapp_purchase/example",
             "console": "integratedTerminal"
         },
@@ -119,7 +119,7 @@
             "type": "node",
             "request": "launch",
             "runtimeExecutable": "bash",
-            "runtimeArgs": ["-lc", "./gradlew :example:composeApp:installDebug"],
+            "runtimeArgs": ["-lc", "adb uninstall dev.hyo.martie || true && ./gradlew :example:composeApp:installDebug && adb shell am start -n dev.hyo.martie/.MainActivity"],
             "cwd": "${workspaceFolder}/libraries/kmp-iap",
             "console": "integratedTerminal"
         }

--- a/libraries-versions.jsonc
+++ b/libraries-versions.jsonc
@@ -1,0 +1,12 @@
+// Library example dependency mode.
+// "local" = use local monorepo source (default)
+// "<version>" = use published package at that version (e.g. "4.0.0-rc.1")
+//
+// After changing, run the corresponding launch config in VSCode — deps resolve automatically.
+{
+  "expo-iap": "local",
+  "react-native-iap": "local",
+  "flutter_inapp_purchase": "local",
+  "kmp-iap": "local"
+  // godot-iap: no package manager — manually swap example/addons symlink to test published releases
+}

--- a/libraries/expo-iap/example/app.config.ts
+++ b/libraries/expo-iap/example/app.config.ts
@@ -10,17 +10,10 @@ const LOCAL_OPENIAP_PATHS = {
 // Read library version mode from libraries-versions.jsonc
 const parseJsonc = (text: string) =>
   JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
-let librariesVersions: Record<string, string> = {'expo-iap': 'local'};
-try {
-  librariesVersions = parseJsonc(
-    fs.readFileSync(
-      path.resolve(__dirname, '../../../libraries-versions.jsonc'),
-      'utf8',
-    ),
-  );
-} catch {
-  // File missing or malformed — default to local dev mode
-}
+const versionsPath = path.resolve(__dirname, '../../../libraries-versions.jsonc');
+const librariesVersions: Record<string, string> = fs.existsSync(versionsPath)
+  ? parseJsonc(fs.readFileSync(versionsPath, 'utf8'))
+  : {'expo-iap': 'local'};
 const useLocalDev = !librariesVersions['expo-iap'] || librariesVersions['expo-iap'] === 'local';
 
 export default ({config}: ConfigContext): ExpoConfig => {

--- a/libraries/expo-iap/example/app.config.ts
+++ b/libraries/expo-iap/example/app.config.ts
@@ -1,9 +1,22 @@
 import type {ConfigContext, ExpoConfig} from '@expo/config';
+import * as fs from 'fs';
+import * as path from 'path';
 
 const LOCAL_OPENIAP_PATHS = {
   ios: '../../../packages/apple',
   android: '../../../packages/google',
 } as const;
+
+// Read library version mode from libraries-versions.jsonc
+const parseJsonc = (text: string) =>
+  JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
+const librariesVersions = parseJsonc(
+  fs.readFileSync(
+    path.resolve(__dirname, '../../../libraries-versions.jsonc'),
+    'utf8',
+  ),
+);
+const useLocalDev = librariesVersions['expo-iap'] === 'local';
 
 export default ({config}: ConfigContext): ExpoConfig => {
   // Check if building for TV (set EXPO_TV=1 before prebuild)
@@ -21,7 +34,7 @@ export default ({config}: ConfigContext): ExpoConfig => {
         // IAPKit API key for server-side receipt verification
         // Get your API key from https://iapkit.com
         iapkitApiKey: process.env.EXPO_PUBLIC_IAPKIT_API_KEY,
-        enableLocalDev: false,
+        enableLocalDev: useLocalDev,
         localPath: {
           ios: LOCAL_OPENIAP_PATHS.ios,
           android: LOCAL_OPENIAP_PATHS.android,

--- a/libraries/expo-iap/example/app.config.ts
+++ b/libraries/expo-iap/example/app.config.ts
@@ -10,13 +10,18 @@ const LOCAL_OPENIAP_PATHS = {
 // Read library version mode from libraries-versions.jsonc
 const parseJsonc = (text: string) =>
   JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
-const librariesVersions = parseJsonc(
-  fs.readFileSync(
-    path.resolve(__dirname, '../../../libraries-versions.jsonc'),
-    'utf8',
-  ),
-);
-const useLocalDev = librariesVersions['expo-iap'] === 'local';
+let librariesVersions: Record<string, string> = {'expo-iap': 'local'};
+try {
+  librariesVersions = parseJsonc(
+    fs.readFileSync(
+      path.resolve(__dirname, '../../../libraries-versions.jsonc'),
+      'utf8',
+    ),
+  );
+} catch {
+  // File missing or malformed — default to local dev mode
+}
+const useLocalDev = !librariesVersions['expo-iap'] || librariesVersions['expo-iap'] === 'local';
 
 export default ({config}: ConfigContext): ExpoConfig => {
   // Check if building for TV (set EXPO_TV=1 before prebuild)

--- a/libraries/expo-iap/example/app/index.tsx
+++ b/libraries/expo-iap/example/app/index.tsx
@@ -207,13 +207,13 @@ const styles = StyleSheet.create({
     backgroundColor: '#FF9800',
   },
   buttonText: {
-    color: '#000000',
+    color: '#ffffff',
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 4,
   },
   buttonSubtext: {
-    color: '#333333',
+    color: 'rgba(255, 255, 255, 0.85)',
     fontSize: 14,
   },
 });

--- a/libraries/expo-iap/example/app/index.tsx
+++ b/libraries/expo-iap/example/app/index.tsx
@@ -143,7 +143,7 @@ export default function Home() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: '#ffffff',
   },
   contentContainer: {
     padding: 20,
@@ -156,17 +156,17 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 28,
     fontWeight: 'bold',
-    color: '#333',
+    color: '#000000',
     marginBottom: 8,
   },
   subtitle: {
     fontSize: 18,
-    color: '#666',
+    color: '#333333',
     marginBottom: 24,
   },
   description: {
     fontSize: 16,
-    color: '#555',
+    color: '#333333',
     textAlign: 'center',
     lineHeight: 24,
     marginBottom: 16,
@@ -207,13 +207,13 @@ const styles = StyleSheet.create({
     backgroundColor: '#FF9800',
   },
   buttonText: {
-    color: '#ffffff',
+    color: '#000000',
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 4,
   },
   buttonSubtext: {
-    color: 'rgba(255, 255, 255, 0.85)',
+    color: '#333333',
     fontSize: 14,
   },
 });

--- a/libraries/expo-iap/example/metro.config.js
+++ b/libraries/expo-iap/example/metro.config.js
@@ -1,32 +1,46 @@
 // Learn more https://docs.expo.io/guides/customizing-metro
 const {getDefaultConfig} = require('expo/metro-config');
 const path = require('path');
+const fs = require('fs');
+
+// Read library version mode from libraries-versions.jsonc
+const parseJsonc = (text) => JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
+const librariesVersions = parseJsonc(
+  fs.readFileSync(
+    path.resolve(__dirname, '../../../libraries-versions.jsonc'),
+    'utf8',
+  ),
+);
+const useLocalDev = librariesVersions['expo-iap'] === 'local';
 
 const config = getDefaultConfig(__dirname);
 
-// npm v7+ will install ../node_modules/react and ../node_modules/react-native because of peerDependencies.
-// To prevent the incompatible react-native between ./node_modules/react-native and ../node_modules/react-native,
-// excludes the one from the parent folder when bundling.
+// Exclude test files from bundling
 config.resolver.blockList = [
   ...Array.from(config.resolver.blockList ?? []),
-  new RegExp(path.resolve('..', 'node_modules', 'react')),
-  new RegExp(path.resolve('..', 'node_modules', 'react-native')),
-  // Exclude test files from bundling
   /.*\/__tests__\/.*/,
   /.*\.test\.(js|jsx|ts|tsx)$/,
   /.*\.spec\.(js|jsx|ts|tsx)$/,
 ];
 
-config.resolver.nodeModulesPaths = [
-  path.resolve(__dirname, './node_modules'),
-  path.resolve(__dirname, '../node_modules'),
-];
+if (useLocalDev) {
+  // Local development: resolve expo-iap from parent directory source
+  config.resolver.blockList.push(
+    new RegExp(path.resolve('..', 'node_modules', 'react')),
+    new RegExp(path.resolve('..', 'node_modules', 'react-native')),
+  );
 
-config.resolver.extraNodeModules = {
-  'expo-iap': '..',
-};
+  config.resolver.nodeModulesPaths = [
+    path.resolve(__dirname, './node_modules'),
+    path.resolve(__dirname, '../node_modules'),
+  ];
 
-config.watchFolders = [path.resolve(__dirname, '..')];
+  config.resolver.extraNodeModules = {
+    'expo-iap': '..',
+  };
+
+  config.watchFolders = [path.resolve(__dirname, '..')];
+}
 
 config.transformer.getTransformOptions = async () => ({
   transform: {

--- a/libraries/expo-iap/example/metro.config.js
+++ b/libraries/expo-iap/example/metro.config.js
@@ -6,16 +6,10 @@ const fs = require('fs');
 // Read library version mode from libraries-versions.jsonc
 const parseJsonc = (text) => JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
 let useLocalDev = true;
-try {
-  const librariesVersions = parseJsonc(
-    fs.readFileSync(
-      path.resolve(__dirname, '../../../libraries-versions.jsonc'),
-      'utf8',
-    ),
-  );
+const versionsPath = path.resolve(__dirname, '../../../libraries-versions.jsonc');
+if (fs.existsSync(versionsPath)) {
+  const librariesVersions = parseJsonc(fs.readFileSync(versionsPath, 'utf8'));
   useLocalDev = !librariesVersions['expo-iap'] || librariesVersions['expo-iap'] === 'local';
-} catch {
-  // File missing or malformed — default to local dev mode
 }
 
 const config = getDefaultConfig(__dirname);
@@ -31,8 +25,8 @@ config.resolver.blockList = [
 if (useLocalDev) {
   // Local development: resolve expo-iap from parent directory source
   config.resolver.blockList.push(
-    new RegExp(path.resolve('..', 'node_modules', 'react')),
-    new RegExp(path.resolve('..', 'node_modules', 'react-native')),
+    new RegExp(path.resolve(__dirname, '..', 'node_modules', 'react')),
+    new RegExp(path.resolve(__dirname, '..', 'node_modules', 'react-native')),
   );
 
   config.resolver.nodeModulesPaths = [
@@ -41,7 +35,7 @@ if (useLocalDev) {
   ];
 
   config.resolver.extraNodeModules = {
-    'expo-iap': '..',
+    'expo-iap': path.resolve(__dirname, '..'),
   };
 
   config.watchFolders = [path.resolve(__dirname, '..')];

--- a/libraries/expo-iap/example/metro.config.js
+++ b/libraries/expo-iap/example/metro.config.js
@@ -5,13 +5,18 @@ const fs = require('fs');
 
 // Read library version mode from libraries-versions.jsonc
 const parseJsonc = (text) => JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
-const librariesVersions = parseJsonc(
-  fs.readFileSync(
-    path.resolve(__dirname, '../../../libraries-versions.jsonc'),
-    'utf8',
-  ),
-);
-const useLocalDev = librariesVersions['expo-iap'] === 'local';
+let useLocalDev = true;
+try {
+  const librariesVersions = parseJsonc(
+    fs.readFileSync(
+      path.resolve(__dirname, '../../../libraries-versions.jsonc'),
+      'utf8',
+    ),
+  );
+  useLocalDev = !librariesVersions['expo-iap'] || librariesVersions['expo-iap'] === 'local';
+} catch {
+  // File missing or malformed — default to local dev mode
+}
 
 const config = getDefaultConfig(__dirname);
 

--- a/libraries/expo-iap/example/scripts/resolve-deps.js
+++ b/libraries/expo-iap/example/scripts/resolve-deps.js
@@ -1,0 +1,70 @@
+/**
+ * Reads libraries-versions.jsonc and patches example dependencies accordingly.
+ * - "local": use local monorepo source (default)
+ * - "<version>": install published npm package at that version
+ *
+ * Run: node scripts/resolve-deps.js
+ */
+const fs = require('fs');
+const path = require('path');
+
+/** Strip // comments from JSONC content */
+const parseJsonc = (text) => JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
+
+const VERSIONS_PATH = path.resolve(__dirname, '../../../../libraries-versions.jsonc');
+const PKG_PATH = path.resolve(__dirname, '../package.json');
+const LIB_NAME = 'expo-iap';
+
+function main() {
+  if (!fs.existsSync(VERSIONS_PATH)) {
+    console.log(`[resolve-deps] No libraries-versions.jsonc found, using local dev.`);
+    return;
+  }
+
+  const versions = parseJsonc(fs.readFileSync(VERSIONS_PATH, 'utf8'));
+  const version = versions[LIB_NAME];
+  const isLocal = !version || version === 'local';
+
+  console.log(`\n========================================`);
+  console.log(`  ${LIB_NAME} : ${isLocal ? 'LOCAL (monorepo source)' : `PUBLISHED v${version}`}`);
+  console.log(`========================================\n`);
+
+  const pkg = JSON.parse(fs.readFileSync(PKG_PATH, 'utf8'));
+
+  let changed = false;
+
+  if (isLocal) {
+    // Ensure local dev setup
+    if (pkg.dependencies?.[LIB_NAME]) {
+      delete pkg.dependencies[LIB_NAME];
+      changed = true;
+    }
+    if (!pkg.expo?.autolinking?.nativeModulesDir) {
+      pkg.expo = pkg.expo || {};
+      pkg.expo.autolinking = pkg.expo.autolinking || {};
+      pkg.expo.autolinking.nativeModulesDir = '..';
+      changed = true;
+    }
+  } else {
+    // Published version: add as dependency and remove autolinking local path
+    const currentDep = pkg.dependencies?.[LIB_NAME];
+    if (currentDep !== version) {
+      pkg.dependencies = pkg.dependencies || {};
+      pkg.dependencies[LIB_NAME] = version;
+      changed = true;
+    }
+    if (pkg.expo?.autolinking?.nativeModulesDir) {
+      delete pkg.expo.autolinking.nativeModulesDir;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    fs.writeFileSync(PKG_PATH, JSON.stringify(pkg, null, 2) + '\n');
+    console.log(`[resolve-deps] ${LIB_NAME}: ${isLocal ? 'local' : version}`);
+    // Signal that install is needed
+    process.exit(2);
+  }
+}
+
+main();

--- a/libraries/expo-iap/example/scripts/with-resolve.sh
+++ b/libraries/expo-iap/example/scripts/with-resolve.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Wrapper: resolve deps from libraries-versions.json, install if needed, then run command.
+# Usage: ./scripts/with-resolve.sh <command...>
+
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$DIR"
+
+# Run resolve-deps.js — exit code 2 means package.json changed
+node scripts/resolve-deps.js || EXIT_CODE=$?
+if [[ "${EXIT_CODE:-0}" -eq 2 ]]; then
+  echo "[with-resolve] Dependencies changed, running install..."
+  bun install
+fi
+
+# Run the actual command
+exec "$@"

--- a/libraries/expo-iap/example/scripts/with-resolve.sh
+++ b/libraries/expo-iap/example/scripts/with-resolve.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Wrapper: resolve deps from libraries-versions.json, install if needed, then run command.
+# Wrapper: resolve deps from libraries-versions.jsonc, install if needed, then run command.
 # Usage: ./scripts/with-resolve.sh <command...>
 
 set -euo pipefail
@@ -7,10 +7,14 @@ DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$DIR"
 
 # Run resolve-deps.js — exit code 2 means package.json changed
+EXIT_CODE=0
 node scripts/resolve-deps.js || EXIT_CODE=$?
-if [[ "${EXIT_CODE:-0}" -eq 2 ]]; then
+if [[ "$EXIT_CODE" -eq 2 ]]; then
   echo "[with-resolve] Dependencies changed, running install..."
   bun install
+elif [[ "$EXIT_CODE" -ne 0 ]]; then
+  echo "[with-resolve] resolve-deps.js failed with exit code $EXIT_CODE"
+  exit "$EXIT_CODE"
 fi
 
 # Run the actual command

--- a/libraries/flutter_inapp_purchase/example/ios/Podfile
+++ b/libraries/flutter_inapp_purchase/example/ios/Podfile
@@ -39,12 +39,16 @@ target 'Runner' do
   use_frameworks!
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
-  # In monorepo: use local openiap-apple source directly
-  openiap_local_path = File.expand_path('../../../../packages/apple', __dir__)
-  if File.directory?(openiap_local_path)
+  # Resolve openiap dependency based on libraries-versions.jsonc
+  libraries_versions_path = File.expand_path('../../../../libraries-versions.jsonc', __dir__)
+  libraries_versions = JSON.parse(File.read(libraries_versions_path).gsub(%r{^\s*//.*$}, ''))
+  flutter_iap_mode = libraries_versions['flutter_inapp_purchase']
+
+  if flutter_iap_mode == 'local'
+    openiap_local_path = File.expand_path('../../../../packages/apple', __dir__)
     pod 'openiap', :path => openiap_local_path
   else
-    pod 'openiap', :git => 'https://github.com/hyodotdev/openiap.git', :tag => openiap_versions['apple']
+    pod 'openiap', openiap_versions['apple']
   end
 end
 

--- a/libraries/flutter_inapp_purchase/example/ios/Podfile
+++ b/libraries/flutter_inapp_purchase/example/ios/Podfile
@@ -41,8 +41,15 @@ target 'Runner' do
 
   # Resolve openiap dependency based on libraries-versions.jsonc
   libraries_versions_path = File.expand_path('../../../../libraries-versions.jsonc', __dir__)
-  libraries_versions = JSON.parse(File.read(libraries_versions_path).gsub(%r{^\s*//.*$}, ''))
-  flutter_iap_mode = libraries_versions['flutter_inapp_purchase']
+  flutter_iap_mode = 'local'
+  if File.exist?(libraries_versions_path)
+    begin
+      libraries_versions = JSON.parse(File.read(libraries_versions_path).gsub(%r{^\s*//.*$}, ''))
+      flutter_iap_mode = libraries_versions['flutter_inapp_purchase'] || 'local'
+    rescue => e
+      puts "[Podfile] Warning: Failed to parse libraries-versions.jsonc: #{e.message}. Defaulting to local."
+    end
+  end
 
   if flutter_iap_mode == 'local'
     openiap_local_path = File.expand_path('../../../../packages/apple', __dir__)

--- a/libraries/flutter_inapp_purchase/example/scripts/resolve-deps.js
+++ b/libraries/flutter_inapp_purchase/example/scripts/resolve-deps.js
@@ -1,0 +1,58 @@
+/**
+ * Reads libraries-versions.jsonc and patches example pubspec.yaml.
+ * - "local": use local path dependency (default)
+ * - "<version>": use published pub.dev package
+ *
+ * Run: node scripts/resolve-deps.js
+ */
+const fs = require('fs');
+const path = require('path');
+
+/** Strip // comments from JSONC content */
+const parseJsonc = (text) => JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
+
+const VERSIONS_PATH = path.resolve(__dirname, '../../../../libraries-versions.jsonc');
+const PUBSPEC_PATH = path.resolve(__dirname, '../pubspec.yaml');
+const LIB_NAME = 'flutter_inapp_purchase';
+
+function main() {
+  if (!fs.existsSync(VERSIONS_PATH)) {
+    console.log(`[resolve-deps] No libraries-versions.jsonc found, using local dev.`);
+    return;
+  }
+
+  const versions = parseJsonc(fs.readFileSync(VERSIONS_PATH, 'utf8'));
+  const version = versions[LIB_NAME];
+  const isLocal = !version || version === 'local';
+
+  console.log(`\n========================================`);
+  console.log(`  ${LIB_NAME} : ${isLocal ? 'LOCAL (monorepo source)' : `PUBLISHED v${version}`}`);
+  console.log(`========================================\n`);
+
+  let content = fs.readFileSync(PUBSPEC_PATH, 'utf8');
+  const original = content;
+
+  // Match version with optional prerelease (e.g. ^9.0.0-rc.1)
+  const VERSION_RE = /flutter_inapp_purchase:\s*\^[\d][^\n]*/;
+  const PATH_RE = /flutter_inapp_purchase:\n\s+path:\s*\.\.\//;
+
+  if (isLocal) {
+    if (VERSION_RE.test(content)) {
+      content = content.replace(VERSION_RE, `flutter_inapp_purchase:\n    path: ../`);
+    }
+  } else {
+    if (PATH_RE.test(content)) {
+      content = content.replace(PATH_RE, `flutter_inapp_purchase: ^${version}`);
+    } else if (VERSION_RE.test(content)) {
+      content = content.replace(VERSION_RE, `flutter_inapp_purchase: ^${version}`);
+    }
+  }
+
+  if (content !== original) {
+    fs.writeFileSync(PUBSPEC_PATH, content);
+    console.log(`[resolve-deps] ${LIB_NAME}: ${isLocal ? 'local' : version}`);
+    process.exit(2);
+  }
+}
+
+main();

--- a/libraries/kmp-iap/example/composeApp/build.gradle.kts
+++ b/libraries/kmp-iap/example/composeApp/build.gradle.kts
@@ -23,15 +23,14 @@ fun loadEnvProperties(): Properties {
 val envProperties = loadEnvProperties()
 
 // Read library version mode from libraries-versions.jsonc
-val kmpIapMode: String = try {
+val versionsFile = rootProject.file("../../libraries-versions.jsonc")
+val kmpIapMode: String = if (!versionsFile.exists()) {
+    "local"
+} else {
     val librariesVersions = JsonSlurper().parseText(
-        rootProject.file("../../libraries-versions.jsonc").readText()
-            .replace(Regex("^\\s*//.*$", RegexOption.MULTILINE), "")
+        versionsFile.readText().replace(Regex("^\\s*//.*$", RegexOption.MULTILINE), "")
     ) as Map<*, *>
     librariesVersions["kmp-iap"]?.toString() ?: "local"
-} catch (e: Exception) {
-    // File missing or malformed — default to local dev mode
-    "local"
 }
 val useLocalDev = kmpIapMode == "local"
 

--- a/libraries/kmp-iap/example/composeApp/build.gradle.kts
+++ b/libraries/kmp-iap/example/composeApp/build.gradle.kts
@@ -23,11 +23,16 @@ fun loadEnvProperties(): Properties {
 val envProperties = loadEnvProperties()
 
 // Read library version mode from libraries-versions.jsonc
-val librariesVersions = JsonSlurper().parseText(
-    rootProject.file("../../libraries-versions.jsonc").readText()
-        .replace(Regex("^\\s*//.*$", RegexOption.MULTILINE), "")
-) as Map<*, *>
-val kmpIapMode = librariesVersions["kmp-iap"]?.toString() ?: "local"
+val kmpIapMode: String = try {
+    val librariesVersions = JsonSlurper().parseText(
+        rootProject.file("../../libraries-versions.jsonc").readText()
+            .replace(Regex("^\\s*//.*$", RegexOption.MULTILINE), "")
+    ) as Map<*, *>
+    librariesVersions["kmp-iap"]?.toString() ?: "local"
+} catch (e: Exception) {
+    // File missing or malformed — default to local dev mode
+    "local"
+}
 val useLocalDev = kmpIapMode == "local"
 
 println("\n========================================")

--- a/libraries/kmp-iap/example/composeApp/build.gradle.kts
+++ b/libraries/kmp-iap/example/composeApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import groovy.json.JsonSlurper
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
@@ -20,6 +21,18 @@ fun loadEnvProperties(): Properties {
 }
 
 val envProperties = loadEnvProperties()
+
+// Read library version mode from libraries-versions.jsonc
+val librariesVersions = JsonSlurper().parseText(
+    rootProject.file("../../libraries-versions.jsonc").readText()
+        .replace(Regex("^\\s*//.*$", RegexOption.MULTILINE), "")
+) as Map<*, *>
+val kmpIapMode = librariesVersions["kmp-iap"]?.toString() ?: "local"
+val useLocalDev = kmpIapMode == "local"
+
+println("\n========================================")
+println("  kmp-iap : ${if (useLocalDev) "LOCAL (monorepo source)" else "PUBLISHED v$kmpIapMode"}")
+println("========================================\n")
 
 plugins {
     alias(libs.plugins.androidApplication)
@@ -82,11 +95,19 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(libs.kotlinx.coroutines.android)
             implementation(compose.preview)
-            implementation(project(":library"))
+            if (useLocalDev) {
+                implementation(project(":library"))
+            } else {
+                implementation("io.github.hyochan:kmp-iap:$kmpIapMode")
+            }
         }
 
         iosMain.dependencies {
-            implementation(project(":library"))
+            if (useLocalDev) {
+                implementation(project(":library"))
+            } else {
+                implementation("io.github.hyochan:kmp-iap:$kmpIapMode")
+            }
         }
 
         desktopMain.dependencies {

--- a/libraries/react-native-iap/example/ios/Podfile
+++ b/libraries/react-native-iap/example/ios/Podfile
@@ -39,13 +39,16 @@ target 'example' do
     :app_path => app_path
   )
 
-  # In monorepo: use local openiap-apple source directly
-  # When publishing, the podspec dependency handles version resolution from CocoaPods/Git
-  openiap_local_path = File.expand_path('../../../../packages/apple', __dir__)
-  if File.directory?(openiap_local_path)
+  # Resolve openiap dependency based on libraries-versions.jsonc
+  libraries_versions_path = File.expand_path('../../../../libraries-versions.jsonc', __dir__)
+  libraries_versions = JSON.parse(File.read(libraries_versions_path).gsub(%r{^\s*//.*$}, ''))
+  rn_iap_mode = libraries_versions['react-native-iap']
+
+  if rn_iap_mode == 'local'
+    openiap_local_path = File.expand_path('../../../../packages/apple', __dir__)
     pod 'openiap', :path => openiap_local_path
   else
-    pod 'openiap', :git => 'https://github.com/hyodotdev/openiap.git', :tag => openiap_apple_version
+    pod 'openiap', openiap_apple_version
   end
 
   post_install do |installer|

--- a/libraries/react-native-iap/example/ios/Podfile
+++ b/libraries/react-native-iap/example/ios/Podfile
@@ -41,8 +41,15 @@ target 'example' do
 
   # Resolve openiap dependency based on libraries-versions.jsonc
   libraries_versions_path = File.expand_path('../../../../libraries-versions.jsonc', __dir__)
-  libraries_versions = JSON.parse(File.read(libraries_versions_path).gsub(%r{^\s*//.*$}, ''))
-  rn_iap_mode = libraries_versions['react-native-iap']
+  rn_iap_mode = 'local'
+  if File.exist?(libraries_versions_path)
+    begin
+      libraries_versions = JSON.parse(File.read(libraries_versions_path).gsub(%r{^\s*//.*$}, ''))
+      rn_iap_mode = libraries_versions['react-native-iap'] || 'local'
+    rescue => e
+      puts "[Podfile] Warning: Failed to parse libraries-versions.jsonc: #{e.message}. Defaulting to local."
+    end
+  end
 
   if rn_iap_mode == 'local'
     openiap_local_path = File.expand_path('../../../../packages/apple', __dir__)

--- a/libraries/react-native-iap/example/metro.config.js
+++ b/libraries/react-native-iap/example/metro.config.js
@@ -5,16 +5,10 @@ const {getDefaultConfig} = require('@react-native/metro-config');
 // Read library version mode from libraries-versions.jsonc
 const parseJsonc = (text) => JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
 let useLocalDev = true;
-try {
-  const librariesVersions = parseJsonc(
-    fs.readFileSync(
-      path.resolve(__dirname, '../../../libraries-versions.jsonc'),
-      'utf8',
-    ),
-  );
+const versionsPath = path.resolve(__dirname, '../../../libraries-versions.jsonc');
+if (fs.existsSync(versionsPath)) {
+  const librariesVersions = parseJsonc(fs.readFileSync(versionsPath, 'utf8'));
   useLocalDev = !librariesVersions['react-native-iap'] || librariesVersions['react-native-iap'] === 'local';
-} catch {
-  // File missing or malformed — default to local dev mode
 }
 
 /**

--- a/libraries/react-native-iap/example/metro.config.js
+++ b/libraries/react-native-iap/example/metro.config.js
@@ -1,7 +1,16 @@
 const path = require('path');
+const fs = require('fs');
 const {getDefaultConfig} = require('@react-native/metro-config');
 
-const root = path.resolve(__dirname, '..');
+// Read library version mode from libraries-versions.jsonc
+const parseJsonc = (text) => JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
+const librariesVersions = parseJsonc(
+  fs.readFileSync(
+    path.resolve(__dirname, '../../../libraries-versions.jsonc'),
+    'utf8',
+  ),
+);
+const useLocalDev = librariesVersions['react-native-iap'] === 'local';
 
 /**
  * Metro configuration
@@ -10,10 +19,15 @@ const root = path.resolve(__dirname, '..');
  * @type {import('metro-config').MetroConfig}
  */
 module.exports = (async () => {
-  const {withMetroConfig} = await import('react-native-monorepo-config');
+  if (useLocalDev) {
+    const root = path.resolve(__dirname, '..');
+    const {withMetroConfig} = await import('react-native-monorepo-config');
 
-  return withMetroConfig(getDefaultConfig(__dirname), {
-    root,
-    dirname: __dirname,
-  });
+    return withMetroConfig(getDefaultConfig(__dirname), {
+      root,
+      dirname: __dirname,
+    });
+  }
+
+  return getDefaultConfig(__dirname);
 })();

--- a/libraries/react-native-iap/example/metro.config.js
+++ b/libraries/react-native-iap/example/metro.config.js
@@ -4,13 +4,18 @@ const {getDefaultConfig} = require('@react-native/metro-config');
 
 // Read library version mode from libraries-versions.jsonc
 const parseJsonc = (text) => JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
-const librariesVersions = parseJsonc(
-  fs.readFileSync(
-    path.resolve(__dirname, '../../../libraries-versions.jsonc'),
-    'utf8',
-  ),
-);
-const useLocalDev = librariesVersions['react-native-iap'] === 'local';
+let useLocalDev = true;
+try {
+  const librariesVersions = parseJsonc(
+    fs.readFileSync(
+      path.resolve(__dirname, '../../../libraries-versions.jsonc'),
+      'utf8',
+    ),
+  );
+  useLocalDev = !librariesVersions['react-native-iap'] || librariesVersions['react-native-iap'] === 'local';
+} catch {
+  // File missing or malformed — default to local dev mode
+}
 
 /**
  * Metro configuration

--- a/libraries/react-native-iap/example/scripts/resolve-deps.js
+++ b/libraries/react-native-iap/example/scripts/resolve-deps.js
@@ -1,0 +1,91 @@
+/**
+ * Reads libraries-versions.jsonc and patches example + root dependencies.
+ * - "local": use yarn workspace + monorepo source (default)
+ * - "<version>": install published npm package, disable workspace
+ *
+ * Run: node scripts/resolve-deps.js
+ */
+const fs = require('fs');
+const path = require('path');
+
+/** Strip // comments from JSONC content */
+const parseJsonc = (text) => JSON.parse(text.replace(/^\s*\/\/.*$/gm, ''));
+
+const VERSIONS_PATH = path.resolve(__dirname, '../../../../libraries-versions.jsonc');
+const EXAMPLE_PKG_PATH = path.resolve(__dirname, '../package.json');
+const ROOT_PKG_PATH = path.resolve(__dirname, '../../package.json');
+const LIB_NAME = 'react-native-iap';
+
+function main() {
+  if (!fs.existsSync(VERSIONS_PATH)) {
+    console.log(`[resolve-deps] No libraries-versions.jsonc found, using local dev.`);
+    return;
+  }
+
+  const versions = parseJsonc(fs.readFileSync(VERSIONS_PATH, 'utf8'));
+  const version = versions[LIB_NAME];
+  const isLocal = !version || version === 'local';
+
+  console.log(`\n========================================`);
+  console.log(`  ${LIB_NAME} : ${isLocal ? 'LOCAL (monorepo source)' : `PUBLISHED v${version}`}`);
+  console.log(`========================================\n`);
+
+  let changed = false;
+
+  const EXAMPLE_LOCKFILE = path.resolve(__dirname, '../yarn.lock');
+
+  if (isLocal) {
+    // 1. Ensure example is in workspace
+    const rootPkg = JSON.parse(fs.readFileSync(ROOT_PKG_PATH, 'utf8'));
+    if (!rootPkg.workspaces?.includes('example')) {
+      rootPkg.workspaces = ['example'];
+      fs.writeFileSync(ROOT_PKG_PATH, JSON.stringify(rootPkg, null, 2) + '\n');
+      changed = true;
+    }
+
+    // 2. Remove published dep from example
+    const pkg = JSON.parse(fs.readFileSync(EXAMPLE_PKG_PATH, 'utf8'));
+    if (pkg.dependencies?.[LIB_NAME]) {
+      delete pkg.dependencies[LIB_NAME];
+      fs.writeFileSync(EXAMPLE_PKG_PATH, JSON.stringify(pkg, null, 2) + '\n');
+      changed = true;
+    }
+
+    // 3. Remove standalone lockfile (rejoin workspace)
+    if (fs.existsSync(EXAMPLE_LOCKFILE)) {
+      fs.unlinkSync(EXAMPLE_LOCKFILE);
+      changed = true;
+    }
+  } else {
+    // 1. Remove example from workspace
+    const rootPkg = JSON.parse(fs.readFileSync(ROOT_PKG_PATH, 'utf8'));
+    if (rootPkg.workspaces?.length > 0) {
+      rootPkg.workspaces = [];
+      fs.writeFileSync(ROOT_PKG_PATH, JSON.stringify(rootPkg, null, 2) + '\n');
+      changed = true;
+    }
+
+    // 2. Add published dep to example
+    const pkg = JSON.parse(fs.readFileSync(EXAMPLE_PKG_PATH, 'utf8'));
+    const currentDep = pkg.dependencies?.[LIB_NAME];
+    if (currentDep !== version) {
+      pkg.dependencies = pkg.dependencies || {};
+      pkg.dependencies[LIB_NAME] = version;
+      fs.writeFileSync(EXAMPLE_PKG_PATH, JSON.stringify(pkg, null, 2) + '\n');
+      changed = true;
+    }
+
+    // 3. Create standalone lockfile so Yarn treats example as independent project
+    if (!fs.existsSync(EXAMPLE_LOCKFILE)) {
+      fs.writeFileSync(EXAMPLE_LOCKFILE, '');
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    console.log(`[resolve-deps] ${LIB_NAME}: ${isLocal ? 'local' : version}`);
+    process.exit(2);
+  }
+}
+
+main();

--- a/libraries/react-native-iap/example/scripts/resolve-deps.js
+++ b/libraries/react-native-iap/example/scripts/resolve-deps.js
@@ -38,7 +38,7 @@ function main() {
     // 1. Ensure example is in workspace
     const rootPkg = JSON.parse(fs.readFileSync(ROOT_PKG_PATH, 'utf8'));
     if (!rootPkg.workspaces?.includes('example')) {
-      rootPkg.workspaces = ['example'];
+      rootPkg.workspaces = [...(rootPkg.workspaces || []), 'example'];
       fs.writeFileSync(ROOT_PKG_PATH, JSON.stringify(rootPkg, null, 2) + '\n');
       changed = true;
     }
@@ -59,8 +59,8 @@ function main() {
   } else {
     // 1. Remove example from workspace
     const rootPkg = JSON.parse(fs.readFileSync(ROOT_PKG_PATH, 'utf8'));
-    if (rootPkg.workspaces?.length > 0) {
-      rootPkg.workspaces = [];
+    if (rootPkg.workspaces?.includes('example')) {
+      rootPkg.workspaces = rootPkg.workspaces.filter((w) => w !== 'example');
       fs.writeFileSync(ROOT_PKG_PATH, JSON.stringify(rootPkg, null, 2) + '\n');
       changed = true;
     }

--- a/libraries/react-native-iap/example/scripts/with-resolve.sh
+++ b/libraries/react-native-iap/example/scripts/with-resolve.sh
@@ -13,10 +13,12 @@ export RN_IAP_DEV_MODE=true
 MODE=$(node -e "
   const fs = require('fs');
   const path = require('path');
-  const f = fs.readFileSync(path.resolve('$ROOT_DIR/../../libraries-versions.jsonc'), 'utf8');
-  const v = JSON.parse(f.replace(/^\s*\/\/.*$/gm, ''));
-  console.log(v['react-native-iap'] || 'local');
-")
+  try {
+    const f = fs.readFileSync(path.resolve('$ROOT_DIR/../../libraries-versions.jsonc'), 'utf8');
+    const v = JSON.parse(f.replace(/^\s*\/\/.*$/gm, ''));
+    console.log(v['react-native-iap'] || 'local');
+  } catch { console.log('local'); }
+" 2>/dev/null || echo "local")
 
 # Run resolve-deps.js — exit code 2 means deps changed
 EXIT_CODE=0

--- a/libraries/react-native-iap/example/scripts/with-resolve.sh
+++ b/libraries/react-native-iap/example/scripts/with-resolve.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Wrapper: resolve deps from libraries-versions.jsonc, install if needed, then run command.
+# Usage: ./scripts/with-resolve.sh <command...>
+
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT_DIR="$(cd "$DIR/.." && pwd)"
+cd "$DIR"
+
+export RN_IAP_DEV_MODE=true
+
+# Read mode from libraries-versions.jsonc
+MODE=$(node -e "
+  const fs = require('fs');
+  const path = require('path');
+  const f = fs.readFileSync(path.resolve('$ROOT_DIR/../../libraries-versions.jsonc'), 'utf8');
+  const v = JSON.parse(f.replace(/^\s*\/\/.*$/gm, ''));
+  console.log(v['react-native-iap'] || 'local');
+")
+
+# Run resolve-deps.js — exit code 2 means deps changed
+EXIT_CODE=0
+node scripts/resolve-deps.js || EXIT_CODE=$?
+if [[ "$EXIT_CODE" -eq 2 ]]; then
+  echo "[with-resolve] Dependencies changed, running install..."
+  if [[ "$MODE" == "local" ]]; then
+    # Workspace mode: install from root
+    cd "$ROOT_DIR" && yarn install && yarn prepare
+    cd "$DIR" && yarn install
+  else
+    # Standalone mode: install inside example only
+    cd "$DIR" && yarn install
+  fi
+  cd "$DIR/ios" && bundle exec pod install && cd "$DIR"
+elif [[ "$EXIT_CODE" -ne 0 ]]; then
+  exit "$EXIT_CODE"
+fi
+
+# Run the actual command
+exec "$@"


### PR DESCRIPTION
## Summary

- Add `libraries-versions.jsonc` config to switch example apps between local source and published packages
- Each library's build system reads this file and auto-resolves dependencies accordingly
- Add `resolve-deps.js` scripts, launch.json improvements, and dark mode text fixes

## Changes

### Core
- `libraries-versions.jsonc` — central config (`"local"` or `"4.0.0-rc.1"` per library)
- `.vscode/launch.json` — add resolve-deps, kill-port 8081, adb uninstall to all configs

### expo-iap
- `app.config.ts` — read JSONC to set `enableLocalDev`
- `metro.config.js` — toggle Metro resolver based on config
- `scripts/resolve-deps.js` — patch `package.json` (add/remove npm dep + autolinking)
- `app/index.tsx` — hardcode text colors for dark mode compatibility

### react-native-iap
- `metro.config.js` — toggle monorepo-config based on config
- `ios/Podfile` — switch openiap pod between local path and CocoaPods version
- `scripts/resolve-deps.js` — patch package.json + workspace + standalone lockfile

### flutter_inapp_purchase
- `ios/Podfile` — switch openiap pod based on config
- `scripts/resolve-deps.js` — patch pubspec.yaml (`path: ../` vs `^version`)

### kmp-iap
- `build.gradle.kts` — read JSONC, switch `project(":library")` vs Maven Central

## How to use

```jsonc
// libraries-versions.jsonc
{
  "expo-iap": "4.0.0-rc.1",        // test published
  "react-native-iap": "local",     // local dev
  "flutter_inapp_purchase": "local",
  "kmp-iap": "local"
}
```

Then run from VSCode launch config — deps resolve automatically.

## Test plan

- [x] expo-iap: local + published (4.0.0-rc.1) iOS/Android verified
- [x] react-native-iap: local + published (15.0.0-rc.0) iOS/Android verified
- [x] flutter_inapp_purchase: published (9.0.0-rc.1) verified
- [x] kmp-iap: local Android verified

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repository-level libraries-versions config plus runtime resolver and wrapper scripts to switch between local and published library sources before launches.

* **Refactor**
  * Made example app build/dependency behavior conditional on the libraries-versions setting across Expo, React Native, Flutter, and KMP.
  * Updated debug launch sequences to run dependency resolution and cleanup steps prior to launching.

* **Style**
  * Updated example app color palette for improved contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->