### PR TITLE
Fix incorrect Android replacement mode

### DIFF
--- a/libraries/flutter_inapp_purchase/lib/enums.dart
+++ b/libraries/flutter_inapp_purchase/lib/enums.dart
@@ -167,9 +167,9 @@ extension AndroidReplacementModeValue on AndroidReplacementMode {
         return 2;
       case AndroidReplacementMode.withoutProration:
         return 3;
-      case AndroidReplacementMode.deferred:
-        return 4;
       case AndroidReplacementMode.chargeFullPrice:
+        return 4;
+      case AndroidReplacementMode.deferred:
         return 5;
     }
   }


### PR DESCRIPTION
fix #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected enum value mappings for Android in-app purchase replacement modes to ensure accurate handling of purchase replacement operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->