### PR TITLE
docs: rename notes to releases and add patch release notes

### DIFF
--- a/knowledge/internal/05-docs-patterns.md
+++ b/knowledge/internal/05-docs-patterns.md
@@ -112,7 +112,7 @@ src/components/
 
 ### Location
 
-Release notes are located at `packages/docs/src/pages/docs/updates/notes.tsx`.
+Release notes are located at `packages/docs/src/pages/docs/updates/releases.tsx`.
 
 ### Adding New Release Notes
 

--- a/packages/docs/src/pages/docs/errors.tsx
+++ b/packages/docs/src/pages/docs/errors.tsx
@@ -902,7 +902,7 @@ var product_id: String    # Related product SKU (if applicable)`}</CodeBlock>
             <strong>⚠️ Important:</strong> Static test product IDs like{' '}
             <code>android.test.purchased</code> are <strong>deprecated</strong>{' '}
             and no longer work. Use real product IDs with test accounts instead.{' '}
-            <Link to="/docs/updates/notes">See Updates page for details →</Link>
+            <Link to="/docs/updates/releases">See Releases page for details →</Link>
           </p>
         </div>
 

--- a/packages/docs/src/pages/docs/errors.tsx
+++ b/packages/docs/src/pages/docs/errors.tsx
@@ -902,7 +902,9 @@ var product_id: String    # Related product SKU (if applicable)`}</CodeBlock>
             <strong>⚠️ Important:</strong> Static test product IDs like{' '}
             <code>android.test.purchased</code> are <strong>deprecated</strong>{' '}
             and no longer work. Use real product IDs with test accounts instead.{' '}
-            <Link to="/docs/updates/releases">See Releases page for details →</Link>
+            <Link to="/docs/updates/releases">
+              See Releases page for details →
+            </Link>
           </p>
         </div>
 

