### PR TITLE
fix(flutter): forward subscriptionProductReplacementParams on Android

### DIFF
--- a/libraries/flutter_inapp_purchase/lib/flutter_inapp_purchase.dart
+++ b/libraries/flutter_inapp_purchase/lib/flutter_inapp_purchase.dart
@@ -386,6 +386,8 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
                 subscriptionOffers;
             final gentype.DeveloperBillingOptionParamsAndroid?
                 developerBillingOption;
+            final gentype.SubscriptionProductReplacementParamsAndroid?
+                subscriptionProductReplacementParams;
 
             if (androidProps is gentype.RequestPurchaseAndroidProps) {
               skus = androidProps.skus;
@@ -397,6 +399,7 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
               offerToken = androidProps.offerToken;
               subscriptionOffers = null;
               developerBillingOption = androidProps.developerBillingOption;
+              subscriptionProductReplacementParams = null;
             } else if (androidProps
                 is gentype.RequestSubscriptionAndroidProps) {
               skus = androidProps.skus;
@@ -408,6 +411,8 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
               offerToken = null; // Subscriptions don't use offerToken
               subscriptionOffers = androidProps.subscriptionOffers;
               developerBillingOption = androidProps.developerBillingOption;
+              subscriptionProductReplacementParams =
+                  androidProps.subscriptionProductReplacementParams;
             } else {
               throw PurchaseError(
                 code: gentype.ErrorCode.DeveloperError,
@@ -466,6 +471,13 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             if (developerBillingOption != null) {
               payload['developerBillingOption'] =
                   developerBillingOption.toJson();
+            }
+
+            // Add subscriptionProductReplacementParams for item-level
+            // replacement (Billing Library 8.1.0+)
+            if (subscriptionProductReplacementParams != null) {
+              payload['subscriptionProductReplacementParams'] =
+                  subscriptionProductReplacementParams.toJson();
             }
 
             await _channel.invokeMethod('requestPurchase', payload);

--- a/libraries/flutter_inapp_purchase/test/flutter_inapp_purchase_channel_test.dart
+++ b/libraries/flutter_inapp_purchase/test/flutter_inapp_purchase_channel_test.dart
@@ -659,6 +659,62 @@ void main() {
     });
 
     test(
+      'forwards subscriptionProductReplacementParams on Android subscription',
+      () async {
+        final calls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (MethodCall call) async {
+          calls.add(call);
+          switch (call.method) {
+            case 'initConnection':
+              return true;
+            case 'requestPurchase':
+              return null;
+          }
+          return null;
+        });
+
+        final iap = FlutterInappPurchase.private(
+          FakePlatform(operatingSystem: 'android'),
+        );
+
+        await iap.initConnection();
+
+        const props = types.RequestPurchaseProps.subs((
+          apple: null,
+          google: types.RequestSubscriptionAndroidProps(
+            skus: <String>['sub.premium'],
+            subscriptionProductReplacementParams:
+                types.SubscriptionProductReplacementParamsAndroid(
+              oldProductId: 'sub.premium',
+              replacementMode:
+                  types.SubscriptionReplacementModeAndroid.ChargeFullPrice,
+            ),
+          ),
+          useAlternativeBilling: null,
+        ));
+
+        await iap.requestPurchase(props);
+
+        final requestCall = calls.singleWhere(
+          (MethodCall c) => c.method == 'requestPurchase',
+        );
+        final payload = Map<String, dynamic>.from(
+          requestCall.arguments as Map<dynamic, dynamic>,
+        );
+
+        expect(payload.containsKey('subscriptionProductReplacementParams'),
+            isTrue);
+        final replacement = Map<String, dynamic>.from(
+          payload['subscriptionProductReplacementParams']
+              as Map<dynamic, dynamic>,
+        );
+        expect(replacement['oldProductId'], 'sub.premium');
+        expect(replacement['replacementMode'], 'charge-full-price');
+      },
+    );
+
+    test(
       'sends developerBillingOption for External Payments on Android',
       () async {
         final calls = <MethodCall>[];


### PR DESCRIPTION
## Summary

- `RequestSubscriptionAndroidProps.subscriptionProductReplacementParams` was declared in `types.dart` and parsed correctly by the Android plugin, but `flutter_inapp_purchase.dart` never copied the field onto the method-channel payload when translating the Dart props into the native call. Any value callers passed was silently dropped, so Google Play fell back to its default replacement mode (`WITHOUT_PRORATION`) regardless of what the Dart side requested.
- Forwards the field through the channel payload and adds a channel test asserting that the serialized `oldProductId` / `replacementMode` reach the native call, so the wiring can't silently regress again.

Reported via #96 (comment). The legacy `replacementMode` int path was already wired correctly; this PR only fixes the newer per-product `SubscriptionProductReplacementParams` path (Billing Library 8.1.0+).

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 243 tests pass (new `forwards subscriptionProductReplacementParams on Android subscription` test included)
- [x] Format check: `dart format --page-width 80 --set-exit-if-changed` clean

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Android subscription product replacement parameters during in-app purchase requests, enabling configuration when requesting subscriptions.

* **Tests**
  * Added test coverage verifying proper handling of subscription product replacement parameters in Android purchase requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->