### PR TITLE
fix(google): prevent double-resume crash in purchase flow

### DIFF
--- a/.claude/commands/resolve-issue.md
+++ b/.claude/commands/resolve-issue.md
@@ -130,6 +130,18 @@ EOF
 )"
 ```
 
+#### 4e. Add labels to the PR
+
+Mirror the same labels you applied to the issue onto the PR so the dashboard views stay consistent. Use the same label selection guide from Step 2.
+
+> **Note:** `gh pr edit --add-label` may fail with a `Projects (classic)` GraphQL error on this repo. Use the REST API directly instead (works reliably since PRs are issues on GitHub):
+
+```bash
+gh api -X POST repos/hyodotdev/openiap/issues/<PR_NUMBER>/labels \
+  -f "labels[]=<label1>" \
+  -f "labels[]=<label2>"
+```
+
 ### 5. Comment on the Issue
 
 Always comment on the issue with your findings:

--- a/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
@@ -383,7 +383,11 @@ class OpenIapModule(
                 val callback: (Result<List<Purchase>>) -> Unit = { result ->
                     if (continuation.isActive) continuation.resume(result.getOrDefault(emptyList()))
                 }
-                currentPurchaseCallback.set(callback)
+                if (!currentPurchaseCallback.compareAndSet(null, callback)) {
+                    OpenIapLog.w("requestPurchase rejected: another purchase is already in progress", TAG)
+                    if (continuation.isActive) continuation.resumeWithException(OpenIapError.DeveloperError)
+                    return@suspendCancellableCoroutine
+                }
                 continuation.invokeOnCancellation { currentPurchaseCallback.compareAndSet(callback, null) }
 
                 val desiredType = if (androidArgs.type == ProductQueryType.Subs) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
@@ -868,8 +872,8 @@ class OpenIapModule(
                 }
 
                 OpenIapLog.d("Invoking currentPurchaseCallback with ${mapped.size} purchases (single-shot)", TAG)
-                    consumePurchaseCallback(Result.success(mapped))
-                    OpenIapLog.i("Purchase callback invoked", TAG)
+                consumePurchaseCallback(Result.success(mapped))
+                OpenIapLog.i("Purchase callback invoked", TAG)
                 } else {
                     // Purchases is null - likely DEFERRED mode
                     OpenIapLog.d("Purchase successful but purchases list is null (DEFERRED mode)", TAG)
@@ -881,7 +885,6 @@ class OpenIapModule(
                 purchaseErrorListeners.forEach { listener -> runCatching { listener.onPurchaseError(error) } }
                 consumePurchaseCallback(Result.success(emptyList()))
             }
-            currentPurchaseCallback.set(null)
             OpenIapLog.i("=== END onPurchasesUpdated ===", TAG)
         } catch (e: Exception) {
             OpenIapLog.e("Exception in onPurchasesUpdated", e, TAG)

--- a/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -97,7 +98,16 @@ class OpenIapModule(
 
     private var billingClient: BillingClient? = null
     private var currentActivityRef: WeakReference<Activity>? = null
-    private var currentPurchaseCallback: ((Result<List<Purchase>>) -> Unit)? = null
+    private val currentPurchaseCallback = AtomicReference<((Result<List<Purchase>>) -> Unit)?>(null)
+
+    /**
+     * Atomically consume the pending purchase callback so the underlying
+     * continuation cannot be resumed twice if Horizon Billing fires
+     * `onPurchasesUpdated` multiple times or races with an early-return path.
+     */
+    private fun consumePurchaseCallback(result: Result<List<Purchase>>) {
+        currentPurchaseCallback.getAndSet(null)?.invoke(result)
+    }
     private val productManager = ProductManager()
     private val fallbackActivity: Activity? = if (context is Activity) context else null
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -370,9 +380,10 @@ class OpenIapModule(
             }
 
             suspendCancellableCoroutine<List<Purchase>> { continuation ->
-                currentPurchaseCallback = { result ->
+                currentPurchaseCallback.set { result ->
                     if (continuation.isActive) continuation.resume(result.getOrDefault(emptyList()))
                 }
+                continuation.invokeOnCancellation { currentPurchaseCallback.set(null) }
 
                 val desiredType = if (androidArgs.type == ProductQueryType.Subs) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
 
@@ -421,7 +432,7 @@ class OpenIapModule(
                                 OpenIapLog.w("Invalid offer token: $resolved not in $availableTokens", TAG)
                                 val err = OpenIapError.SkuOfferMismatch
                                 purchaseErrorListeners.forEach { listener -> runCatching { listener.onPurchaseError(err) } }
-                                currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                                consumePurchaseCallback(Result.success(emptyList()))
                                 return
                             }
 
@@ -437,7 +448,7 @@ class OpenIapModule(
                                 OpenIapLog.w("Invalid empty offerToken provided for ${productDetails.productId}", TAG)
                                 val err = OpenIapError.SkuOfferMismatch
                                 for (listener in purchaseErrorListeners) { runCatching { listener.onPurchaseError(err) } }
-                                currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                                consumePurchaseCallback(Result.success(emptyList()))
                                 return
                             }
 
@@ -502,7 +513,7 @@ class OpenIapModule(
                                 else -> OpenIapError.PurchaseFailed
                             }
                             purchaseErrorListeners.forEach { listener -> runCatching { listener.onPurchaseError(err) } }
-                            currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                            consumePurchaseCallback(Result.success(emptyList()))
                         } else {
                             // CRITICAL FIX: Proactively query purchases in case onPurchasesUpdated doesn't fire
                             // Horizon SDK may not always trigger the callback, so we query after a delay
@@ -524,7 +535,7 @@ class OpenIapModule(
                                                 runCatching { listener.onPurchaseUpdated(purchase) }
                                             }
                                         }
-                                        currentPurchaseCallback?.invoke(Result.success(filtered))
+                                        consumePurchaseCallback(Result.success(filtered))
                                     }
                                 } catch (e: Exception) {
                                     OpenIapLog.e("Error in proactive purchase query", e, TAG)
@@ -540,7 +551,7 @@ class OpenIapModule(
                         val missingSku = androidArgs.skus.firstOrNull { !detailsBySku.containsKey(it) }
                         val err = OpenIapError.SkuNotFound(missingSku ?: "")
                         purchaseErrorListeners.forEach { listener -> runCatching { listener.onPurchaseError(err) } }
-                        currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                        consumePurchaseCallback(Result.success(emptyList()))
                         return@suspendCancellableCoroutine
                     }
                     buildAndLaunch(ordered)
@@ -560,7 +571,7 @@ class OpenIapModule(
                         if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
                             val err = OpenIapError.QueryProduct
                             purchaseErrorListeners.forEach { listener -> runCatching { listener.onPurchaseError(err) } }
-                            currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                            consumePurchaseCallback(Result.success(emptyList()))
                             return@queryProductDetailsAsync
                         }
 
@@ -578,7 +589,7 @@ class OpenIapModule(
                             }
                             val err = OpenIapError.SkuNotFound(missingSku ?: "")
                             purchaseErrorListeners.forEach { listener -> runCatching { listener.onPurchaseError(err) } }
-                            currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                            consumePurchaseCallback(Result.success(emptyList()))
                             return@queryProductDetailsAsync
                         }
 
@@ -856,26 +867,20 @@ class OpenIapModule(
                 }
 
                 OpenIapLog.d("Invoking currentPurchaseCallback with ${mapped.size} purchases (single-shot)", TAG)
-                    currentPurchaseCallback?.let { cb ->
-                        currentPurchaseCallback = null
-                        cb.invoke(Result.success(mapped))
-                    }
+                    consumePurchaseCallback(Result.success(mapped))
                     OpenIapLog.i("Purchase callback invoked", TAG)
                 } else {
                     // Purchases is null - likely DEFERRED mode
                     OpenIapLog.d("Purchase successful but purchases list is null (DEFERRED mode)", TAG)
-                    currentPurchaseCallback?.let { cb ->
-                        currentPurchaseCallback = null
-                        cb.invoke(Result.success(emptyList()))
-                    }
+                    consumePurchaseCallback(Result.success(emptyList()))
                 }
             } else {
                 OpenIapLog.w("Purchase failed or cancelled: code=${result.responseCode}", TAG)
                 val error = OpenIapError.fromBillingResponseCode(result.responseCode, result.debugMessage)
                 purchaseErrorListeners.forEach { listener -> runCatching { listener.onPurchaseError(error) } }
-                currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                consumePurchaseCallback(Result.success(emptyList()))
             }
-            currentPurchaseCallback = null
+            currentPurchaseCallback.set(null)
             OpenIapLog.i("=== END onPurchasesUpdated ===", TAG)
         } catch (e: Exception) {
             OpenIapLog.e("Exception in onPurchasesUpdated", e, TAG)

--- a/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
@@ -380,10 +380,11 @@ class OpenIapModule(
             }
 
             suspendCancellableCoroutine<List<Purchase>> { continuation ->
-                currentPurchaseCallback.set { result ->
+                val callback: (Result<List<Purchase>>) -> Unit = { result ->
                     if (continuation.isActive) continuation.resume(result.getOrDefault(emptyList()))
                 }
-                continuation.invokeOnCancellation { currentPurchaseCallback.set(null) }
+                currentPurchaseCallback.set(callback)
+                continuation.invokeOnCancellation { currentPurchaseCallback.compareAndSet(callback, null) }
 
                 val desiredType = if (androidArgs.type == ProductQueryType.Subs) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
 

--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/OpenIapModule.kt
@@ -860,10 +860,11 @@ class OpenIapModule(
             }
 
             suspendCancellableCoroutine<List<Purchase>> { continuation ->
-                currentPurchaseCallback.set { result ->
+                val callback: (Result<List<Purchase>>) -> Unit = { result ->
                     if (continuation.isActive) continuation.resume(result.getOrDefault(emptyList()))
                 }
-                continuation.invokeOnCancellation { currentPurchaseCallback.set(null) }
+                currentPurchaseCallback.set(callback)
+                continuation.invokeOnCancellation { currentPurchaseCallback.compareAndSet(callback, null) }
 
                 val desiredType = if (androidArgs.type == ProductQueryType.Subs) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
 

--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/OpenIapModule.kt
@@ -71,6 +71,7 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicReference
 
 // AlternativeBillingMode moved to main source set (shared between Play and Horizon)
 
@@ -109,7 +110,16 @@ class OpenIapModule(
     private val purchaseErrorListeners = mutableSetOf<OpenIapPurchaseErrorListener>()
     private val userChoiceBillingListeners = mutableSetOf<OpenIapUserChoiceBillingListener>()
     private val developerProvidedBillingListeners = mutableSetOf<OpenIapDeveloperProvidedBillingListener>()
-    private var currentPurchaseCallback: ((Result<List<Purchase>>) -> Unit)? = null
+    private val currentPurchaseCallback = AtomicReference<((Result<List<Purchase>>) -> Unit)?>(null)
+
+    /**
+     * Atomically consume the pending purchase callback. Ensures the underlying
+     * continuation is resumed at most once even if Google Play Billing fires
+     * `onPurchasesUpdated` multiple times or races with an early-return path.
+     */
+    private fun consumePurchaseCallback(result: Result<List<Purchase>>) {
+        currentPurchaseCallback.getAndSet(null)?.invoke(result)
+    }
 
     // Billing programs enabled via enableBillingProgram (8.2.0+, EXTERNAL_PAYMENTS in 8.3.0+)
     private val enabledBillingPrograms = mutableSetOf<BillingProgramAndroid>()
@@ -850,9 +860,10 @@ class OpenIapModule(
             }
 
             suspendCancellableCoroutine<List<Purchase>> { continuation ->
-                currentPurchaseCallback = { result ->
+                currentPurchaseCallback.set { result ->
                     if (continuation.isActive) continuation.resume(result.getOrDefault(emptyList()))
                 }
+                continuation.invokeOnCancellation { currentPurchaseCallback.set(null) }
 
                 val desiredType = if (androidArgs.type == ProductQueryType.Subs) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
 
@@ -878,7 +889,7 @@ class OpenIapModule(
                         )
                         val err = OpenIapError.SkuOfferMismatch
                         for (listener in purchaseErrorListeners) { runCatching { listener.onPurchaseError(err) } }
-                        currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                        consumePurchaseCallback(Result.success(emptyList()))
                         return
                     }
 
@@ -915,7 +926,7 @@ class OpenIapModule(
                                 OpenIapLog.w("Invalid offer token: $resolved not in $availableTokens", TAG)
                                 val err = OpenIapError.SkuOfferMismatch
                                 for (listener in purchaseErrorListeners) { runCatching { listener.onPurchaseError(err) } }
-                                currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                                consumePurchaseCallback(Result.success(emptyList()))
                                 return
                             }
 
@@ -942,7 +953,7 @@ class OpenIapModule(
                                 OpenIapLog.w("No one-time purchase offers available for ${productDetails.productId}, but offerToken was provided: ${androidArgs.offerToken}", TAG)
                                 val err = OpenIapError.SkuOfferMismatch
                                 for (listener in purchaseErrorListeners) { runCatching { listener.onPurchaseError(err) } }
-                                currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                                consumePurchaseCallback(Result.success(emptyList()))
                                 return
                             }
 
@@ -950,7 +961,7 @@ class OpenIapModule(
                                 OpenIapLog.w("Invalid one-time offer token: ${androidArgs.offerToken} not in $availableTokens", TAG)
                                 val err = OpenIapError.SkuOfferMismatch
                                 for (listener in purchaseErrorListeners) { runCatching { listener.onPurchaseError(err) } }
-                                currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                                consumePurchaseCallback(Result.success(emptyList()))
                                 return
                             }
 
@@ -1034,7 +1045,7 @@ class OpenIapModule(
                             else -> OpenIapError.PurchaseFailed
                         }
                         for (listener in purchaseErrorListeners) { runCatching { listener.onPurchaseError(err) } }
-                        currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                        consumePurchaseCallback(Result.success(emptyList()))
                     }
                 }
 
@@ -1044,7 +1055,7 @@ class OpenIapModule(
                         val missingSku = androidArgs.skus.firstOrNull { !detailsBySku.containsKey(it) }
                         val err = OpenIapError.SkuNotFound(missingSku ?: "")
                         for (listener in purchaseErrorListeners) { runCatching { listener.onPurchaseError(err) } }
-                        currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                        consumePurchaseCallback(Result.success(emptyList()))
                         return@suspendCancellableCoroutine
                     }
                     buildAndLaunch(ordered)
@@ -1070,14 +1081,14 @@ class OpenIapModule(
                                 val missingSku = androidArgs.skus.firstOrNull { !detailsBySku.containsKey(it) }
                                 val err = OpenIapError.SkuNotFound(missingSku ?: "")
                                 for (listener in purchaseErrorListeners) { runCatching { listener.onPurchaseError(err) } }
-                                currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                                consumePurchaseCallback(Result.success(emptyList()))
                                 return@queryProductDetailsAsync
                             }
                             buildAndLaunch(ordered)
                         } else {
                             val err = OpenIapError.QueryProduct
                             for (listener in purchaseErrorListeners) { runCatching { listener.onPurchaseError(err) } }
-                            currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                            consumePurchaseCallback(Result.success(emptyList()))
                         }
                     }
                 }
@@ -1334,18 +1345,18 @@ class OpenIapModule(
                         runCatching { listener.onPurchaseUpdated(converted) }
                     }
                 }
-                currentPurchaseCallback?.invoke(Result.success(mapped))
+                consumePurchaseCallback(Result.success(mapped))
             } else {
                 // Purchases is null - likely DEFERRED mode
                 OpenIapLog.d("Purchase successful but purchases list is null (DEFERRED mode)", TAG)
-                currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                consumePurchaseCallback(Result.success(emptyList()))
             }
         } else {
             when (billingResult.responseCode) {
                 BillingClient.BillingResponseCode.USER_CANCELED -> {
                     val err = OpenIapError.UserCancelled
                     for (listener in purchaseErrorListeners) { runCatching { listener.onPurchaseError(err) } }
-                    currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                    consumePurchaseCallback(Result.success(emptyList()))
                 }
                 else -> {
                     val error = OpenIapError.fromBillingResponseCode(
@@ -1354,11 +1365,11 @@ class OpenIapModule(
                     )
                     OpenIapLog.w("Purchase failed: code=${billingResult.responseCode} msg=${error.message}", TAG)
                     for (listener in purchaseErrorListeners) { runCatching { listener.onPurchaseError(error) } }
-                    currentPurchaseCallback?.invoke(Result.success(emptyList()))
+                    consumePurchaseCallback(Result.success(emptyList()))
                 }
             }
         }
-        currentPurchaseCallback = null
+        currentPurchaseCallback.set(null)
     }
 
     private fun buildBillingClient() {

--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/OpenIapModule.kt
@@ -863,7 +863,11 @@ class OpenIapModule(
                 val callback: (Result<List<Purchase>>) -> Unit = { result ->
                     if (continuation.isActive) continuation.resume(result.getOrDefault(emptyList()))
                 }
-                currentPurchaseCallback.set(callback)
+                if (!currentPurchaseCallback.compareAndSet(null, callback)) {
+                    OpenIapLog.w("requestPurchase rejected: another purchase is already in progress", TAG)
+                    if (continuation.isActive) continuation.resumeWithException(OpenIapError.DeveloperError)
+                    return@suspendCancellableCoroutine
+                }
                 continuation.invokeOnCancellation { currentPurchaseCallback.compareAndSet(callback, null) }
 
                 val desiredType = if (androidArgs.type == ProductQueryType.Subs) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
@@ -1370,7 +1374,6 @@ class OpenIapModule(
                 }
             }
         }
-        currentPurchaseCallback.set(null)
     }
 
     private fun buildBillingClient() {


### PR DESCRIPTION
## Summary

- Replace the mutable `currentPurchaseCallback` var in both Play and Horizon `OpenIapModule` with an `AtomicReference`, and route every invocation through a new `consumePurchaseCallback()` helper that atomically swaps the slot to `null` before invoking — guaranteeing the underlying `suspendCancellableCoroutine` continuation can be resumed at most once.
- Clear the callback slot on continuation cancellation so a late billing event can't resume a cancelled coroutine.

Closes #94

## Root cause

`requestPurchase` stored the resume lambda in a shared mutable field and only nulled it out at the end of `onPurchasesUpdated`. Between the invocation and the clear:

- `onPurchasesUpdated` could fire again (Play Billing is known to deliver duplicate updates), or
- a re-entrant / racing callback could observe the still-set lambda and call it a second time, or
- an early-return path inside `requestPurchase` could invoke the callback without nulling the slot, leaving it primed for a stale event later.

The lambda's `if (continuation.isActive)` guard is not atomic with `resume()`, so two callers could both pass the check and both call `resume()` — producing the observed `IllegalStateException: Already resumed`. Making the slot single-shot via `AtomicReference.getAndSet(null)` eliminates the window entirely.

## Test plan

- [x] `./gradlew :openiap:compilePlayDebugKotlin :openiap:compileHorizonDebugKotlin` passes
- [ ] Verify a normal purchase flow still resolves (manual smoke on a debug build)
- [ ] Verify rapid double-tap of `requestPurchase` no longer crashes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal robustness of purchase callback handling for more reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->