--- a/packages/docs/src/pages/docs/index.tsx
+++ b/packages/docs/src/pages/docs/index.tsx
@@ -403,6 +403,10 @@ function Docs() {
             element={<FoundationFoundingSupporters />}
           />
           <Route path="updates/announcements" element={<Announcements />} />
+          <Route
+            path="updates/notes"
+            element={<Navigate to="/docs/updates/releases" replace />}
+          />
           <Route path="updates/releases" element={<Releases />} />
           <Route path="updates/versions" element={<Versions />} />
           <Route path="*" element={<NotFound />} />

--- a/packages/docs/src/pages/docs/index.tsx
+++ b/packages/docs/src/pages/docs/index.tsx
@@ -40,7 +40,7 @@ import GodotSetup from './setup/godot';
 import KmpSetup from './setup/kmp';
 import Example from './example';
 import Announcements from './updates/announcements';
-import Notes from './updates/notes';
+import Releases from './updates/releases';
 import Versions from './updates/versions';
 import AIAssistants from './guides/ai-assistants';
 import Testing from './guides/testing';
@@ -311,11 +311,11 @@ function Docs() {
             </li>
             <li>
               <NavLink
-                to="/docs/updates/notes"
+                to="/docs/updates/releases"
                 className={({ isActive }) => (isActive ? 'active' : '')}
                 onClick={closeSidebar}
               >
-                Notes
+                Releases
               </NavLink>
             </li>
             <li>
@@ -403,7 +403,7 @@ function Docs() {
             element={<FoundationFoundingSupporters />}
           />
           <Route path="updates/announcements" element={<Announcements />} />
-          <Route path="updates/notes" element={<Notes />} />
+          <Route path="updates/releases" element={<Releases />} />
           <Route path="updates/versions" element={<Versions />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/packages/docs/src/pages/docs/types/purchase.tsx
+++ b/packages/docs/src/pages/docs/types/purchase.tsx
@@ -107,7 +107,7 @@ function TypesPurchase() {
           Note: iOS StoreKit 2 only returns <code>Transaction</code> objects on
           successful purchases, so iOS purchases always have{' '}
           <code>Purchased</code> state. See{' '}
-          <a href="/docs/updates/notes#gql-1-3-11-google-1-3-20">
+          <a href="/docs/updates/releases#gql-1-3-11-google-1-3-20">
             release notes
           </a>{' '}
           for details.

--- a/packages/docs/src/pages/docs/types/purchase.tsx
+++ b/packages/docs/src/pages/docs/types/purchase.tsx
@@ -107,7 +107,7 @@ function TypesPurchase() {
           Note: iOS StoreKit 2 only returns <code>Transaction</code> objects on
           successful purchases, so iOS purchases always have{' '}
           <code>Purchased</code> state. See{' '}
-          <a href="/docs/updates/releases#gql-1-3-11-google-1-3-20">
+          <a href="/docs/updates/releases#gql-1-3-11-google-1-3-21-apple-1-3-9">
             release notes
           </a>{' '}
           for details.

--- a/packages/docs/src/pages/docs/updates/releases.tsx
+++ b/packages/docs/src/pages/docs/updates/releases.tsx
@@ -19,10 +19,95 @@ interface Note {
   element: React.ReactNode;
 }
 
-function Notes() {
+function Releases() {
   useScrollToHash();
 
   const allNotes: Note[] = [
+    // Monorepo patch releases - Apr 13, 2026
+    {
+      id: 'monorepo-2026-04-13',
+      date: new Date('2026-04-13'),
+      element: (
+        <div key="monorepo-2026-04-13" style={noteCardStyle}>
+          <AnchorLink id="monorepo-2026-04-13" level="h4">
+            Monorepo Patch Releases - April 13, 2026
+          </AnchorLink>
+
+          <p
+            style={{
+              marginTop: '0.75rem',
+              marginBottom: '1.5rem',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            First patch releases from the OpenIAP monorepo. Includes a critical
+            Android crash fix and godot-iap initialization guard.
+          </p>
+
+          <div style={{ marginBottom: '1.25rem' }}>
+            <h5 style={{ margin: '0 0 0.5rem 0' }}>
+              openiap-google 1.3.30
+            </h5>
+            <ul style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.9rem' }}>
+              <li>
+                <strong>Fix: Android crash in ProductManager.getOrQuery</strong> —
+                Guard coroutine continuation with <code>isActive</code> before
+                resume to prevent <code>IllegalStateException: Already resumed</code>{' '}
+                when the billing callback arrives after coroutine cancellation.
+                (<a href="https://github.com/hyodotdev/openiap/issues/88">#88</a>)
+              </li>
+              <li>
+                Cache is now updated before the <code>isActive</code> check so
+                cancelled queries still warm the ProductDetails cache, preventing
+                redundant network requests.
+              </li>
+              <li>
+                Same guard added to <code>queryPurchases</code> in Helpers.kt.
+              </li>
+            </ul>
+          </div>
+
+          <div style={{ marginBottom: '1.25rem' }}>
+            <h5 style={{ margin: '0 0 0.5rem 0' }}>
+              godot-iap 2.0.1
+            </h5>
+            <ul style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.9rem' }}>
+              <li>
+                <strong>Fix: Double initialization guard</strong> — Added{' '}
+                <code>static var _is_initialized</code> in <code>_ready()</code> to
+                prevent duplicate native plugin initialization when the plugin is
+                both enabled in ProjectSettings and attached as an AutoLoad node.
+                (<a href="https://github.com/hyochan/godot-iap/issues/24">hyochan/godot-iap#24</a>)
+              </li>
+            </ul>
+          </div>
+
+          <div style={{ marginBottom: '0.5rem' }}>
+            <h5 style={{ margin: '0 0 0.5rem 0' }}>
+              Framework Library Patches
+            </h5>
+            <p
+              style={{
+                margin: '0.25rem 0',
+                fontSize: '0.9rem',
+                color: 'var(--text-secondary)',
+              }}
+            >
+              All framework libraries receive a patch release to pick up the
+              openiap-google 1.3.30 fix:
+            </p>
+            <ul style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.9rem' }}>
+              <li>react-native-iap — patch</li>
+              <li>expo-iap — patch</li>
+              <li>flutter_inapp_purchase — patch</li>
+              <li>kmp-iap — patch</li>
+              <li>godot-iap 2.0.1 (includes init guard fix above)</li>
+            </ul>
+          </div>
+        </div>
+      ),
+    },
+
     // Apple 1.3.15 - Feb 12, 2026
     {
       id: 'apple-1-3-15',
@@ -2161,13 +2246,13 @@ result.error                  // optional error`}</CodeBlock>
   return (
     <div className="doc-page">
       <SEO
-        title="Notes"
-        description="Important changes and deprecations in IAP libraries and platforms - API changes, breaking changes, validateReceipt to verifyPurchase migration, and guides."
-        path="/docs/updates/notes"
+        title="Releases"
+        description="Release notes for OpenIAP packages and framework libraries - new features, bug fixes, and breaking changes."
+        path="/docs/updates/releases"
         keywords="IAP updates, validateReceipt, verifyPurchase, receipt validation, purchase verification, migration guide"
       />
-      <h1>Notes</h1>
-      <p>Important changes and deprecations in IAP libraries and platforms.</p>
+      <h1>Releases</h1>
+      <p>Release notes for OpenIAP packages and framework libraries.</p>
 
       <Pagination itemsPerPage={itemsPerPage} initialPage={initialPage}>
         {sortedNotes.map((note) => (
@@ -2178,4 +2263,4 @@ result.error                  // optional error`}</CodeBlock>
   );
 }
 
-export default Notes;
+export default Releases;

--- a/packages/docs/src/pages/docs/updates/releases.tsx
+++ b/packages/docs/src/pages/docs/updates/releases.tsx
@@ -105,11 +105,52 @@ function Releases() {
             <ul
               style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.9rem' }}
             >
-              <li>react-native-iap v15.0.1</li>
-              <li>expo-iap v4.0.1</li>
-              <li>flutter_inapp_purchase v9.0.1</li>
-              <li>kmp-iap v2.0.1</li>
-              <li>godot-iap v2.0.1 (includes init guard fix above)</li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/react-native-iap-15.0.1"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  react-native-iap v15.0.1
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/expo-iap-4.0.1"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  expo-iap v4.0.1
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.0.1"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  flutter_inapp_purchase v9.0.1
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/kmp-iap-2.0.1"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  kmp-iap v2.0.1
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/godot-iap-2.0.1"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  godot-iap v2.0.1
+                </a>{' '}
+                (includes init guard fix above)
+              </li>
             </ul>
           </div>
         </div>

--- a/packages/docs/src/pages/docs/updates/releases.tsx
+++ b/packages/docs/src/pages/docs/updates/releases.tsx
@@ -105,11 +105,11 @@ function Releases() {
             <ul
               style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.9rem' }}
             >
-              <li>react-native-iap — patch</li>
-              <li>expo-iap — patch</li>
-              <li>flutter_inapp_purchase — patch</li>
-              <li>kmp-iap — patch</li>
-              <li>godot-iap 2.0.1 (includes init guard fix above)</li>
+              <li>react-native-iap v15.0.1</li>
+              <li>expo-iap v4.0.1</li>
+              <li>flutter_inapp_purchase v9.0.1</li>
+              <li>kmp-iap v2.0.1</li>
+              <li>godot-iap v2.0.1 (includes init guard fix above)</li>
             </ul>
           </div>
         </div>

--- a/packages/docs/src/pages/docs/updates/releases.tsx
+++ b/packages/docs/src/pages/docs/updates/releases.tsx
@@ -45,21 +45,23 @@ function Releases() {
           </p>
 
           <div style={{ marginBottom: '1.25rem' }}>
-            <h5 style={{ margin: '0 0 0.5rem 0' }}>
-              openiap-google 1.3.30
-            </h5>
-            <ul style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.9rem' }}>
+            <h5 style={{ margin: '0 0 0.5rem 0' }}>openiap-google 1.3.30</h5>
+            <ul
+              style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.9rem' }}
+            >
               <li>
-                <strong>Fix: Android crash in ProductManager.getOrQuery</strong> —
-                Guard coroutine continuation with <code>isActive</code> before
-                resume to prevent <code>IllegalStateException: Already resumed</code>{' '}
-                when the billing callback arrives after coroutine cancellation.
-                (<a href="https://github.com/hyodotdev/openiap/issues/88">#88</a>)
+                <strong>Fix: Android crash in ProductManager.getOrQuery</strong>{' '}
+                — Guard coroutine continuation with <code>isActive</code> before
+                resume to prevent{' '}
+                <code>IllegalStateException: Already resumed</code> when the
+                billing callback arrives after coroutine cancellation. (
+                <a href="https://github.com/hyodotdev/openiap/issues/88">#88</a>
+                )
               </li>
               <li>
                 Cache is now updated before the <code>isActive</code> check so
-                cancelled queries still warm the ProductDetails cache, preventing
-                redundant network requests.
+                cancelled queries still warm the ProductDetails cache,
+                preventing redundant network requests.
               </li>
               <li>
                 Same guard added to <code>queryPurchases</code> in Helpers.kt.
@@ -68,16 +70,20 @@ function Releases() {
           </div>
 
           <div style={{ marginBottom: '1.25rem' }}>
-            <h5 style={{ margin: '0 0 0.5rem 0' }}>
-              godot-iap 2.0.1
-            </h5>
-            <ul style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.9rem' }}>
+            <h5 style={{ margin: '0 0 0.5rem 0' }}>godot-iap 2.0.1</h5>
+            <ul
+              style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.9rem' }}
+            >
               <li>
                 <strong>Fix: Double initialization guard</strong> — Added{' '}
-                <code>static var _is_initialized</code> in <code>_ready()</code> to
-                prevent duplicate native plugin initialization when the plugin is
-                both enabled in ProjectSettings and attached as an AutoLoad node.
-                (<a href="https://github.com/hyochan/godot-iap/issues/24">hyochan/godot-iap#24</a>)
+                <code>static var _is_initialized</code> in <code>_ready()</code>{' '}
+                to prevent duplicate native plugin initialization when the
+                plugin is both enabled in ProjectSettings and attached as an
+                AutoLoad node. (
+                <a href="https://github.com/hyochan/godot-iap/issues/24">
+                  hyochan/godot-iap#24
+                </a>
+                )
               </li>
             </ul>
           </div>
@@ -96,7 +102,9 @@ function Releases() {
               All framework libraries receive a patch release to pick up the
               openiap-google 1.3.30 fix:
             </p>
-            <ul style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.9rem' }}>
+            <ul
+              style={{ margin: 0, paddingLeft: '1.25rem', fontSize: '0.9rem' }}
+            >
               <li>react-native-iap — patch</li>
               <li>expo-iap — patch</li>
               <li>flutter_inapp_purchase — patch</li>


### PR DESCRIPTION
## Summary

- Rename `updates/notes` → `updates/releases` (page, route, sidebar, all references)
- Add first monorepo patch release notes:
  - **openiap-google 1.3.30** — coroutine `isActive` guard to fix `IllegalStateException` crash (#88)
  - **godot-iap 2.0.1** — static initialization guard to prevent double plugin init
  - **Framework patches** — react-native-iap, expo-iap, flutter_inapp_purchase, kmp-iap, godot-iap

## Test plan

- [x] `bun run typecheck` passes
- [x] Verify `/docs/updates/releases` renders correctly
- [x] Verify old `/docs/updates/notes` links redirect or 404 gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed the Updates page from “Notes” to “Releases” and updated site navigation and cross-references to the new Releases route.
  * Added a new April 13, 2026 patch release entry, detailing Android crash fixes and initialization guards across multiple packages.
  * Reformatted link markup and updated inline references to point to the Releases page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->