### PR TITLE
chore: migrate IAPKit verification host to kit.openiap.dev

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/docs": {
       "name": "@hyodotdev/openiap-docs",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@preact/signals-react": "^3.2.1",
         "@types/prismjs": "^1.26.5",
@@ -61,7 +61,7 @@
     },
     "packages/gql": {
       "name": "@hyodotdev/openiap-gql",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "devDependencies": {
         "@graphql-codegen/add": "^6.0.0",
         "@graphql-codegen/cli": "^6.0.0",

--- a/libraries/expo-iap/example/.env.example
+++ b/libraries/expo-iap/example/.env.example
@@ -1,3 +1,3 @@
 # IAPKit Configuration
-# Get your API key from https://iapkit.com
+# Get your API key from https://kit.openiap.dev
 EXPO_PUBLIC_IAPKIT_API_KEY=your_iapkit_api_key_here

--- a/libraries/expo-iap/example/app.config.ts
+++ b/libraries/expo-iap/example/app.config.ts
@@ -30,7 +30,7 @@ export default ({config}: ConfigContext): ExpoConfig => {
       '../app.plugin.js',
       {
         // IAPKit API key for server-side receipt verification
-        // Get your API key from https://iapkit.com
+        // Get your API key from https://kit.openiap.dev
         iapkitApiKey: process.env.EXPO_PUBLIC_IAPKIT_API_KEY,
         enableLocalDev: useLocalDev,
         localPath: {

--- a/libraries/expo-iap/plugin/src/withIAP.ts
+++ b/libraries/expo-iap/plugin/src/withIAP.ts
@@ -489,7 +489,7 @@ const withIapIOS: ConfigPlugin<WithIapIosOptions | undefined> = (
 export interface ExpoIapPluginOptions {
   /**
    * IAPKit API key for server-side receipt verification.
-   * Get your API key from https://iapkit.com
+   * Get your API key from https://kit.openiap.dev
    * This will be available via `Constants.expoConfig?.extra?.iapkitApiKey`
    */
   iapkitApiKey?: string;

--- a/libraries/flutter_inapp_purchase/example/env.example
+++ b/libraries/flutter_inapp_purchase/example/env.example
@@ -1,3 +1,3 @@
 # IAPKit API Key for purchase verification
-# Get your API key from https://iapkit.com
+# Get your API key from https://kit.openiap.dev
 IAPKIT_API_KEY=your_iapkit_api_key_here

--- a/libraries/flutter_inapp_purchase/example/lib/src/constants.dart
+++ b/libraries/flutter_inapp_purchase/example/lib/src/constants.dart
@@ -3,7 +3,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 // Product IDs for testing in the example app
 class IapConstants {
   // IAPKit API Key for purchase verification
-  // Get your API key from https://iapkit.com
+  // Get your API key from https://kit.openiap.dev
   static String get iapkitApiKey => dotenv.env['IAPKIT_API_KEY'] ?? '';
 
   // Consumable Product IDs

--- a/libraries/kmp-iap/.env.example
+++ b/libraries/kmp-iap/.env.example
@@ -1,3 +1,3 @@
 # IAPKit API Key for purchase verification
-# Get your API key from https://iapkit.com
+# Get your API key from https://kit.openiap.dev
 IAPKIT_API_KEY=your_iapkit_api_key_here

--- a/libraries/kmp-iap/example/.env.example
+++ b/libraries/kmp-iap/example/.env.example
@@ -1,3 +1,3 @@
 # IAPKit Configuration
-# Get your API key from https://iapkit.com
+# Get your API key from https://kit.openiap.dev
 IAPKIT_API_KEY=your_iapkit_api_key_here

--- a/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/config/AppConfig.kt
+++ b/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/config/AppConfig.kt
@@ -9,7 +9,7 @@ package dev.hyo.martie.config
 expect object AppConfig {
     /**
      * IAPKit API key for purchase verification.
-     * Get your API key from https://iapkit.com
+     * Get your API key from https://kit.openiap.dev
      */
     val iapkitApiKey: String
 }

--- a/libraries/kmp-iap/example/iosApp/Configuration/Secrets.xcconfig.example
+++ b/libraries/kmp-iap/example/iosApp/Configuration/Secrets.xcconfig.example
@@ -2,5 +2,5 @@
 // Copy this file to Secrets.xcconfig and add your API keys
 
 // IAPKit API Key for purchase verification
-// Get your API key from https://iapkit.com
+// Get your API key from https://kit.openiap.dev
 IAPKIT_API_KEY=your_iapkit_api_key_here

--- a/libraries/react-native-iap/example-expo/.env.example
+++ b/libraries/react-native-iap/example-expo/.env.example
@@ -1,3 +1,3 @@
 # IAPKit Configuration
-# Get your API key from https://iapkit.com
+# Get your API key from https://kit.openiap.dev
 EXPO_PUBLIC_IAPKIT_API_KEY=your_iapkit_api_key_here

--- a/libraries/react-native-iap/example-expo/app.config.ts
+++ b/libraries/react-native-iap/example-expo/app.config.ts
@@ -6,7 +6,7 @@ export default ({config}: ConfigContext): ExpoConfig => {
       'react-native-iap',
       {
         // IAPKit API key for purchase verification (optional)
-        // Get your API key from https://iapkit.com
+        // Get your API key from https://kit.openiap.dev
         iapkitApiKey: process.env.EXPO_PUBLIC_IAPKIT_API_KEY,
 
         // iOS Alternative Billing configuration (optional)

--- a/libraries/react-native-iap/example/.env.example
+++ b/libraries/react-native-iap/example/.env.example
@@ -1,3 +1,3 @@
 # IAPKit Configuration
-# Get your API key from https://iapkit.com
+# Get your API key from https://kit.openiap.dev
 IAPKIT_API_KEY=your_iapkit_api_key_here

--- a/libraries/react-native-iap/plugin/src/withIAP.ts
+++ b/libraries/react-native-iap/plugin/src/withIAP.ts
@@ -363,7 +363,7 @@ type IapPluginProps = {
   /**
    * IAPKit API key for purchase verification.
    * This key will be added to AndroidManifest.xml (as meta-data) and Info.plist.
-   * Get your API key from https://iapkit.com
+   * Get your API key from https://kit.openiap.dev
    */
   iapkitApiKey?: string;
 };

--- a/packages/apple/Sources/OpenIapModule.swift
+++ b/packages/apple/Sources/OpenIapModule.swift
@@ -706,7 +706,7 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
     // but it is never invoked from this module.
     private func verifyPurchaseWithIapkit(props: RequestVerifyPurchaseWithIapkitProps) async throws -> RequestVerifyPurchaseWithIapkitResult {
         // URL is a constant and cannot fail, so force unwrap is safe
-        let url = URL(string: "https://api.iapkit.com/v1/purchase/verify")!
+        let url = URL(string: "https://kit.openiap.dev/v1/purchase/verify")!
 
         // On Apple, only Apple verification is supported
         guard props.apple != nil else {

--- a/packages/docs/src/components/Navigation.tsx
+++ b/packages/docs/src/components/Navigation.tsx
@@ -180,6 +180,20 @@ function Navigation() {
                 Sponsors
               </NavLink>
             </li>
+
+            <li>
+              <a
+                href={IAPKIT_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => {
+                  trackIapKitClick();
+                  closeMobileMenu();
+                }}
+              >
+                IAPKit
+              </a>
+            </li>
           </ul>
         </div>
       </div>

--- a/packages/docs/src/components/Navigation.tsx
+++ b/packages/docs/src/components/Navigation.tsx
@@ -4,7 +4,7 @@ import { DarkModeToggle } from './DarkModeToggle';
 import { Menu, X } from 'lucide-react';
 import { FaGithub, FaSearch } from 'react-icons/fa';
 import { openSearchModal } from '../lib/signals';
-import { LOGO_PATH } from '../lib/config';
+import { IAPKIT_URL, LOGO_PATH, trackIapKitClick } from '../lib/config';
 
 function Navigation() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -95,6 +95,17 @@ function Navigation() {
           </button>
 
           <DarkModeToggle />
+
+          {/* IAPKit Link */}
+          <a
+            href={IAPKIT_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="iapkit-link"
+            onClick={trackIapKitClick}
+          >
+            IAPKit
+          </a>
 
           {/* GitHub Link */}
           <a

--- a/packages/docs/src/lib/config.ts
+++ b/packages/docs/src/lib/config.ts
@@ -15,7 +15,7 @@ export const LOGO_PATH = '/logo.webp';
 // IAPKit Configuration
 // =============================================================================
 
-export const IAPKIT_URL = 'https://iapkit.com';
+export const IAPKIT_URL = 'https://kit.openiap.dev';
 export const IAPKIT_AD_BANNER_URL =
   'https://www.hyo.dev/api/ad-banner/cmjf0l27p0004249h2blztbct';
 

--- a/packages/docs/src/pages/docs/example.tsx
+++ b/packages/docs/src/pages/docs/example.tsx
@@ -221,7 +221,7 @@ xcodebuild -project Martie.xcodeproj \\
                     className="external-link"
                     onClick={trackIapKitClick}
                   >
-                    iapkit.com
+                    kit.openiap.dev
                   </a>{' '}
                   and configure it in <code>Info.plist</code>:
                   <pre
@@ -574,7 +574,7 @@ adb install Example/build/outputs/apk/debug/Example-debug.apk`}</pre>
                     className="external-link"
                     onClick={trackIapKitClick}
                   >
-                    iapkit.com
+                    kit.openiap.dev
                   </a>{' '}
                   and configure it in <code>local.properties</code>:
                   <pre

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -691,7 +691,8 @@ Future<bool> verifyOnServer(ProductPurchase purchase) async {
           Verify Purchase with IAPKit
         </AnchorLink>
         <p>
-          Don&apos;t want to run a verification backend?{' '}
+          Don&apos;t want to implement App Store / Google Play verification
+          yourself?{' '}
           <a
             href="https://kit.openiap.dev"
             target="_blank"
@@ -705,7 +706,10 @@ Future<bool> verifyOnServer(ProductPurchase purchase) async {
           <code>verifyPurchaseWithProvider</code> with the{' '}
           <code>&apos;iapkit&apos;</code> provider and pass the
           platform-specific token (iOS JWS or Android purchase token) — no
-          server code required.
+          store-verification code required. If your app has server-side accounts
+          or entitlements, keep the final grant decision on your backend and
+          call IAPKit from that trusted path; client-only use is convenient, but
+          not tamper-proof.
         </p>
 
         <div className="alert-card alert-card--info">
@@ -763,8 +767,8 @@ func verifyWithIapkit(_ purchase: PurchaseIOS) async -> Bool {
             VerifyPurchaseWithProviderProps(
                 provider: .iapkit,
                 iapkit: RequestVerifyPurchaseWithIapkitProps(
-                    apiKey: Bundle.main.object(forInfoDictionaryKey: "IAPKIT_API_KEY") as? String,
-                    apple: RequestVerifyPurchaseWithIapkitApple(jws: purchase.purchaseToken ?? "")
+                    apiKey: Bundle.main.object(forInfoDictionaryKey: "IAPKitAPIKey") as? String,
+                    apple: RequestVerifyPurchaseWithIapkitAppleProps(jws: purchase.purchaseToken ?? "")
                 )
             )
         )
@@ -794,7 +798,7 @@ suspend fun verifyWithIapkit(purchase: PurchaseAndroid): Boolean {
                 iapkit = RequestVerifyPurchaseWithIapkitProps(
                     // apiKey is optional when configured via AndroidManifest meta-data
                     apiKey = BuildConfig.IAPKIT_API_KEY,
-                    google = RequestVerifyPurchaseWithIapkitGoogle(
+                    google = RequestVerifyPurchaseWithIapkitGoogleProps(
                         purchaseToken = purchase.purchaseToken.orEmpty()
                     )
                 )
@@ -825,7 +829,7 @@ suspend fun verifyWithIapkit(purchase: PurchaseAndroid): Boolean {
                 provider = PurchaseVerificationProvider.Iapkit,
                 iapkit = RequestVerifyPurchaseWithIapkitProps(
                     apiKey = AppConfig.iapkitApiKey,
-                    google = RequestVerifyPurchaseWithIapkitGoogle(
+                    google = RequestVerifyPurchaseWithIapkitGoogleProps(
                         purchaseToken = purchase.purchaseToken.orEmpty()
                     )
                 )
@@ -859,12 +863,12 @@ Future<bool> verifyWithIapkit(ProductPurchase purchase) async {
         iapkit: RequestVerifyPurchaseWithIapkitProps(
           apiKey: IapConstants.iapkitApiKey,
           apple: Platform.isIOS
-              ? RequestVerifyPurchaseWithIapkitApple(
+              ? RequestVerifyPurchaseWithIapkitAppleProps(
                   jws: purchase.purchaseToken ?? '',
                 )
               : null,
           google: Platform.isAndroid
-              ? RequestVerifyPurchaseWithIapkitGoogle(
+              ? RequestVerifyPurchaseWithIapkitGoogleProps(
                   purchaseToken: purchase.purchaseToken ?? '',
                 )
               : null,
@@ -893,10 +897,10 @@ Future<bool> verifyWithIapkit(ProductPurchase purchase) async {
     props.iapkit.api_key = AppConfig.iapkit_api_key
 
     if OS.get_name() == "iOS":
-        props.iapkit.apple = RequestVerifyPurchaseWithIapkitApple.new()
+        props.iapkit.apple = RequestVerifyPurchaseWithIapkitAppleProps.new()
         props.iapkit.apple.jws = purchase.purchase_token
     else:
-        props.iapkit.google = RequestVerifyPurchaseWithIapkitGoogle.new()
+        props.iapkit.google = RequestVerifyPurchaseWithIapkitGoogleProps.new()
         props.iapkit.google.purchase_token = purchase.purchase_token
 
     var result = await iap.verify_purchase_with_provider(props)

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -687,6 +687,244 @@ Future<bool> verifyOnServer(ProductPurchase purchase) async {
       </section>
 
       <section>
+        <AnchorLink id="verify-purchase-iapkit" level="h2">
+          Verify Purchase with IAPKit
+        </AnchorLink>
+        <p>
+          Don&apos;t want to run a verification backend?{' '}
+          <a
+            href="https://kit.openiap.dev"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="external-link"
+          >
+            IAPKit
+          </a>{' '}
+          is a hosted purchase verification service that validates App Store and
+          Google Play purchases for you. Use{' '}
+          <code>verifyPurchaseWithProvider</code> with the{' '}
+          <code>&apos;iapkit&apos;</code> provider and pass the
+          platform-specific token (iOS JWS or Android purchase token) — no
+          server code required.
+        </p>
+
+        <div className="alert-card alert-card--info">
+          <p>
+            <strong>ℹ️ Get an API key:</strong> Sign up at{' '}
+            <a
+              href="https://kit.openiap.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="external-link"
+            >
+              kit.openiap.dev
+            </a>{' '}
+            to obtain an <code>IAPKIT_API_KEY</code>. You can pass it directly,
+            or configure it once in your app (Expo extra, Info.plist,
+            AndroidManifest, etc.) so the SDK picks it up automatically.
+          </p>
+        </div>
+
+        <LanguageTabs>
+          {{
+            typescript: (
+              <CodeBlock language="typescript">{`import { Platform } from 'react-native';
+import { verifyPurchaseWithProvider, type Purchase } from 'expo-iap';
+
+const verifyWithIapkit = async (purchase: Purchase) => {
+  const result = await verifyPurchaseWithProvider({
+    provider: 'iapkit',
+    iapkit: {
+      // apiKey is optional when configured via app config / Info.plist / AndroidManifest
+      apiKey: process.env.EXPO_PUBLIC_IAPKIT_API_KEY,
+      ...(Platform.OS === 'ios'
+        ? { apple: { jws: purchase.purchaseToken ?? '' } }
+        : { google: { purchaseToken: purchase.purchaseToken ?? '' } }),
+    },
+  });
+
+  if (result.iapkit?.isValid) {
+    console.log('IAPKit verified:', result.iapkit.state);
+    return true;
+  }
+
+  console.error('IAPKit verification failed');
+  return false;
+};`}</CodeBlock>
+            ),
+            swift: (
+              <CodeBlock language="swift">{`import OpenIap
+
+func verifyWithIapkit(_ purchase: PurchaseIOS) async -> Bool {
+    let iapStore = OpenIapStore.shared
+
+    do {
+        let result = try await iapStore.verifyPurchaseWithProvider(
+            VerifyPurchaseWithProviderProps(
+                provider: .iapkit,
+                iapkit: RequestVerifyPurchaseWithIapkitProps(
+                    apiKey: Bundle.main.object(forInfoDictionaryKey: "IAPKIT_API_KEY") as? String,
+                    apple: RequestVerifyPurchaseWithIapkitApple(jws: purchase.purchaseToken ?? "")
+                )
+            )
+        )
+
+        if result.iapkit?.isValid == true {
+            print("IAPKit verified: \\(result.iapkit?.state.rawValue ?? "")")
+            return true
+        }
+
+        print("IAPKit verification failed")
+        return false
+    } catch {
+        print("IAPKit verification error: \\(error.localizedDescription)")
+        return false
+    }
+}`}</CodeBlock>
+            ),
+            kotlin: (
+              <CodeBlock language="kotlin">{`import dev.hyo.openiap.OpenIapStore
+import dev.hyo.openiap.models.*
+
+suspend fun verifyWithIapkit(purchase: PurchaseAndroid): Boolean {
+    return try {
+        val result = iapStore.verifyPurchaseWithProvider(
+            VerifyPurchaseWithProviderProps(
+                provider = PurchaseVerificationProvider.Iapkit,
+                iapkit = RequestVerifyPurchaseWithIapkitProps(
+                    // apiKey is optional when configured via AndroidManifest meta-data
+                    apiKey = BuildConfig.IAPKIT_API_KEY,
+                    google = RequestVerifyPurchaseWithIapkitGoogle(
+                        purchaseToken = purchase.purchaseToken.orEmpty()
+                    )
+                )
+            )
+        )
+
+        if (result.iapkit?.isValid == true) {
+            println("IAPKit verified: \${result.iapkit?.state}")
+            true
+        } else {
+            println("IAPKit verification failed")
+            false
+        }
+    } catch (e: Exception) {
+        println("IAPKit verification error: \${e.message}")
+        false
+    }
+}`}</CodeBlock>
+            ),
+            kmp: (
+              <CodeBlock language="kotlin">{`import io.github.hyochan.kmpiap.KmpIAP
+import io.github.hyochan.kmpiap.*
+
+suspend fun verifyWithIapkit(purchase: PurchaseAndroid): Boolean {
+    return try {
+        val result = kmpIAP.verifyPurchaseWithProvider(
+            VerifyPurchaseWithProviderProps(
+                provider = PurchaseVerificationProvider.Iapkit,
+                iapkit = RequestVerifyPurchaseWithIapkitProps(
+                    apiKey = AppConfig.iapkitApiKey,
+                    google = RequestVerifyPurchaseWithIapkitGoogle(
+                        purchaseToken = purchase.purchaseToken.orEmpty()
+                    )
+                )
+            )
+        )
+
+        if (result.iapkit?.isValid == true) {
+            println("IAPKit verified: \${result.iapkit?.state}")
+            true
+        } else {
+            println("IAPKit verification failed")
+            false
+        }
+    } catch (e: Exception) {
+        println("IAPKit verification error: \${e.message}")
+        false
+    }
+}`}</CodeBlock>
+            ),
+            dart: (
+              <CodeBlock language="dart">{`import 'dart:io';
+import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
+
+Future<bool> verifyWithIapkit(ProductPurchase purchase) async {
+  final iap = FlutterInappPurchase.instance;
+
+  try {
+    final result = await iap.verifyPurchaseWithProvider(
+      VerifyPurchaseWithProviderProps(
+        provider: PurchaseVerificationProvider.iapkit,
+        iapkit: RequestVerifyPurchaseWithIapkitProps(
+          apiKey: IapConstants.iapkitApiKey,
+          apple: Platform.isIOS
+              ? RequestVerifyPurchaseWithIapkitApple(
+                  jws: purchase.purchaseToken ?? '',
+                )
+              : null,
+          google: Platform.isAndroid
+              ? RequestVerifyPurchaseWithIapkitGoogle(
+                  purchaseToken: purchase.purchaseToken ?? '',
+                )
+              : null,
+        ),
+      ),
+    );
+
+    if (result.iapkit?.isValid == true) {
+      print('IAPKit verified: \${result.iapkit?.state}');
+      return true;
+    }
+
+    print('IAPKit verification failed');
+    return false;
+  } catch (e) {
+    print('IAPKit verification error: $e');
+    return false;
+  }
+}`}</CodeBlock>
+            ),
+            gdscript: (
+              <CodeBlock language="gdscript">{`func verify_with_iapkit(purchase: Purchase) -> bool:
+    var props = VerifyPurchaseWithProviderProps.new()
+    props.provider = PurchaseVerificationProvider.IAPKIT
+    props.iapkit = RequestVerifyPurchaseWithIapkitProps.new()
+    props.iapkit.api_key = AppConfig.iapkit_api_key
+
+    if OS.get_name() == "iOS":
+        props.iapkit.apple = RequestVerifyPurchaseWithIapkitApple.new()
+        props.iapkit.apple.jws = purchase.purchase_token
+    else:
+        props.iapkit.google = RequestVerifyPurchaseWithIapkitGoogle.new()
+        props.iapkit.google.purchase_token = purchase.purchase_token
+
+    var result = await iap.verify_purchase_with_provider(props)
+
+    if result.iapkit and result.iapkit.is_valid:
+        print("IAPKit verified: %s" % result.iapkit.state)
+        return true
+
+    print("IAPKit verification failed")
+    return false`}</CodeBlock>
+            ),
+          }}
+        </LanguageTabs>
+
+        <div className="alert-card alert-card--info">
+          <p>
+            <strong>ℹ️ Endpoint:</strong> Requests are sent to{' '}
+            <code>https://kit.openiap.dev/v1/purchase/verify</code> with{' '}
+            <code>Authorization: Bearer &lt;apiKey&gt;</code>. See the{' '}
+            <Link to="/docs/types/verification#purchase-verification-provider">
+              PurchaseVerificationProvider
+            </Link>{' '}
+            type reference for the full response shape.
+          </p>
+        </div>
+      </section>
+
+      <section>
         <AnchorLink id="finish-transaction" level="h2">
           Finish Transaction
         </AnchorLink>

--- a/packages/docs/src/pages/docs/lifecycle/subscription.tsx
+++ b/packages/docs/src/pages/docs/lifecycle/subscription.tsx
@@ -141,7 +141,7 @@ function Subscription() {
           <p>
             <strong>Recommendation</strong>: Use{' '}
             <a
-              href="https://iapkit.com"
+              href="https://kit.openiap.dev"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/packages/docs/src/pages/docs/types/verification.tsx
+++ b/packages/docs/src/pages/docs/types/verification.tsx
@@ -646,7 +646,7 @@ function TypesVerification() {
               </td>
               <td>
                 <a
-                  href="https://iapkit.com"
+                  href="https://kit.openiap.dev"
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/packages/docs/src/pages/docs/updates/releases.tsx
+++ b/packages/docs/src/pages/docs/updates/releases.tsx
@@ -25,6 +25,67 @@ function Releases() {
   useScrollToHash();
 
   const allNotes: Note[] = [
+    // April 19, 2026 — IAPKit verification host migration
+    {
+      id: 'releases-2026-04-19',
+      date: new Date('2026-04-19'),
+      element: (
+        <div key="releases-2026-04-19" style={noteCardStyle}>
+          <AnchorLink id="releases-2026-04-19" level="h4">
+            April 19, 2026
+          </AnchorLink>
+
+          <div style={{ marginTop: '0.75rem', marginBottom: '1.5rem' }}>
+            <h5 style={{ margin: '0 0 0.5rem 0' }}>
+              IAPKit verification host migrated to <code>kit.openiap.dev</code>
+            </h5>
+            <p
+              style={{
+                marginBottom: '1rem',
+                color: 'var(--text-secondary)',
+              }}
+            >
+              The IAPKit purchase verification service moved from{' '}
+              <code>api.iapkit.com</code> to <code>kit.openiap.dev</code>. Only
+              the host changed — the request/response shape, authentication (
+              <code>Authorization: Bearer &lt;apiKey&gt;</code>), and the{' '}
+              <code>/v1/purchase/verify</code> path are identical. No client
+              code changes are required once you pick up the latest package
+              versions.
+            </p>
+            <ul
+              style={{
+                marginBottom: 0,
+                paddingLeft: '1.25rem',
+                fontSize: '0.9rem',
+              }}
+            >
+              <li>
+                <strong>Old:</strong>{' '}
+                <code>https://api.iapkit.com/v1/purchase/verify</code>
+              </li>
+              <li>
+                <strong>New:</strong>{' '}
+                <code>https://kit.openiap.dev/v1/purchase/verify</code>
+              </li>
+              <li>
+                API keys are now issued from{' '}
+                <a
+                  href="https://kit.openiap.dev"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="external-link"
+                >
+                  kit.openiap.dev
+                </a>
+                .
+              </li>
+            </ul>
+          </div>
+        </div>
+      ),
+    },
+
     // April 17, 2026 — Advanced Commerce & Transaction History
     {
       id: 'releases-2026-04-17',

--- a/packages/docs/src/styles/navigation.css
+++ b/packages/docs/src/styles/navigation.css
@@ -87,6 +87,36 @@
   background: var(--bg-secondary);
 }
 
+/* IAPKit Link */
+.iapkit-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  padding: 0 0.75rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: linear-gradient(
+    135deg,
+    var(--primary-color),
+    var(--accent-color)
+  );
+  text-decoration: none;
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s,
+    opacity 0.15s;
+  white-space: nowrap;
+}
+
+.iapkit-link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  opacity: 0.95;
+}
+
 /* Mobile menu button */
 .mobile-menu-button {
   display: none;

--- a/packages/docs/src/styles/navigation.css
+++ b/packages/docs/src/styles/navigation.css
@@ -97,7 +97,7 @@
   border-radius: 6px;
   font-size: 0.85rem;
   font-weight: 600;
-  color: #ffffff;
+  color: #000000;
   background: linear-gradient(
     135deg,
     var(--primary-color),

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/utils/PurchaseVerificationValidator.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/utils/PurchaseVerificationValidator.kt
@@ -18,7 +18,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
 
-private const val DEFAULT_IAPKIT_ENDPOINT = "https://api.iapkit.com/v1/purchase/verify"
+private const val DEFAULT_IAPKIT_ENDPOINT = "https://kit.openiap.dev/v1/purchase/verify"
 private val gson = Gson()
 
 private fun openConnection(url: String): HttpURLConnection {


### PR DESCRIPTION
## Summary

- Migrate the IAPKit purchase verification endpoint from `api.iapkit.com` to `kit.openiap.dev` across native modules (Apple, Google) and all downstream libraries/docs.
- Only the host changed — request/response schema, `Authorization: Bearer <apiKey>`, and `/v1/purchase/verify` path are identical; no consumer code change required after picking up the new package versions.
- Add an IAPKit nav button (top-right) and a new "Verify Purchase with IAPKit" section on `/docs/features/purchase`.

## Changes

### Native modules (packages/apple, packages/google)
- `packages/apple/Sources/OpenIapModule.swift`: IAPKit provider URL → `https://kit.openiap.dev/v1/purchase/verify`.
- `packages/google/openiap/src/main/java/dev/hyo/openiap/utils/PurchaseVerificationValidator.kt`: `DEFAULT_IAPKIT_ENDPOINT` → `https://kit.openiap.dev/v1/purchase/verify`.

### Docs (packages/docs)
- `IAPKIT_URL` constant → `https://kit.openiap.dev`; update `example.tsx`, `types/verification.tsx`, `lifecycle/subscription.tsx` link targets.
- New top-right `IAPKit` nav button (`Navigation.tsx` + `navigation.css`) with gradient pill styling.
- `features/purchase.tsx`: new "Verify Purchase with IAPKit" section with `verifyPurchaseWithProvider({ provider: 'iapkit', ... })` examples for TypeScript, Swift, Kotlin, KMP, Dart, GDScript; notes endpoint and API-key flow.
- `updates/releases.tsx`: 2026-04-19 release note describing the host-only migration.

### Libraries (env/plugin references)
- Update `Get your API key from https://iapkit.com` comments to `https://kit.openiap.dev` in:
  - `libraries/expo-iap/{example,plugin}`
  - `libraries/react-native-iap/{example,example-expo,plugin}`
  - `libraries/flutter_inapp_purchase/example`
  - `libraries/kmp-iap/{,example,example/iosApp/Configuration/Secrets.xcconfig.example}`
- `bun.lock`: workspace version sync picked up during `bun install`.

## Test plan

- [x] `bun run typecheck` (packages/docs) passes
- [x] `bunx prettier --check src/**` (packages/docs) passes
- [ ] Local build of downstream libraries (rn-iap, expo-iap, flutter, kmp) — URL-only change, no API surface impact; deferred to CI
- [ ] Verify purchase flow against `kit.openiap.dev` with a valid API key

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API endpoint references across all platform-specific libraries and examples to reflect the new IAPKit location.
  * Added comprehensive purchase verification guide, including endpoint information and authentication requirements.
  * Published migration notes documenting the IAPKit verification endpoint transition.

* **New Features**
  * Added direct IAPKit link in documentation navigation for quick access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->