### PR TITLE
fix(google): guard coroutine continuation with isActive before resume

### DIFF
--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/helpers/Helpers.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/helpers/Helpers.kt
@@ -50,6 +50,8 @@ internal suspend fun queryPurchases(
 
     val params = paramsBuilder.build()
     billingClient.queryPurchasesAsync(params) { result, purchaseList ->
+        if (!continuation.isActive) return@queryPurchasesAsync
+
         if (result.responseCode == BillingClient.BillingResponseCode.OK) {
             val mapped = purchaseList.map { billingPurchase ->
                 // IMPORTANT: Google Play Billing Library does not include basePlanId in the Purchase object

--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/helpers/ProductManager.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/helpers/ProductManager.kt
@@ -3,11 +3,9 @@ package dev.hyo.openiap.helpers
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.ProductDetails
-import dev.hyo.openiap.OpenIapError
 import dev.hyo.openiap.OpenIapLog
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 /**
  * Manages ProductDetails caching and queries.
@@ -91,14 +89,18 @@ internal class ProductManager {
 
         return suspendCancellableCoroutine { cont ->
             client.queryProductDetailsAsync(params) { billingResult, result ->
+                // Always update cache even if coroutine was cancelled
+                if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                    val list = result.productDetailsList ?: emptyList()
+                    putAll(list)
+                }
+
                 if (!cont.isActive) return@queryProductDetailsAsync
 
                 if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
-                    cont.resumeWithException(OpenIapError.QueryProduct)
+                    cont.resume(emptyList())
                     return@queryProductDetailsAsync
                 }
-                val list = result.productDetailsList ?: emptyList()
-                putAll(list)
                 // Preserve requested order and include cached + newly-fetched
                 cont.resume(productIds.mapNotNull { cache[it] })
             }

--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/helpers/ProductManager.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/helpers/ProductManager.kt
@@ -3,9 +3,11 @@ package dev.hyo.openiap.helpers
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.ProductDetails
+import dev.hyo.openiap.OpenIapError
 import dev.hyo.openiap.OpenIapLog
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Manages ProductDetails caching and queries.
@@ -98,7 +100,7 @@ internal class ProductManager {
                 if (!cont.isActive) return@queryProductDetailsAsync
 
                 if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
-                    cont.resume(emptyList())
+                    cont.resumeWithException(OpenIapError.QueryProduct)
                     return@queryProductDetailsAsync
                 }
                 // Preserve requested order and include cached + newly-fetched

--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/helpers/ProductManager.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/helpers/ProductManager.kt
@@ -91,6 +91,8 @@ internal class ProductManager {
 
         return suspendCancellableCoroutine { cont ->
             client.queryProductDetailsAsync(params) { billingResult, result ->
+                if (!cont.isActive) return@queryProductDetailsAsync
+
                 if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
                     cont.resumeWithException(OpenIapError.QueryProduct)
                     return@queryProductDetailsAsync


### PR DESCRIPTION
## Summary

- Add `cont.isActive` guard in `ProductManager.getOrQuery` before resuming the coroutine
- Add `continuation.isActive` guard in `queryPurchases` (Helpers.kt)
- Prevents `IllegalStateException: Already resumed` crash when billing callback arrives after coroutine cancellation

## Context

Production crash reported in #88 — 729 occurrences, 658 users impacted. The crash occurs when `queryProductDetailsAsync` callback tries to resume a coroutine that was already cancelled (e.g., caller lifecycle ends before callback returns).

The Horizon flavor already had `isActive` guards; this brings the Play flavor to parity.

**Note:** This repository handles react-native-iap v15.0.0+ and all OpenIAP monorepo libraries.

Closes #88

## Test plan

- [x] `./gradlew :openiap:compilePlayDebugKotlin` passes
- [ ] Verify crash no longer occurs in production

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling in async purchase and product-detail flows to avoid resuming cancelled operations
  * Ensured product-detail cache is updated on successful billing responses even if the surrounding operation is later cancelled
  * Clarified that failed product queries continue to surface errors rather than returning empty results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->