### PR TITLE
docs: cross-link wrapper SDKs + doc pages to openiap.dev API references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ This document provides an overview for AI agents working across the OpenIAP mono
 | Platform Packages | [`knowledge/internal/04-platform-packages.md`](knowledge/internal/04-platform-packages.md) |
 | Docs Patterns | [`knowledge/internal/05-docs-patterns.md`](knowledge/internal/05-docs-patterns.md) |
 | Git & Deployment | [`knowledge/internal/06-git-deployment.md`](knowledge/internal/06-git-deployment.md) |
+| Docs Consistency / SSOT | [`knowledge/internal/07-docs-consistency.md`](knowledge/internal/07-docs-consistency.md) (run `bun audit:docs` before pushing API/Type doc edits) |
 
 ## Monorepo Structure
 

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "@typescript-eslint/parser": "^8.39.1",
         "@vitejs/plugin-react": "^4.3.1",
         "babel-plugin-react-compiler": "^19.1.0-rc.2",
+        "baseline-browser-mapping": "^2.10.22",
         "eslint": "^9.21.0",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.7",
@@ -528,7 +529,7 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.8.16", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.22", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
@@ -1223,6 +1224,8 @@
     "@whatwg-node/node-fetch/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@whatwg-node/promise-helpers/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.8.16", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw=="],
 
     "camel-case/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/knowledge/internal/07-docs-consistency.md
+++ b/knowledge/internal/07-docs-consistency.md
@@ -1,0 +1,190 @@
+# Docs Consistency Rules — Single Source of Truth (SSOT)
+
+This document captures the consistency rules for OpenIAP documentation, code
+comments, and generated types. PR #107 (and earlier rounds) repeatedly
+surfaced the same class of drift — the docs claimed one field/default/type,
+but the SDK code actually used another. These rules + the companion audit
+script (`scripts/audit-docs.ts`) catch those before review.
+
+## Sources of truth
+
+When two places disagree, the upstream wins:
+
+```
+GraphQL schema  →  generated Types  →  hand-written wrapper SDK  →  docs page
+(packages/gql      (libraries/*/src       (Swift / Kotlin /          (packages/docs/
+ /src/*.graphql)   /types.{ts,kt,...})    Dart / TS / GDScript)        src/pages/...)
+```
+
+- `packages/gql/src/*.graphql` — schema descriptions ARE the canonical doc
+  string. Edits propagate via `bun run generate` to every generated
+  `Types.{ts,kt,swift,dart,gd}`.
+- `libraries/*/src/types.ts` (or equivalent) — generated; never hand-edit.
+  When a docs page mentions a field name, that field MUST exist in the
+  generated TS type. The audit script enforces this.
+- Wrapper SDK source (e.g. `libraries/expo-iap/src/index.ts`) — JSDoc
+  parameter names MUST match the actual function-signature parameter
+  names. ESLint rule `tsdoc/syntax` + the audit script catch drift.
+- Doc pages — the surface visible to users. Must reflect what each upstream
+  layer actually exposes.
+
+## Rules
+
+### R1 — JSDoc / KDoc / Dartdoc / Swift `@param` names match the signature
+
+If the function declares `(args) =>`, the JSDoc tag is `@param args …`.
+If it declares `(request) =>`, the tag is `@param request …`. Don't carry
+over the schema field name (`props`, `params`) when the wrapper destructured
+or renamed.
+
+```ts
+// ✅ wrapper destructures from `args`
+/** @param args Purchase request. … */
+export const requestPurchase = async (args) => { … };
+
+// ❌ JSDoc says `props`; signature says `args`
+/** @param props … */
+export const requestPurchase = async (args) => { … };
+```
+
+### R2 — Defaults match across SDKs
+
+If `fetchProducts.type` defaults to `'in-app'` in Flutter / expo-iap /
+react-native-iap / godot-iap, then the Apple wrapper must also default to
+`.inApp` — and the Apple doc comment must say `.inApp`. The schema
+description is the canonical statement.
+
+When changing a default, update:
+1. The GraphQL schema description.
+2. Re-run `bun run generate`.
+3. Every wrapper SDK's `?? <default>` expression and JSDoc / KDoc / etc.
+4. Every API doc page (`packages/docs/src/pages/docs/apis/<symbol>.tsx`).
+
+### R3 — Doc pages reference real fields only
+
+When a Type doc page lists fields in a `<table>` or `<ul>`, every field name
+MUST exist in the generated `libraries/expo-iap/src/types.ts` (or
+`libraries/react-native-iap/src/types.ts` — they're identical in shape).
+The audit script greps for fields that don't appear in the type definition
+and flags them.
+
+Example failure modes already encountered:
+- `BillingProgramAvailabilityResultAndroid` doc listed
+  `responseCode` + `debugMessage` — neither field exists; the type has
+  `billingProgram` + `isAvailable`.
+- `LaunchExternalLinkParamsAndroid` doc listed `program` + `url` — neither
+  exists; the type has `billingProgram` + `launchMode` + `linkType` +
+  `linkUri`.
+- `ExternalPurchaseCustomLinkNoticeResultIOS` doc listed `result` +
+  `noticeType` — neither exists; the type has `continued` + `error`.
+
+### R4 — Enum values listed in docs must exist
+
+When a doc page mentions enum values (e.g.
+`'continue' | 'cancelled'`, `.acquisition`, `.services`), they must
+appear in the generated enum definition. The audit script extracts string
+literals from `<code>'…'</code>` blocks in doc pages and checks them
+against the generated TypeScript union types.
+
+`ExternalPurchaseCustomLinkNoticeTypeIOS` is the canonical recent miss —
+the union is `'browser'` only, but the doc claimed
+`'continue' | 'cancelled' | …`.
+
+### R5 — `<Link to="/docs/...">` targets must resolve
+
+Anchor links should point to existing pages and section anchors. Common
+recent failures:
+- "Use verifyPurchase" link pointed to `/docs/apis/get-active-subscriptions`
+  (totally unrelated).
+- `getExternalPurchaseCustomLinkTokenIOS` Returns linked to the
+  `external-purchase-link` page without an anchor — but that page
+  documents only `ExternalPurchaseNoticeResultIOS`, so users land in the
+  wrong section. Add a precise `#external-purchase-custom-link-token-result-ios`
+  anchor on the type page AND link to it.
+
+The audit script crawls every internal `<Link to="/docs/...">` and asserts
+the target file (and anchor when given) exists.
+
+### R6 — Native version constraints are honest
+
+`enableBillingProgramAndroid: 'external-payments'` is gated to Play Billing
+8.3.0+ (Japan only); the 8.2.0+ programs are `EXTERNAL_CONTENT_LINK` /
+`EXTERNAL_OFFER`. A doc page that mixes these up misleads readers about
+what works on which SDK.
+
+When you write `<X> 8.2.0+`, you should be able to point to the matching
+release-notes line. Don't paraphrase — quote the version requirement
+exactly as Google / Apple states it.
+
+### R7 — Code-example snippets compile-check
+
+Code examples in doc pages should at minimum parse / type-check against
+the wrapper they target. The audit script does NOT yet run a full
+TypeScript / Kotlin / Dart parser, but it does:
+- Verify imports (`import {…} from 'expo-iap'`) reference symbols that
+  expo-iap actually exports.
+- Verify field accesses on shown objects (e.g. `purchase.purchaseToken`)
+  exist on the corresponding generated type.
+
+When in doubt, run the example in a real example app before publishing.
+
+### R8 — Platform-only callouts use the right wrapper
+
+iOS-suffixed APIs (`syncIOS`, `getStorefrontIOS`, …) and Android-suffixed
+APIs (`acknowledgePurchaseAndroid`, …) are exposed via every framework
+wrapper (expo-iap, rn-iap, kmp-iap, flutter, godot-iap). The TS / Dart /
+KMP / GDScript example tabs MUST show how to call the function from each
+wrapper, with a `Platform.OS === 'ios'` (or `Platform.isIOS` / etc.)
+guard so readers don't accidentally call iOS-only methods on Android.
+
+The native Swift / Kotlin tab keeps the platform-native call. The
+wrapper tabs use the suffixed name (`syncIOS()`, etc.) — except in
+`packages/google` Kotlin (the Android-only native), where convention
+strips the `Android` suffix from method names.
+
+## Pre-commit checklist
+
+Run before every `git push` on docs / SDK changes:
+
+```bash
+# 1. Format + lint the docs site
+cd packages/docs
+bunx prettier --check "src/**/*.{ts,tsx,css}"
+bun run lint
+
+# 2. Cross-library typecheck for SDKs you touched
+cd libraries/expo-iap && bun run lint:tsc
+cd libraries/react-native-iap && yarn typecheck   # ignore example-expo errors
+cd libraries/flutter_inapp_purchase && dart analyze lib
+cd packages/apple && swift build
+cd packages/google && ./gradlew :openiap:compilePlayDebugKotlin
+
+# 3. SSOT audit — run the docs-consistency audit script
+cd scripts && bun run audit-docs.ts
+```
+
+Auto-mode users: the `commit-push-pr` skill runs steps 1 + 2 automatically
+before pushing. Step 3 is opt-in until the audit script has zero false
+positives in CI.
+
+## Audit script
+
+`scripts/audit-docs.ts` is the executable companion to this guide. It
+parses every `/docs/apis/*.tsx` and `/docs/types/*.tsx` page, extracts:
+- `<Link to="/docs/...">` targets
+- `<code>fieldName</code>` mentions inside Returns / Parameters tables
+- String-literal enum values in `<code>'…'</code>` blocks
+- `@see {@link openiap.dev/...}` URLs
+
+…and cross-references each against the generated TypeScript types in
+`libraries/expo-iap/src/types.ts`. Failures print as a punch-list with the
+file, line, and the offending mention.
+
+Run with:
+
+```bash
+cd /Users/hyo/Github/hyodotdev/openiap
+bun run scripts/audit-docs.ts
+```
+
+Exit code 1 means at least one drift; 0 means clean.

--- a/libraries/expo-iap/src/index.ts
+++ b/libraries/expo-iap/src/index.ts
@@ -331,18 +331,57 @@ export const subscriptionBillingIssueListener = (
   );
 };
 
+/**
+ * Initialize the store connection. Must be called before any other IAP API.
+ *
+ * @param config Optional connection config. Use `enableBillingProgramAndroid` (Android,
+ *   Play Billing 8.2.0+) to opt into External Payments etc. iOS ignores Android-specific fields.
+ * @returns Promise resolving to `true` when the platform billing client is connected.
+ * @throws When the platform billing client fails to initialize.
+ *
+ * @example
+ * ```ts
+ * await initConnection();
+ * await initConnection({ enableBillingProgramAndroid: 'external-offer' });
+ * ```
+ *
+ * @remarks When using `useIAP()`, connection is auto-managed on mount/unmount —
+ *   pass options to the hook instead of calling this directly.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/init-connection}
+ */
 export const initConnection: MutationField<'initConnection'> = async (config) =>
   ExpoIapModule.initConnection(config ?? null);
 
+/**
+ * Close the store connection and release resources.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/end-connection}
+ */
 export const endConnection: MutationField<'endConnection'> = async () =>
   ExpoIapModule.endConnection();
 
 /**
- * Fetch products with unified API (v2.7.0+)
+ * Retrieve products or subscriptions from the store by SKU.
  *
- * @param request - Product fetch configuration
- * @param request.skus - Array of product SKUs to fetch
- * @param request.type - Product query type: 'in-app', 'subs', or 'all'
+ * @param params `ProductRequest` — `skus` (string[]) and optional `type`
+ *   (`'in-app' | 'subs' | 'all'`, defaults to `'in-app'`).
+ * @returns Promise resolving to a `FetchProductsResult` union — `Product[]` for `'in-app'`,
+ *   `ProductSubscription[]` for `'subs'`, or a mixed array for `'all'`.
+ * @throws When the store rejects the request (unknown SKU, network, not connected).
+ *
+ * @example
+ * ```ts
+ * const products = await fetchProducts({
+ *   skus: ['com.app.coins_100', 'com.app.premium'],
+ *   type: 'in-app',
+ * });
+ * ```
+ *
+ * @remarks This is a regular promise-based call. Don't confuse with `request*` APIs
+ *   (`requestPurchase`), which are event-based.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/fetch-products}
  */
 export const fetchProducts: QueryField<'fetchProducts'> = async (request) => {
   ExpoIapConsole.debug('fetchProducts called with:', request);
@@ -413,6 +452,25 @@ export const fetchProducts: QueryField<'fetchProducts'> = async (request) => {
   throw new Error('Unsupported platform');
 };
 
+/**
+ * List the user's unfinished purchases — non-consumables, active subscriptions, and any
+ * pending transactions not yet finished.
+ *
+ * @param options Optional `PurchaseOptions`. iOS-only flags:
+ *   `alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`.
+ * @returns Promise resolving to an array of `Purchase` currently held by the store.
+ * @throws When the platform query fails.
+ *
+ * @example
+ * ```ts
+ * const purchases = await getAvailablePurchases();
+ * for (const p of purchases) {
+ *   if (await verifyOnServer(p)) await finishTransaction({ purchase: p, isConsumable: false });
+ * }
+ * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/get-available-purchases}
+ */
 export const getAvailablePurchases: QueryField<
   'getAvailablePurchases'
 > = async (options) => {
@@ -467,6 +525,8 @@ export const getAvailablePurchases: QueryField<
  *   }
  * });
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/get-active-subscriptions}
  */
 export const getActiveSubscriptions: QueryField<
   'getActiveSubscriptions'
@@ -491,6 +551,8 @@ export const getActiveSubscriptions: QueryField<
  * // Check specific subscriptions
  * const hasPremium = await hasActiveSubscriptions(['premium', 'premium_year']);
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/has-active-subscriptions}
  */
 export const hasActiveSubscriptions: QueryField<
   'hasActiveSubscriptions'
@@ -500,6 +562,11 @@ export const hasActiveSubscriptions: QueryField<
   ));
 };
 
+/**
+ * Return the user's storefront country code.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/get-storefront}
+ */
 export const getStorefront: QueryField<'getStorefront'> = async () => {
   if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
     return '';
@@ -541,44 +608,30 @@ function normalizeRequestProps(
 }
 
 /**
- * Request a purchase for products or subscriptions.
+ * Initiate a purchase or subscription flow. The result is delivered through
+ * `purchaseUpdatedListener` — NOT the return value.
  *
- * @param requestObj - Purchase request configuration
- * @param requestObj.request - Store-specific purchase parameters
- * @param requestObj.type - Type of purchase: 'in-app' for products (default) or 'subs' for subscriptions
+ * @param props `RequestPurchaseProps`, discriminated by `type`:
+ *   - `type: 'in-app'` — pass `request.apple.sku` (iOS) and/or `request.google.skus` (Android).
+ *   - `type: 'subs'`  — same shape, plus `request.google.subscriptionOffers: [{ sku, offerToken }]`.
+ * @returns The dispatched purchase payload. **Do not rely on it** for the actual outcome.
+ * @throws Synchronous rejection from the store (e.g. `E_NOT_PREPARED`, validation failure).
  *
  * @example
- * ```typescript
- * // Product purchase (recommended: use apple/google)
+ * ```ts
  * await requestPurchase({
  *   request: {
- *     apple: { sku: productId },
- *     google: { skus: [productId] }
+ *     apple: { sku: 'com.app.premium' },
+ *     google: { skus: ['com.app.premium'] },
  *   },
- *   type: 'in-app'
- * });
- *
- * // Subscription purchase
- * await requestPurchase({
- *   request: {
- *     apple: { sku: subscriptionId },
- *     google: {
- *       skus: [subscriptionId],
- *       subscriptionOffers: [{ sku: subscriptionId, offerToken: 'token' }]
- *     }
- *   },
- *   type: 'subs'
- * });
- *
- * // Legacy format (deprecated, but still supported)
- * await requestPurchase({
- *   request: {
- *     ios: { sku: productId },
- *     android: { skus: [productId] }
- *   },
- *   type: 'in-app'
+ *   type: 'in-app',
  * });
  * ```
+ *
+ * @remarks Event-based. Listen for the result via {@link purchaseUpdatedListener} /
+ *   {@link purchaseErrorListener}, or use `useIAP({ onPurchaseSuccess, onPurchaseError })`.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/request-purchase}
  */
 export const requestPurchase: MutationField<'requestPurchase'> = async (
   args,
@@ -739,6 +792,29 @@ export const requestPurchase: MutationField<'requestPurchase'> = async (
   throw new Error('Platform not supported');
 };
 
+/**
+ * Complete a purchase transaction. Call after server-side verification to remove it
+ * from the queue.
+ *
+ * @param args.purchase The `Purchase` to finalize.
+ * @param args.isConsumable `true` for consumables (consumes the token so the SKU can be
+ *   re-bought, e.g. coins); `false` (default) for non-consumables and subscriptions.
+ * @returns Promise that resolves once the platform finalizes the transaction.
+ * @throws When the platform finalize call fails.
+ *
+ * @example
+ * ```ts
+ * // Inside purchaseUpdatedListener:
+ * if (await verifyOnServer(purchase)) {
+ *   await finishTransaction({ purchase, isConsumable: false });
+ * }
+ * ```
+ *
+ * @remarks **Critical:** Android purchases must be finalized within 3 days or Google
+ *   auto-refunds. iOS unfinished transactions replay on every app launch.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/finish-transaction}
+ */
 export const finishTransaction: MutationField<'finishTransaction'> = async ({
   purchase,
   isConsumable = false,
@@ -781,6 +857,8 @@ export const finishTransaction: MutationField<'finishTransaction'> = async ({
  *
  * This helper triggers the refresh flows but does not return the purchases; consumers should
  * call `getAvailablePurchases` or rely on hook state to inspect the latest items.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/restore-purchases}
  */
 export const restorePurchases: MutationField<'restorePurchases'> = async () => {
   if (Platform.OS === 'ios') {
@@ -810,6 +888,8 @@ export const restorePurchases: MutationField<'restorePurchases'> = async () => {
  *   skuAndroid: 'your_subscription_sku',
  *   packageNameAndroid: 'com.example.app'
  * });
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/deep-link-to-subscriptions}
  */
 export const deepLinkToSubscriptions: MutationField<
   'deepLinkToSubscriptions'
@@ -836,6 +916,8 @@ export const deepLinkToSubscriptions: MutationField<
  * - Android: Use Google Play Developer API with service account credentials
  *
  * @deprecated Use verifyPurchase instead
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/validate-receipt}
  */
 export const validateReceipt: MutationField<'validateReceipt'> = async (
   options,
@@ -881,6 +963,8 @@ export const validateReceipt: MutationField<'validateReceipt'> = async (
  *
  * @param options - Receipt validation options containing the SKU
  * @returns Promise resolving to receipt validation result
+ *
+ * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase}
  */
 export const verifyPurchase: MutationField<'verifyPurchase'> = async (
   options,
@@ -916,6 +1000,8 @@ export const verifyPurchase: MutationField<'verifyPurchase'> = async (
  *   }
  * });
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider}
  */
 export const verifyPurchaseWithProvider: MutationField<
   'verifyPurchaseWithProvider'

--- a/libraries/expo-iap/src/index.ts
+++ b/libraries/expo-iap/src/index.ts
@@ -368,7 +368,8 @@ export const endConnection: MutationField<'endConnection'> = async () =>
  *   (`'in-app' | 'subs' | 'all'`, defaults to `'in-app'`).
  * @returns Promise resolving to a `FetchProductsResult` union — `Product[]` for `'in-app'`,
  *   `ProductSubscription[]` for `'subs'`, or a mixed array for `'all'`.
- * @throws When the store rejects the request (unknown SKU, network, not connected).
+ * @throws When the store rejects the request (empty `skus`, not connected,
+ *   network/store error). Unknown SKUs are simply omitted from the result, not thrown.
  *
  * @example
  * ```ts

--- a/libraries/expo-iap/src/index.ts
+++ b/libraries/expo-iap/src/index.ts
@@ -364,7 +364,7 @@ export const endConnection: MutationField<'endConnection'> = async () =>
 /**
  * Retrieve products or subscriptions from the store by SKU.
  *
- * @param params `ProductRequest` — `skus` (string[]) and optional `type`
+ * @param request `ProductRequest` — `skus` (string[]) and optional `type`
  *   (`'in-app' | 'subs' | 'all'`, defaults to `'in-app'`).
  * @returns Promise resolving to a `FetchProductsResult` union — `Product[]` for `'in-app'`,
  *   `ProductSubscription[]` for `'subs'`, or a mixed array for `'all'`.
@@ -611,7 +611,7 @@ function normalizeRequestProps(
  * Initiate a purchase or subscription flow. The result is delivered through
  * `purchaseUpdatedListener` — NOT the return value.
  *
- * @param props `RequestPurchaseProps`, discriminated by `type`:
+ * @param args `RequestPurchaseProps`, discriminated by `type`:
  *   - `type: 'in-app'` — pass `request.apple.sku` (iOS) and/or `request.google.skus` (Android).
  *   - `type: 'subs'`  — same shape, plus `request.google.subscriptionOffers: [{ sku, offerToken }]`.
  * @returns The dispatched purchase payload. **Do not rely on it** for the actual outcome.

--- a/libraries/expo-iap/src/modules/android.ts
+++ b/libraries/expo-iap/src/modules/android.ts
@@ -131,6 +131,8 @@ export const validateReceiptAndroid = async ({
  * Consume a purchase token so the user can purchase the same product again
  * (Android consumable products). Prefer using `finishTransaction` with
  * `isConsumable: true`, which dispatches to this under the hood.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/consume-purchase-android}
  */
 export const consumePurchaseAndroid: MutationField<
   'consumePurchaseAndroid'
@@ -163,6 +165,8 @@ export const consumePurchaseAndroid: MutationField<
  * @param {Object} params - The parameters object
  * @param {string} params.token - The product's token (on Android)
  * @returns {Promise<VoidResult | void>}
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android}
  */
 export const acknowledgePurchaseAndroid: MutationField<
   'acknowledgePurchaseAndroid'
@@ -213,6 +217,8 @@ export const openRedeemOfferCodeAndroid = async (): Promise<void> => {
  *   // Proceed with alternative billing flow
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android}
  */
 export const checkAlternativeBillingAvailabilityAndroid: MutationField<
   'checkAlternativeBillingAvailabilityAndroid'
@@ -243,6 +249,8 @@ export const checkAlternativeBillingAvailabilityAndroid: MutationField<
  *   }
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android}
  */
 export const showAlternativeBillingDialogAndroid: MutationField<
   'showAlternativeBillingDialogAndroid'
@@ -273,6 +281,8 @@ export const showAlternativeBillingDialogAndroid: MutationField<
  *   });
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android}
  */
 export const createAlternativeBillingTokenAndroid: MutationField<
   'createAlternativeBillingTokenAndroid'
@@ -298,6 +308,8 @@ export const createAlternativeBillingTokenAndroid: MutationField<
  *   // Proceed with billing program flow
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/is-billing-program-available-android}
  */
 export const isBillingProgramAvailableAndroid: MutationField<
   'isBillingProgramAvailableAndroid'
@@ -321,6 +333,8 @@ export const isBillingProgramAvailableAndroid: MutationField<
  *   linkUri: 'https://your-payment-site.com',
  * });
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/launch-external-link-android}
  */
 export const launchExternalLinkAndroid: MutationField<
   'launchExternalLinkAndroid'
@@ -344,6 +358,8 @@ export const launchExternalLinkAndroid: MutationField<
  * // Report details.externalTransactionToken to Google Play within 24 hours
  * await reportToGooglePlay(details.externalTransactionToken);
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android}
  */
 export const createBillingProgramReportingDetailsAndroid: MutationField<
   'createBillingProgramReportingDetailsAndroid'

--- a/libraries/expo-iap/src/modules/ios.ts
+++ b/libraries/expo-iap/src/modules/ios.ts
@@ -53,6 +53,8 @@ export function isProductIOS<T extends {platform?: string}>(
  * @throws Error if called on non-iOS platform
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/sync-ios}
  */
 export const syncIOS: MutationField<'syncIOS'> = async () => {
   return !!(await ExpoIapModule.syncIOS());
@@ -66,6 +68,8 @@ export const syncIOS: MutationField<'syncIOS'> = async () => {
  * @throws Error if called on non-iOS platform
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios}
  */
 export const isEligibleForIntroOfferIOS: QueryField<
   'isEligibleForIntroOfferIOS'
@@ -84,6 +88,8 @@ export const isEligibleForIntroOfferIOS: QueryField<
  * @throws Error if called on non-iOS platform
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/subscription-status-ios}
  */
 export const subscriptionStatusIOS: QueryField<
   'subscriptionStatusIOS'
@@ -103,6 +109,8 @@ export const subscriptionStatusIOS: QueryField<
  * @throws Error if called on non-iOS platform
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/current-entitlement-ios}
  */
 export const currentEntitlementIOS: QueryField<
   'currentEntitlementIOS'
@@ -122,6 +130,8 @@ export const currentEntitlementIOS: QueryField<
  * @throws Error if called on non-iOS platform
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/latest-transaction-ios}
  */
 export const latestTransactionIOS: QueryField<'latestTransactionIOS'> = async (
   sku,
@@ -141,6 +151,8 @@ export const latestTransactionIOS: QueryField<'latestTransactionIOS'> = async (
  * @throws Error if called on non-iOS platform
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios}
  */
 export const beginRefundRequestIOS: MutationField<
   'beginRefundRequestIOS'
@@ -160,6 +172,8 @@ export const beginRefundRequestIOS: MutationField<
  * @throws Error if called on non-iOS platform
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios}
  */
 export const showManageSubscriptionsIOS: MutationField<
   'showManageSubscriptionsIOS'
@@ -177,6 +191,8 @@ export const showManageSubscriptionsIOS: MutationField<
  * Apple's verifyReceipt endpoint, not directly from the app.
  *
  * @returns {Promise<string>} Base64 encoded receipt data
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios}
  */
 export const getReceiptDataIOS: QueryField<'getReceiptDataIOS'> = async () => {
   return ExpoIapModule.getReceiptDataIOS();
@@ -195,6 +211,8 @@ export const getReceiptIOS = getReceiptDataIOS;
  * @returns {Promise<string>} ISO 3166-1 alpha-2 country code (e.g. "US")
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-storefront-ios}
  */
 export const getStorefrontIOS: QueryField<'getStorefrontIOS'> = async () => {
   return ExpoIapModule.getStorefront();
@@ -224,6 +242,8 @@ export const requestReceiptRefreshIOS = async (): Promise<string> => {
  * @throws Error if called on non-iOS platform
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios}
  */
 export const isTransactionVerifiedIOS: QueryField<
   'isTransactionVerifiedIOS'
@@ -243,6 +263,8 @@ export const isTransactionVerifiedIOS: QueryField<
  * @throws Error if called on non-iOS platform
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios}
  */
 export const getTransactionJwsIOS: QueryField<'getTransactionJwsIOS'> = async (
   sku,
@@ -269,6 +291,8 @@ export const getTransactionJwsIOS: QueryField<'getTransactionJwsIOS'> = async (
  *   jwsRepresentation: string;
  *   latestTransaction?: Purchase;
  * }>}
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/validate-receipt-ios}
  */
 const validateReceiptIOSImpl = async (props: VerifyPurchaseProps | string) => {
   const sku =
@@ -298,6 +322,8 @@ export const validateReceiptIOS =
  * @throws Error if called on non-iOS platform or tvOS
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios}
  */
 export const presentCodeRedemptionSheetIOS: MutationField<
   'presentCodeRedemptionSheetIOS'
@@ -318,6 +344,8 @@ export const presentCodeRedemptionSheetIOS: MutationField<
  *
  * @platform iOS
  * @since iOS 16.0
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios}
  */
 export const getAppTransactionIOS: QueryField<
   'getAppTransactionIOS'
@@ -334,6 +362,8 @@ export const getAppTransactionIOS: QueryField<
  * @throws Error if called on non-iOS platform
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios}
  */
 export const getPromotedProductIOS: QueryField<
   'getPromotedProductIOS'
@@ -353,6 +383,8 @@ export const getPromotedProductIOS: QueryField<
  * @throws Error if called on non-iOS platform or no promoted product is available
  *
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios}
  */
 export const requestPurchaseOnPromotedProductIOS =
   async (): Promise<boolean> => {
@@ -365,6 +397,8 @@ export const requestPurchaseOnPromotedProductIOS =
  *
  * @returns Promise resolving to array of pending transactions
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios}
  */
 export const getPendingTransactionsIOS: QueryField<
   'getPendingTransactionsIOS'
@@ -373,6 +407,11 @@ export const getPendingTransactionsIOS: QueryField<
   return (transactions ?? []) as PurchaseIOS[];
 };
 
+/**
+ * List every StoreKit transaction (finished + unfinished) for the current user.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios}
+ */
 export const getAllTransactionsIOS: QueryField<
   'getAllTransactionsIOS'
 > = async () => {
@@ -385,6 +424,8 @@ export const getAllTransactionsIOS: QueryField<
  *
  * @returns Promise resolving when transaction is cleared
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/clear-transaction-ios}
  */
 export const clearTransactionIOS: MutationField<
   'clearTransactionIOS'
@@ -406,6 +447,8 @@ export const deepLinkToSubscriptionsIOS = (): Promise<void> =>
  *
  * @returns Promise resolving to true if the notice sheet can be presented
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios}
  */
 export const canPresentExternalPurchaseNoticeIOS: QueryField<
   'canPresentExternalPurchaseNoticeIOS'
@@ -420,6 +463,8 @@ export const canPresentExternalPurchaseNoticeIOS: QueryField<
  *
  * @returns Promise resolving to the result with action, token, and error if any
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios}
  */
 export const presentExternalPurchaseNoticeSheetIOS =
   async (): Promise<ExternalPurchaseNoticeResultIOS> => {
@@ -433,6 +478,8 @@ export const presentExternalPurchaseNoticeSheetIOS =
  * @param url - The external purchase URL to open
  * @returns Promise resolving to the result with success status and error if any
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios}
  */
 export const presentExternalPurchaseLinkIOS: MutationField<
   'presentExternalPurchaseLinkIOS'
@@ -448,6 +495,8 @@ export const presentExternalPurchaseLinkIOS: MutationField<
  * @returns Promise resolving to true if eligible
  * @platform iOS
  * @see https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios}
  */
 export const isEligibleForExternalPurchaseCustomLinkIOS =
   async (): Promise<boolean> => {
@@ -462,6 +511,8 @@ export const isEligibleForExternalPurchaseCustomLinkIOS =
  * @returns Promise resolving to the token result with token string or error
  * @platform iOS
  * @see https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios}
  */
 export const getExternalPurchaseCustomLinkTokenIOS = async (
   tokenType: ExternalPurchaseCustomLinkTokenTypeIOS,
@@ -486,6 +537,8 @@ export const getExternalPurchaseCustomLinkTokenIOS = async (
  * @returns Promise resolving to the result with continued status and error if any
  * @platform iOS
  * @see https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios}
  */
 export const showExternalPurchaseCustomLinkNoticeIOS = async (
   noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS,

--- a/libraries/expo-iap/src/modules/ios.ts
+++ b/libraries/expo-iap/src/modules/ios.ts
@@ -443,7 +443,11 @@ export const deepLinkToSubscriptionsIOS = (): Promise<void> =>
   Linking.openURL('https://apps.apple.com/account/subscriptions');
 
 /**
- * Check if the device can present an external purchase notice sheet (iOS 18.2+).
+ * Check if the device can present an external purchase notice sheet (iOS 17.4+).
+ *
+ * Wraps `ExternalPurchase.canPresent`, which Apple introduced in iOS 17.4.
+ * Note: the notice sheet itself (`presentExternalPurchaseNoticeSheetIOS`)
+ * still requires iOS 18.2+; only the eligibility check is available earlier.
  *
  * @returns Promise resolving to true if the notice sheet can be presented
  * @platform iOS

--- a/libraries/expo-iap/src/types.ts
+++ b/libraries/expo-iap/src/types.ts
@@ -746,7 +746,9 @@ export interface Mutation {
    */
   verifyPurchase: Promise<VerifyPurchaseResult>;
   /**
-   * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+   * Verify via a managed provider without standing up your own server. The
+   * PurchaseVerificationProvider enum currently exposes only IAPKit; platform
+   * availability may differ by implementation.
    * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
    */
   verifyPurchaseWithProvider: Promise<VerifyPurchaseWithProviderResult>;

--- a/libraries/expo-iap/src/types.ts
+++ b/libraries/expo-iap/src/types.ts
@@ -741,7 +741,11 @@ export interface Mutation {
    */
   validateReceipt: Promise<VerifyPurchaseResult>;
   /**
-   * Verify a purchase against your own backend (returns isValid + raw store metadata).
+   * Verify a purchase against your own backend. Returns a platform-specific
+   * variant of VerifyPurchaseResult — VerifyPurchaseResultIOS exposes isValid
+   * + receipt/JWS metadata, VerifyPurchaseResultAndroid carries Play Store
+   * receipt fields (no isValid), and VerifyPurchaseResultHorizon uses success.
+   * Inspect the concrete variant before reading fields.
    * See: https://www.openiap.dev/docs/features/validation#verify-purchase
    */
   verifyPurchase: Promise<VerifyPurchaseResult>;

--- a/libraries/expo-iap/src/types.ts
+++ b/libraries/expo-iap/src/types.ts
@@ -585,118 +585,170 @@ export interface LimitedQuantityInfoAndroid {
 }
 
 export interface Mutation {
-  /** Acknowledge a non-consumable purchase or subscription */
+  /**
+   * Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+   * See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
+   */
   acknowledgePurchaseAndroid: Promise<boolean>;
-  /** Initiate a refund request for a product (iOS 15+) */
+  /**
+   * Present the refund request sheet (iOS 15+). See also Features → Refund.
+   * See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
+   */
   beginRefundRequestIOS?: Promise<(string | null)>;
   /**
-   * Check if alternative billing is available for this user/device
-   * Step 1 of alternative billing flow
+   * Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
    *
-   * Returns true if available, false otherwise
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns true if available, false otherwise.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
    */
   checkAlternativeBillingAvailabilityAndroid: Promise<boolean>;
-  /** Clear pending transactions from the StoreKit payment queue */
+  /**
+   * Clear pending transactions in the queue (sandbox helper).
+   * See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
+   */
   clearTransactionIOS: Promise<boolean>;
-  /** Consume a purchase token so it can be repurchased */
+  /**
+   * Consume a consumable purchase so it can be re-bought.
+   * See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
+   */
   consumePurchaseAndroid: Promise<boolean>;
   /**
-   * Create external transaction token for Google Play reporting
-   * Step 3 of alternative billing flow
-   * Must be called AFTER successful payment in your payment system
-   * Token must be reported to Google Play backend within 24 hours
+   * Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
+   * Must be called AFTER successful payment in your payment system.
+   * Token must be reported to Google Play backend within 24 hours.
    *
-   * Returns token string, or null if creation failed
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns token string, or null if creation failed.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
    */
   createAlternativeBillingTokenAndroid?: Promise<(string | null)>;
   /**
-   * Create reporting details for a billing program
-   * Replaces the deprecated createExternalOfferReportingDetailsAsync API
+   * Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+   * Replaces the deprecated createExternalOfferReportingDetailsAsync API.
    *
-   * Available in Google Play Billing Library 8.2.0+
-   * Returns external transaction token needed for reporting external transactions
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns external transaction token needed for reporting external transactions.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
    */
   createBillingProgramReportingDetailsAndroid: Promise<BillingProgramReportingDetailsAndroid>;
-  /** Open the native subscription management surface */
+  /**
+   * Open the platform's subscription management UI.
+   * See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
+   */
   deepLinkToSubscriptions: Promise<void>;
-  /** Close the platform billing connection */
+  /**
+   * Close the store connection and release resources.
+   * See: https://www.openiap.dev/docs/apis/end-connection
+   */
   endConnection: Promise<boolean>;
-  /** Finish a transaction after validating receipts */
+  /**
+   * Complete a transaction after server-side verification. Required on Android within 3 days.
+   * See: https://www.openiap.dev/docs/apis/finish-transaction
+   */
   finishTransaction: Promise<void>;
-  /** Establish the platform billing connection */
+  /**
+   * Initialize the store connection. Call before any IAP API.
+   * See: https://www.openiap.dev/docs/apis/init-connection
+   */
   initConnection: Promise<boolean>;
   /**
-   * Check if a billing program is available for the current user
-   * Replaces the deprecated isExternalOfferAvailableAsync API
+   * Check whether a billing program (e.g., External Payments) is available for the current user.
+   * Replaces the deprecated isExternalOfferAvailableAsync API.
    *
-   * Available in Google Play Billing Library 8.2.0+
-   * Returns availability result with isAvailable flag
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Available in Google Play Billing Library 8.2.0+.
+   * Returns availability result with isAvailable flag.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
    */
   isBillingProgramAvailableAndroid: Promise<BillingProgramAvailabilityResultAndroid>;
   /**
-   * Launch external link flow for external billing programs
-   * Replaces the deprecated showExternalOfferInformationDialog API
+   * Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+   * Replaces the deprecated showExternalOfferInformationDialog API.
    *
-   * Available in Google Play Billing Library 8.2.0+
-   * Shows Play Store dialog and optionally launches external URL
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Shows Play Store dialog and optionally launches external URL.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
    */
   launchExternalLinkAndroid: Promise<boolean>;
-  /** Present the App Store code redemption sheet */
+  /**
+   * Show the App Store offer code redemption sheet.
+   * See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
+   */
   presentCodeRedemptionSheetIOS: Promise<boolean>;
-  /** Present external purchase custom link with StoreKit UI */
+  /**
+   * Present an external purchase link, StoreKit External (iOS 16+).
+   * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
+   */
   presentExternalPurchaseLinkIOS: Promise<ExternalPurchaseLinkResultIOS>;
   /**
-   * Present external purchase notice sheet (iOS 17.4+).
-   * Uses ExternalPurchase.presentNoticeSheet() which returns a token when user continues.
+   * Present the external purchase notice sheet (iOS 17.4+).
+   * Uses ExternalPurchase.presentNoticeSheet() which returns a token when the user continues.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()
+   * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
    */
   presentExternalPurchaseNoticeSheetIOS: Promise<ExternalPurchaseNoticeResultIOS>;
-  /** Initiate a purchase flow; rely on events for final state */
+  /**
+   * Initiate a purchase or subscription flow; rely on events for final state.
+   * See: https://www.openiap.dev/docs/apis/request-purchase
+   */
   requestPurchase?: Promise<(Purchase | Purchase[] | null)>;
   /**
-   * Purchase the promoted product surfaced by the App Store.
+   * Buy the currently promoted product.
    *
    * @deprecated Use promotedProductListenerIOS to receive the productId,
    * then call requestPurchase with that SKU instead. In StoreKit 2,
    * promoted products can be purchased directly via the standard purchase flow.
+   * See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
    * @deprecated Use promotedProductListenerIOS + requestPurchase instead
    */
   requestPurchaseOnPromotedProductIOS: Promise<boolean>;
-  /** Restore completed purchases across platforms */
+  /**
+   * Restore non-consumable and active subscription purchases.
+   * See: https://www.openiap.dev/docs/apis/restore-purchases
+   */
   restorePurchases: Promise<void>;
   /**
-   * Show alternative billing information dialog to user
-   * Step 2 of alternative billing flow
-   * Must be called BEFORE processing payment in your payment system
+   * Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
+   * Must be called BEFORE processing payment in your payment system.
    *
-   * Returns true if user accepted, false if user canceled
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns true if user accepted, false if user canceled.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
    */
   showAlternativeBillingDialogAndroid: Promise<boolean>;
   /**
-   * Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-   * Displays the system disclosure notice sheet for custom external purchase links.
+   * Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
    * Call this after a deliberate customer interaction before linking out to external purchases.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+   * See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
    */
   showExternalPurchaseCustomLinkNoticeIOS: Promise<ExternalPurchaseCustomLinkNoticeResultIOS>;
-  /** Open subscription management UI and return changed purchases (iOS 15+) */
+  /**
+   * Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
+   */
   showManageSubscriptionsIOS: Promise<PurchaseIOS[]>;
-  /** Force a StoreKit sync for transactions (iOS 15+) */
+  /**
+   * Force sync transactions with the App Store (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/sync-ios
+   */
   syncIOS: Promise<boolean>;
   /**
-   * Validate purchase receipts with the configured providers
+   * Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
+   * See: https://www.openiap.dev/docs/features/validation#verify-purchase
    * @deprecated Use verifyPurchase
    */
   validateReceipt: Promise<VerifyPurchaseResult>;
-  /** Verify purchases with the configured providers */
+  /**
+   * Verify a purchase against your own backend (returns isValid + raw store metadata).
+   * See: https://www.openiap.dev/docs/features/validation#verify-purchase
+   */
   verifyPurchase: Promise<VerifyPurchaseResult>;
-  /** Verify purchases with a specific provider (e.g., IAPKit) */
+  /**
+   * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+   * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
+   */
   verifyPurchaseWithProvider: Promise<VerifyPurchaseWithProviderResult>;
 }
 
@@ -1234,66 +1286,117 @@ export type PurchaseVerificationProvider = 'iapkit';
 
 export interface Query {
   /**
-   * Check if external purchase notice sheet can be presented (iOS 17.4+)
-   * Uses ExternalPurchase.canPresent
+   * Check eligibility for the external purchase notice sheet (iOS 17.4+).
+   * Uses ExternalPurchase.canPresent.
+   * See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
    */
   canPresentExternalPurchaseNoticeIOS: Promise<boolean>;
-  /** Get current StoreKit 2 entitlements (iOS 15+) */
+  /**
+   * Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
+   */
   currentEntitlementIOS?: Promise<(PurchaseIOS | null)>;
-  /** Retrieve products or subscriptions from the store */
+  /**
+   * Fetch products or subscriptions from the store.
+   * See: https://www.openiap.dev/docs/apis/fetch-products
+   */
   fetchProducts: Promise<(ProductOrSubscription[] | Product[] | ProductSubscription[] | null)>;
-  /** Get active subscriptions (filters by subscriptionIds when provided) */
+  /**
+   * Get details of all currently active subscriptions (filters by subscriptionIds when provided).
+   * See: https://www.openiap.dev/docs/apis/get-active-subscriptions
+   */
   getActiveSubscriptions: Promise<ActiveSubscription[]>;
   /**
-   * Get the full StoreKit 2 transaction history as PurchaseIOS values.
+   * List every StoreKit transaction (finished + unfinished) for the current user.
    * Requires the SK2ConsumableTransactionHistory Info.plist key in the host app
    * for finished consumables to be included (iOS 18+).
    * Unlike getAvailablePurchases, always returns the iOS-specific PurchaseIOS shape.
+   * See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
    */
   getAllTransactionsIOS: Promise<PurchaseIOS[]>;
-  /** Fetch the current app transaction (iOS 16+) */
+  /**
+   * Fetch the app transaction (iOS 16+).
+   * See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
+   */
   getAppTransactionIOS?: Promise<(AppTransaction | null)>;
-  /** Get all available purchases for the current user */
+  /**
+   * List active purchases for the current user.
+   * See: https://www.openiap.dev/docs/apis/get-available-purchases
+   */
   getAvailablePurchases: Promise<Purchase[]>;
   /**
-   * Get external purchase token for reporting to Apple (iOS 18.1+).
-   * Use this token with Apple's External Purchase Server API to report transactions.
+   * Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+   * Use this token to report transactions made through ExternalPurchaseCustomLink.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+   * See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
    */
   getExternalPurchaseCustomLinkTokenIOS: Promise<ExternalPurchaseCustomLinkTokenResultIOS>;
-  /** Retrieve all pending transactions in the StoreKit queue */
+  /**
+   * List unfinished StoreKit transactions in the queue.
+   * See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
+   */
   getPendingTransactionsIOS: Promise<PurchaseIOS[]>;
-  /** Get the currently promoted product (iOS 11+) */
+  /**
+   * Read the App Store-promoted product, if any (iOS 11+).
+   * See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
+   */
   getPromotedProductIOS?: Promise<(ProductIOS | null)>;
-  /** Get base64-encoded receipt data for validation */
+  /**
+   * Get base64-encoded receipt data (legacy validation).
+   * See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
+   */
   getReceiptDataIOS?: Promise<(string | null)>;
-  /** Get the current storefront country code */
+  /**
+   * Return the user's storefront country code.
+   * See: https://www.openiap.dev/docs/apis/get-storefront
+   */
   getStorefront: Promise<string>;
   /**
-   * Get the current App Store storefront country code
+   * Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
+   * See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
    * @deprecated Use getStorefront
    */
   getStorefrontIOS: Promise<string>;
-  /** Get the transaction JWS (StoreKit 2) */
+  /**
+   * Return the JWS string for a transaction (StoreKit 2).
+   * See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
+   */
   getTransactionJwsIOS?: Promise<(string | null)>;
-  /** Check whether the user has active subscriptions */
+  /**
+   * Check whether the user has any active subscription.
+   * See: https://www.openiap.dev/docs/apis/has-active-subscriptions
+   */
   hasActiveSubscriptions: Promise<boolean>;
   /**
-   * Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+   * Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
    * Returns true if the app can use custom external purchase links.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+   * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
    */
   isEligibleForExternalPurchaseCustomLinkIOS: Promise<boolean>;
-  /** Check introductory offer eligibility for a subscription group */
+  /**
+   * Check intro-offer eligibility for a subscription group.
+   * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
+   */
   isEligibleForIntroOfferIOS: Promise<boolean>;
-  /** Verify a StoreKit 2 transaction signature */
+  /**
+   * Check whether a transaction's JWS verification passed (StoreKit 2).
+   * See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
+   */
   isTransactionVerifiedIOS: Promise<boolean>;
-  /** Get the latest transaction for a product using StoreKit 2 */
+  /**
+   * Get the latest verified transaction for a product, using StoreKit 2.
+   * See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
+   */
   latestTransactionIOS?: Promise<(PurchaseIOS | null)>;
-  /** Get StoreKit 2 subscription status details (iOS 15+) */
+  /**
+   * Get subscription status objects from StoreKit 2 (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
+   */
   subscriptionStatusIOS: Promise<SubscriptionStatusIOS[]>;
   /**
-   * Validate a receipt for a specific product
+   * Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
+   * See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
    * @deprecated Use verifyPurchase
    */
   validateReceiptIOS: Promise<VerifyPurchaseResultIOS>;

--- a/libraries/expo-iap/src/useIAP.ts
+++ b/libraries/expo-iap/src/useIAP.ts
@@ -259,7 +259,8 @@ export function useIAP(options?: UseIAPOptions): UseIap {
    *   (`'in-app' | 'subs' | 'all'`, defaults to `'in-app'`).
    * @returns Promise that resolves when the request is dispatched; results land in the
    *   hook's reactive `products` / `subscriptions` state.
-   * @throws When the store rejects the request (unknown SKU, network, not connected).
+   * @throws When the store rejects the request (empty `skus`, not connected,
+   *   network/store error). Unknown SKUs are simply omitted from the result, not thrown.
    *
    * @example
    * ```ts

--- a/libraries/expo-iap/src/useIAP.ts
+++ b/libraries/expo-iap/src/useIAP.ts
@@ -588,7 +588,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   }, []);
 
   /**
-   * Verify via a managed provider (IAPKit, Apple, Google, Horizon).
+   * Verify via a managed provider (currently IAPKit; the PurchaseVerificationProvider enum exposes only Iapkit today).
    *
    * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider}
    */

--- a/libraries/expo-iap/src/useIAP.ts
+++ b/libraries/expo-iap/src/useIAP.ts
@@ -588,7 +588,7 @@ export function useIAP(options?: UseIAPOptions): UseIap {
   }, []);
 
   /**
-   * Verify via a managed provider (currently IAPKit; the PurchaseVerificationProvider enum exposes only Iapkit today).
+   * Verify via a managed provider — currently only `iapkit` (IAPKit). The PurchaseVerificationProvider enum exposes no other provider literal today.
    *
    * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider}
    */

--- a/libraries/expo-iap/src/useIAP.ts
+++ b/libraries/expo-iap/src/useIAP.ts
@@ -252,6 +252,29 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     }
   }, []);
 
+  /**
+   * Retrieve products or subscriptions from the store by SKU.
+   *
+   * @param params `ProductRequest` — `skus` (string[]) and optional `type`
+   *   (`'in-app' | 'subs' | 'all'`, defaults to `'in-app'`).
+   * @returns Promise that resolves when the request is dispatched; results land in the
+   *   hook's reactive `products` / `subscriptions` state.
+   * @throws When the store rejects the request (unknown SKU, network, not connected).
+   *
+   * @example
+   * ```ts
+   * const { fetchProducts, products } = useIAP();
+   * await fetchProducts({
+   *   skus: ['com.app.coins_100', 'com.app.premium'],
+   *   type: 'in-app',
+   * });
+   * ```
+   *
+   * @remarks This is a regular promise-based call. Don't confuse with `request*` APIs
+   *   (`requestPurchase`), which are event-based.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/fetch-products}
+   */
   const fetchProductsInternal = useCallback(
     async (params: {
       skus: string[];
@@ -349,6 +372,27 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     ],
   );
 
+  /**
+   * List the user's unfinished purchases — non-consumables, active subscriptions, and any
+   * pending transactions not yet finished.
+   *
+   * @param options Optional `PurchaseOptions`. iOS-only flags:
+   *   `alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`.
+   * @returns Promise that resolves when the request is dispatched; results land in the
+   *   hook's reactive `availablePurchases` state.
+   * @throws When the platform query fails.
+   *
+   * @example
+   * ```ts
+   * const { getAvailablePurchases, availablePurchases } = useIAP();
+   * await getAvailablePurchases();
+   * for (const p of availablePurchases) {
+   *   if (await verifyOnServer(p)) await finishTransaction({ purchase: p, isConsumable: false });
+   * }
+   * ```
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/get-available-purchases}
+   */
   const getAvailablePurchasesInternal = useCallback(
     async (options?: PurchaseOptions): Promise<void> => {
       try {
@@ -368,6 +412,11 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     [invokeOnError],
   );
 
+  /**
+   * Get details of all currently active subscriptions.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/get-active-subscriptions}
+   */
   const getActiveSubscriptionsInternal = useCallback(
     async (subscriptionIds?: string[]): Promise<void> => {
       try {
@@ -382,6 +431,11 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     [invokeOnError],
   );
 
+  /**
+   * Check whether the user has any active subscription.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/has-active-subscriptions}
+   */
   const hasActiveSubscriptionsInternal = useCallback(
     async (subscriptionIds?: string[]): Promise<boolean> => {
       try {
@@ -394,6 +448,29 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     [],
   );
 
+  /**
+   * Complete a purchase transaction. Call after server-side verification to remove it
+   * from the queue.
+   *
+   * @param args.purchase The `Purchase` to finalize.
+   * @param args.isConsumable `true` for consumables (consumes the token so the SKU can be
+   *   re-bought, e.g. coins); `false` (default) for non-consumables and subscriptions.
+   * @returns Promise that resolves once the platform finalizes the transaction.
+   * @throws When the platform finalize call fails.
+   *
+   * @example
+   * ```ts
+   * // Inside purchaseUpdatedListener:
+   * if (await verifyOnServer(purchase)) {
+   *   await finishTransaction({ purchase, isConsumable: false });
+   * }
+   * ```
+   *
+   * @remarks **Critical:** Android purchases must be finalized within 3 days or Google
+   *   auto-refunds. iOS unfinished transactions replay on every app launch.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/finish-transaction}
+   */
   const finishTransaction = useCallback(
     async ({
       purchase,
@@ -410,6 +487,33 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     [toPurchaseInput],
   );
 
+  /**
+   * Initiate a purchase or subscription flow. The result is delivered through
+   * `purchaseUpdatedListener` — NOT the return value.
+   *
+   * @param props `RequestPurchaseProps`, discriminated by `type`:
+   *   - `type: 'in-app'` — pass `request.apple.sku` (iOS) and/or `request.google.skus` (Android).
+   *   - `type: 'subs'`  — same shape, plus `request.google.subscriptionOffers: [{ sku, offerToken }]`.
+   * @returns Promise that resolves when the request is dispatched; the actual purchase
+   *   outcome lands in the hook's `onPurchaseSuccess` / `onPurchaseError` callbacks.
+   * @throws Synchronous rejection from the store (e.g. `E_NOT_PREPARED`, validation failure).
+   *
+   * @example
+   * ```ts
+   * await requestPurchase({
+   *   request: {
+   *     apple: { sku: 'com.app.premium' },
+   *     google: { skus: ['com.app.premium'] },
+   *   },
+   *   type: 'in-app',
+   * });
+   * ```
+   *
+   * @remarks Event-based. Listen for the result via {@link purchaseUpdatedListener} /
+   *   {@link purchaseErrorListener}, or use `useIAP({ onPurchaseSuccess, onPurchaseError })`.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/request-purchase}
+   */
   const requestPurchaseWithReset = useCallback(
     (requestObj: MutationRequestPurchaseArgs) => {
       return requestPurchaseInternal(requestObj);
@@ -436,9 +540,11 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     ],
   );
 
-  // Restore completed transactions with cross-platform behavior.
-  // iOS: best-effort sync (ignore sync errors) then fetch available purchases.
-  // Android: fetch available purchases directly.
+  /**
+   * Restore non-consumable and active subscription purchases.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/restore-purchases}
+   */
   const restorePurchasesInternal = useCallback(
     async (options?: PurchaseOptions): Promise<void> => {
       try {
@@ -463,14 +569,29 @@ export function useIAP(options?: UseIAPOptions): UseIap {
     [invokeOnError],
   );
 
+  /**
+   * Deprecated. Use verifyPurchase instead — same input/output shape.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/validate-receipt}
+   */
   const validateReceipt = useCallback(async (props: VerifyPurchaseProps) => {
     return validateReceiptInternal(props);
   }, []);
 
+  /**
+   * Verify a purchase against your own backend (returns isValid + raw store metadata).
+   *
+   * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase}
+   */
   const verifyPurchase = useCallback(async (props: VerifyPurchaseProps) => {
     return verifyPurchaseInternal(props);
   }, []);
 
+  /**
+   * Verify via a managed provider (IAPKit, Apple, Google, Horizon).
+   *
+   * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider}
+   */
   const verifyPurchaseWithProvider = useCallback(
     async (props: VerifyPurchaseWithProviderProps) => {
       return verifyPurchaseWithProviderInternal(props);

--- a/libraries/flutter_inapp_purchase/lib/flutter_inapp_purchase.dart
+++ b/libraries/flutter_inapp_purchase/lib/flutter_inapp_purchase.dart
@@ -246,7 +246,22 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
     });
   }
 
-  /// Initialize connection (flutter IAP compatible)
+  /// Initialize the store connection. Must be called before any other IAP API.
+  ///
+  /// Parameters:
+  /// - `alternativeBillingModeAndroid`: Android-only — opt into Google's alternative
+  ///   billing flow (deprecated; prefer `enableBillingProgramAndroid`).
+  /// - `enableBillingProgramAndroid`: Android-only — Play Billing 8.2.0+ billing program
+  ///   (e.g. External Payments). iOS ignores both fields.
+  ///
+  /// Returns `true` once the platform billing client is connected.
+  /// Throws when the billing client fails to initialize.
+  ///
+  /// ```dart
+  /// await FlutterInappPurchase.instance.initConnection();
+  /// ```
+  ///
+  /// See: https://www.openiap.dev/docs/apis/init-connection
   gentype.MutationInitConnectionHandler get initConnection => ({
         gentype.AlternativeBillingModeAndroid? alternativeBillingModeAndroid,
         gentype.BillingProgramAndroid? enableBillingProgramAndroid,
@@ -289,7 +304,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// End connection (flutter IAP compatible)
+  /// Close the store connection and release resources.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/end-connection
   gentype.MutationEndConnectionHandler get endConnection => () async {
         if (!_isInitialized) {
           return false;
@@ -314,7 +331,32 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// Request purchase (flutter IAP compatible)
+  /// Initiate a purchase or subscription flow. The result is delivered via the
+  /// `purchaseUpdated` stream — NOT the return value.
+  ///
+  /// Parameters:
+  /// - `params`: `RequestPurchaseProps`, discriminated by `type`. Pass platform fields
+  ///   via `request.apple` (iOS sku) and `request.google` (skus, subscriptionOffers).
+  ///
+  /// Returns the dispatched purchase payload. **Do not rely on it** for the outcome.
+  /// Throws on synchronous rejection (e.g. billing not ready, missing offerToken on subs).
+  ///
+  /// ```dart
+  /// await FlutterInappPurchase.instance.requestPurchase(
+  ///   RequestPurchaseProps(
+  ///     request: RequestPurchasePropsByPlatforms(
+  ///       apple: RequestPurchaseIosProps(sku: 'com.app.premium'),
+  ///       google: RequestPurchaseAndroidProps(skus: ['com.app.premium']),
+  ///     ),
+  ///     type: ProductQueryType.InApp,
+  ///   ),
+  /// );
+  /// ```
+  ///
+  /// **Warning:** Event-based. Subscribe to `purchaseUpdated` / `purchaseError` for
+  /// the actual outcome.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/request-purchase
   @override
   gentype.MutationRequestPurchaseHandler get requestPurchase => (params) async {
         if (!_isInitialized) {
@@ -536,14 +578,33 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
   /// DSL-like request subscription method with builder pattern
   // requestSubscriptionWithBuilder removed in 6.6.0 (use requestPurchaseWithBuilder)
 
-  /// Get all available purchases (OpenIAP standard)
-  /// Returns non-consumed purchases that are still pending acknowledgment or consumption
+  /// List the user's unfinished purchases — non-consumables, active subscriptions, and
+  /// any pending transactions not yet finished.
   ///
-  /// [options] - Optional configuration for the method behavior
-  /// - onlyIncludeActiveItemsIOS: Whether to only include active items (default: true)
-  ///   Set to false to include expired subscriptions
-  /// - includeSuspendedAndroid: Include suspended subscriptions (Android 8.1+, default: false)
-  ///   Suspended subscriptions have isSuspendedAndroid=true and should NOT be granted entitlements.
+  /// Parameters:
+  /// - `alsoPublishToEventListenerIOS`: iOS-only — also emit results to the
+  ///   `purchaseUpdated` event listener.
+  /// - `includeSuspendedAndroid`: Android-only — include suspended subscriptions in the
+  ///   result.
+  /// - `onlyIncludeActiveItemsIOS`: iOS-only — when `true` (default), excludes expired
+  ///   subscriptions from the result.
+  ///
+  /// Returns a list of `Purchase` currently held by the store.
+  /// Throws when the platform query fails.
+  ///
+  /// ```dart
+  /// final purchases = await FlutterInappPurchase.instance.getAvailablePurchases();
+  /// for (final p in purchases) {
+  ///   if (await verifyOnServer(p)) {
+  ///     await FlutterInappPurchase.instance.finishTransaction(
+  ///       purchase: p,
+  ///       isConsumable: false,
+  ///     );
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// See: https://www.openiap.dev/docs/apis/get-available-purchases
   gentype.QueryGetAvailablePurchasesHandler get getAvailablePurchases => ({
         bool? alsoPublishToEventListenerIOS,
         bool? includeSuspendedAndroid,
@@ -638,7 +699,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// Get the current storefront country code (unified method)
+  /// Return the user's storefront country code.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/get-storefront
   gentype.QueryGetStorefrontHandler get getStorefront => () async {
         if (!isIOS && !_platform.isAndroid) {
           return '';
@@ -662,7 +725,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// iOS specific: Get storefront
+  /// Deprecated. Use cross-platform `getStorefront` instead.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
   gentype.QueryGetStorefrontIOSHandler get getStorefrontIOS => () async {
         if (!_platform.isIOS || _platform.isMacOS) {
           throw PurchaseError(
@@ -696,6 +761,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
+  /// Force sync transactions with the App Store.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/sync-ios
   gentype.MutationSyncIOSHandler get syncIOS => () async {
         if (!_platform.isIOS || _platform.isMacOS) {
           debugPrint('syncIOS is only supported on iOS');
@@ -717,6 +785,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
+  /// Check intro-offer eligibility for a subscription group.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
   gentype.QueryIsEligibleForIntroOfferIOSHandler
       get isEligibleForIntroOfferIOS => (groupId) async {
             if (!_platform.isIOS || _platform.isMacOS) {
@@ -735,6 +806,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             }
           };
 
+  /// Get subscription status objects from StoreKit 2.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
   gentype.QuerySubscriptionStatusIOSHandler get subscriptionStatusIOS =>
       (sku) async {
         if (!_platform.isIOS || _platform.isMacOS) {
@@ -778,6 +852,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
+  /// Clear pending transactions in the queue (sandbox helper).
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
   gentype.MutationClearTransactionIOSHandler get clearTransactionIOS =>
       () async {
         if (!_platform.isIOS || _platform.isMacOS) {
@@ -793,6 +870,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
+  /// Read the App Store-promoted product, if any.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
   gentype.QueryGetPromotedProductIOSHandler get getPromotedProductIOS =>
       () async {
         if (!_platform.isIOS || _platform.isMacOS) {
@@ -826,26 +906,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// Request purchase on promoted product (iOS only)
+  /// Buy the currently promoted product.
   ///
-  /// @deprecated Use `purchasePromoted` stream to receive the product ID when a
-  /// user taps a promoted product in the App Store, then call `requestPurchase()`
-  /// with the received SKU directly. In StoreKit 2, promoted products can be
-  /// purchased via the standard `requestPurchase()` flow.
-  ///
-  /// Example:
-  /// ```dart
-  /// iap.purchasePromoted.listen((productId) async {
-  ///   if (productId != null) {
-  ///     await iap.requestPurchaseWithBuilder(
-  ///       build: (builder) {
-  ///         builder.ios.sku = productId;
-  ///         builder.type = ProductQueryType.InApp;
-  ///       },
-  ///     );
-  ///   }
-  /// });
-  /// ```
+  /// See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
   @Deprecated(
     'Use purchasePromoted stream + requestPurchase() instead. '
     'In StoreKit 2, promoted products are purchased via standard flow.',
@@ -866,6 +929,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             }
           };
 
+  /// Fetch the app transaction (iOS 16+).
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
   gentype.QueryGetAppTransactionIOSHandler get getAppTransactionIOS =>
       () async {
         if (!_platform.isIOS || _platform.isMacOS) {
@@ -890,7 +956,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// iOS specific: Present code redemption sheet
+  /// Show the App Store offer code redemption sheet.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
   gentype.MutationPresentCodeRedemptionSheetIOSHandler
       get presentCodeRedemptionSheetIOS => () async {
             if (!_platform.isIOS || _platform.isMacOS) {
@@ -919,11 +987,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             }
           };
 
-  /// iOS specific: Begin a refund request for a purchase
+  /// Present the refund request sheet (iOS 15+).
   ///
-  /// Opens the StoreKit 2 refund sheet for the given SKU and returns the
-  /// resulting status string (`"success"` or `"userCancelled"`). Returns
-  /// `null` when StoreKit reports an unknown status. Requires iOS 15.0+.
+  /// See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
   gentype.MutationBeginRefundRequestIOSHandler get beginRefundRequestIOS =>
       (String sku) async {
         if (!_platform.isIOS || _platform.isMacOS) {
@@ -953,7 +1019,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// iOS specific: Show manage subscriptions
+  /// Present the manage-subscriptions sheet.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
   gentype.MutationShowManageSubscriptionsIOSHandler
       get showManageSubscriptionsIOS => () async {
             if (!_platform.isIOS || _platform.isMacOS) {
@@ -983,6 +1051,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
 
   // Original API methods (with deprecation annotations where needed)
 
+  /// List unfinished StoreKit transactions.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
   gentype.QueryGetPendingTransactionsIOSHandler get getPendingTransactionsIOS =>
       () async {
         if (_platform.isIOS || _platform.isMacOS) {
@@ -1003,6 +1074,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         return const <gentype.PurchaseIOS>[];
       };
 
+  /// List every StoreKit transaction (finished + unfinished) for the current user.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
   gentype.QueryGetAllTransactionsIOSHandler get getAllTransactionsIOS =>
       () async {
         if (_platform.isIOS || _platform.isMacOS) {
@@ -1023,7 +1097,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         return const <gentype.PurchaseIOS>[];
       };
 
-  /// iOS specific: Return the current active entitlement for a SKU, if any.
+  /// Get the user's current entitlement for a product.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
   gentype.QueryCurrentEntitlementIOSHandler get currentEntitlementIOS =>
       (String sku) async {
         if (!_platform.isIOS || _platform.isMacOS) {
@@ -1057,8 +1133,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// iOS specific: Return the most recent transaction for a SKU, including
-  /// expired or revoked ones.
+  /// Get the latest verified transaction for a product.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
   gentype.QueryLatestTransactionIOSHandler get latestTransactionIOS =>
       (String sku) async {
         if (!_platform.isIOS || _platform.isMacOS) {
@@ -1092,8 +1169,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// iOS specific: Whether the latest transaction for a SKU passes StoreKit 2
-  /// verification.
+  /// Check whether a transaction's JWS verification passed.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
   gentype.QueryIsTransactionVerifiedIOSHandler get isTransactionVerifiedIOS =>
       (String sku) async {
         if (!_platform.isIOS || _platform.isMacOS) {
@@ -1119,8 +1197,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// iOS specific: Return the signed JWS representation of the latest
-  /// transaction for a SKU, suitable for server-side verification.
+  /// Return the JWS string for a transaction.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
   gentype.QueryGetTransactionJwsIOSHandler get getTransactionJwsIOS =>
       (String sku) async {
         if (!_platform.isIOS || _platform.isMacOS) {
@@ -1145,8 +1224,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// iOS specific: Return the base64-encoded App Store receipt data (legacy
-  /// StoreKit 1 API). Use JWS-based verification for StoreKit 2.
+  /// Get base64 receipt data (legacy validation).
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
   gentype.QueryGetReceiptDataIOSHandler get getReceiptDataIOS => () async {
         if (!_platform.isIOS || _platform.isMacOS) {
           return null;
@@ -1167,10 +1247,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// iOS 17.4+: Whether the current device/region can present the external
-  /// purchase notice sheet. The underlying StoreKit call
-  /// `ExternalPurchase.canPresent` is available from iOS 17.4 / macOS 14.4 /
-  /// tvOS 17.4 / visionOS 1.1 — older runtimes return false.
+  /// Check eligibility for the external purchase notice sheet (iOS 17.4+).
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
   gentype.QueryCanPresentExternalPurchaseNoticeIOSHandler
       get canPresentExternalPurchaseNoticeIOS => () async {
             if (!_platform.isIOS || _platform.isMacOS) {
@@ -1196,6 +1275,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             }
           };
 
+  /// Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
   gentype.MutationAcknowledgePurchaseAndroidHandler
       get acknowledgePurchaseAndroid => (purchaseToken) async {
             if (!_platform.isAndroid) {
@@ -1247,6 +1329,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             }
           };
 
+  /// Consume a consumable purchase so it can be re-bought.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
   gentype.MutationConsumePurchaseAndroidHandler get consumePurchaseAndroid =>
       (purchaseToken) async {
         if (!_platform.isAndroid) {
@@ -1280,6 +1365,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
+  /// Open the platform's subscription management UI.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
   gentype.MutationDeepLinkToSubscriptionsHandler get deepLinkToSubscriptions =>
       ({String? packageNameAndroid, String? skuAndroid}) async {
         if (!_platform.isAndroid) {
@@ -1303,7 +1391,27 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         await _channel.invokeMethod('deepLinkToSubscriptionsAndroid', args);
       };
 
-  /// Finish a transaction using OpenIAP generated handler signature
+  /// Complete a purchase transaction. Call after server-side verification to remove
+  /// it from the queue.
+  ///
+  /// Parameters:
+  /// - `purchase` (required): the `Purchase` to finalize.
+  /// - `isConsumable`: `true` for consumables (re-buyable like coins); `false` (default)
+  ///   for non-consumables and subscriptions.
+  ///
+  /// Throws when the platform finalize call fails.
+  ///
+  /// ```dart
+  /// await FlutterInappPurchase.instance.finishTransaction(
+  ///   purchase: purchase,
+  ///   isConsumable: false,
+  /// );
+  /// ```
+  ///
+  /// **Critical:** Android purchases must be finalized within 3 days or Google
+  /// auto-refunds. iOS unfinished transactions replay on every app launch.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/finish-transaction
   gentype.MutationFinishTransactionHandler get finishTransaction =>
       ({required gentype.Purchase purchase, bool? isConsumable}) async {
         final bool consumable = isConsumable ?? false;
@@ -1453,44 +1561,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         );
       };
 
-  /// Validate receipt using StoreKit 2 (iOS only) - LOCAL TESTING ONLY
+  /// Deprecated. Legacy App Store receipt validation. Use `verifyPurchase` instead.
   ///
-  /// ⚠️ WARNING: This performs LOCAL validation for TESTING purposes.
-  /// For production, send the JWS representation to your server for validation.
-  ///
-  /// What this method does:
-  /// 1. Performs local on-device validation (for testing)
-  /// 2. Returns JWS representation (send this to your server)
-  /// 3. Provides transaction details for debugging
-  ///
-  /// Server-side validation guide:
-  /// 1. Send `result.jwsRepresentation` to your server
-  /// 2. Verify the JWS using Apple's public keys
-  /// 3. Decode and validate the transaction on your server
-  /// 4. Grant entitlements based on server validation
-  ///
-  /// Example for LOCAL TESTING:
-  /// ```dart
-  /// // Step 1: Local validation (testing only)
-  /// final result = await FlutterInappPurchase.instance.validateReceiptIOS(
-  ///   apple: VerifyPurchaseAppleOptions(sku: 'com.example.premium'),
-  /// );
-  ///
-  /// if (result.isValid) {
-  ///   print('Local validation passed (TEST ONLY)');
-  ///
-  ///   // Step 2: Send to your server for PRODUCTION validation
-  ///   final serverPayload = {
-  ///     'purchaseToken': result.purchaseToken,  // Unified field (JWS for iOS)
-  ///     'productId': 'com.example.premium',
-  ///   };
-  ///
-  ///   // await yourApi.validateOnServer(serverPayload);
-  ///   print('Send purchaseToken to your server for production validation');
-  /// }
-  /// ```
-  ///
-  /// Note: This method requires iOS 15.0+ for StoreKit 2 support.
+  /// See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
   gentype.QueryValidateReceiptIOSHandler get validateReceiptIOS => ({
         gentype.VerifyPurchaseAppleOptions? apple,
         gentype.VerifyPurchaseGoogleOptions? google,
@@ -1572,6 +1645,10 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
           );
         }
       };
+
+  /// Deprecated. Use verifyPurchase instead — same input/output shape.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/validate-receipt
   gentype.MutationValidateReceiptHandler get validateReceipt => ({
         gentype.VerifyPurchaseAppleOptions? apple,
         gentype.VerifyPurchaseGoogleOptions? google,
@@ -1599,26 +1676,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         );
       };
 
-  /// Verify purchase with an external provider (IAPKit)
+  /// Verify via a managed provider (IAPKit, Apple, Google, Horizon).
   ///
-  /// This method allows you to verify purchases using external verification
-  /// providers like IAPKit. It sends the purchase receipt to the provider
-  /// for server-side verification.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = await FlutterInappPurchase.instance.verifyPurchaseWithProvider(
-  ///   provider: PurchaseVerificationProvider.Iapkit,
-  ///   iapkit: RequestVerifyPurchaseWithIapkitProps(
-  ///     apiKey: 'your-iapkit-api-key',
-  ///     apple: RequestVerifyPurchaseWithIapkitAppleProps(jws: purchase.jws),
-  ///     // or for Android:
-  ///     // google: RequestVerifyPurchaseWithIapkitGoogleProps(
-  ///     //   purchaseToken: purchase.purchaseToken,
-  ///     // ),
-  ///   ),
-  /// );
-  /// ```
+  /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
   gentype.MutationVerifyPurchaseWithProviderHandler
       get verifyPurchaseWithProvider => ({
             required gentype.PurchaseVerificationProvider provider,
@@ -1726,33 +1786,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             }
           };
 
-  /// Verifies a purchase using the native platform's local verification.
+  /// Verify a purchase against your own backend (returns isValid + raw store metadata).
   ///
-  /// On iOS, this verifies the transaction using StoreKit 2's built-in
-  /// verification. On Android, this requires providing Google Play Developer
-  /// API credentials via [google].
-  ///
-  /// Example (iOS):
-  /// ```dart
-  /// final result = await iap.verifyPurchase(
-  ///   apple: VerifyPurchaseAppleOptions(sku: 'premium_upgrade'),
-  /// );
-  /// if (result is VerifyPurchaseResultIOS && result.isValid) {
-  ///   // Purchase verified locally
-  /// }
-  /// ```
-  ///
-  /// Example (Android):
-  /// ```dart
-  /// final result = await iap.verifyPurchase(
-  ///   google: VerifyPurchaseGoogleOptions(
-  ///     sku: 'premium_upgrade',
-  ///     accessToken: 'your-google-access-token', // From your backend
-  ///     packageName: 'com.your.app',
-  ///     purchaseToken: purchase.purchaseToken,
-  ///   ),
-  /// );
-  /// ```
+  /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
   gentype.MutationVerifyPurchaseHandler get verifyPurchase => ({
         gentype.VerifyPurchaseAppleOptions? apple,
         gentype.VerifyPurchaseGoogleOptions? google,
@@ -1944,24 +1980,31 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
     }
   }
 
-  /// Fetch products from the store
+  /// Retrieve products or subscriptions from the store by SKU.
   ///
-  /// When type is InApp, returns List<Product>
-  /// When type is Subs, returns List<ProductSubscription>
-  /// When type is All, returns List<ProductCommon>
+  /// Parameters:
+  /// - `skus` (required): list of product identifiers to fetch.
+  /// - `type`: `ProductQueryType.InApp`, `Subs`, or `All`. Defaults to `InApp`.
   ///
-  /// Example:
+  /// Returns a `List<T>` cast to the generic type — pass `<Product>` for one-time
+  /// items, `<ProductSubscription>` for subs, or `<ProductCommon>` for mixed `All`
+  /// queries.
+  /// Throws when the store rejects the request.
+  ///
   /// ```dart
-  /// final products = await iap.fetchProducts<Product>(
-  ///   skus: ['product_id'],
+  /// final products = await FlutterInappPurchase.instance.fetchProducts<Product>(
+  ///   skus: ['com.app.premium'],
   ///   type: ProductQueryType.InApp,
-  /// ); // Type: List<Product>
-  ///
-  /// final subs = await iap.fetchProducts<ProductSubscription>(
-  ///   skus: ['sub_id'],
-  ///   type: ProductQueryType.Subs,
-  /// ); // Type: List<ProductSubscription>
+  /// );
+  /// for (final product in products) {
+  ///   print('${product.title}: ${product.displayPrice}');
+  /// }
   /// ```
+  ///
+  /// **Note:** This is a regular promise-based call. Don't confuse with `request*`
+  /// APIs (e.g. `requestPurchase`), which are event-based.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/fetch-products
   Future<List<T>> fetchProducts<T extends gentype.ProductCommon>({
     required List<String> skus,
     gentype.ProductQueryType type = gentype.ProductQueryType.InApp,
@@ -1972,6 +2015,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
 
   // MARK: - StoreKit 2 specific methods
 
+  /// Restore non-consumable and active subscription purchases.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/restore-purchases
   gentype.MutationRestorePurchasesHandler get restorePurchases => () async {
         try {
           if (_platform.isIOS || _platform.isMacOS) {
@@ -2071,15 +2117,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
     return subscriptions;
   }
 
-  /// Get all active subscriptions with detailed information (OpenIAP compliant)
-  /// Returns an array of active subscriptions. If subscriptionIds is not provided,
-  /// returns all active subscriptions. Platform-specific fields are populated based
-  /// on the current platform.
+  /// Get details of all currently active subscriptions.
   ///
-  /// This uses the native getActiveSubscriptions method on both platforms:
-  /// - iOS: includes renewalInfoIOS with subscription renewal status, pending
-  ///   upgrades/downgrades, cancellation status, and auto-renewal preferences
-  /// - Android: includes autoRenewingAndroid and other subscription details
+  /// See: https://www.openiap.dev/docs/apis/get-active-subscriptions
   gentype.QueryGetActiveSubscriptionsHandler get getActiveSubscriptions =>
       ([subscriptionIds]) async {
         if (!_isInitialized) {
@@ -2119,9 +2159,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         }
       };
 
-  /// Check if the user has any active subscriptions (OpenIAP compliant)
-  /// Returns true if the user has at least one active subscription, false otherwise.
-  /// If subscriptionIds is provided, only checks for those specific subscriptions.
+  /// Check whether the user has any active subscription.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/has-active-subscriptions
   gentype.QueryHasActiveSubscriptionsHandler get hasActiveSubscriptions =>
       ([subscriptionIds]) async {
         try {
@@ -2149,7 +2189,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
 
   // MARK: - Alternative Billing APIs
 
-  /// Check if alternative billing is available on Android
+  /// Check whether alternative billing is available for the user.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
   gentype.MutationCheckAlternativeBillingAvailabilityAndroidHandler
       get checkAlternativeBillingAvailabilityAndroid => () async {
             if (!_platform.isAndroid) {
@@ -2167,7 +2209,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             }
           };
 
-  /// Show alternative billing information dialog on Android
+  /// Display Google's alternative billing information dialog.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
   gentype.MutationShowAlternativeBillingDialogAndroidHandler
       get showAlternativeBillingDialogAndroid => () async {
             if (!_platform.isAndroid) {
@@ -2184,7 +2228,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             }
           };
 
-  /// Create alternative billing reporting token on Android
+  /// Create a reporting token for an alternative billing flow.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
   gentype.MutationCreateAlternativeBillingTokenAndroidHandler
       get createAlternativeBillingTokenAndroid => () async {
             if (!_platform.isAndroid) {
@@ -2203,7 +2249,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
 
   // MARK: - Billing Programs API (Android 8.2.0+)
 
-  /// Check if a billing program is available on Android (8.2.0+)
+  /// Check whether a billing program (e.g., External Payments) is available.
+  ///
+  /// See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
   Future<gentype.BillingProgramAvailabilityResultAndroid>
       isBillingProgramAvailableAndroid(
     gentype.BillingProgramAndroid program,
@@ -2236,7 +2284,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
     }
   }
 
-  /// Create billing program reporting details on Android (8.2.0+)
+  /// Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+  ///
+  /// See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
   Future<gentype.BillingProgramReportingDetailsAndroid>
       createBillingProgramReportingDetailsAndroid(
     gentype.BillingProgramAndroid program,
@@ -2267,7 +2317,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
     }
   }
 
-  /// Launch external link on Android (8.2.0+)
+  /// Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+  ///
+  /// See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
   Future<bool> launchExternalLinkAndroid(
     gentype.LaunchExternalLinkParamsAndroid params,
   ) async {
@@ -2292,7 +2344,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
     }
   }
 
-  /// Present external purchase notice sheet on iOS (iOS 18.2+)
+  /// Present the external purchase notice sheet (iOS 17.4+).
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
   gentype.MutationPresentExternalPurchaseNoticeSheetIOSHandler
       get presentExternalPurchaseNoticeSheetIOS => () async {
             if (!_platform.isIOS || _platform.isMacOS) {
@@ -2321,7 +2375,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             }
           };
 
-  /// Present external purchase link on iOS (iOS 16.0+)
+  /// Present an external purchase link, StoreKit External (iOS 16+).
+  ///
+  /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
   gentype.MutationPresentExternalPurchaseLinkIOSHandler
       get presentExternalPurchaseLinkIOS => (String url) async {
             if (!_platform.isIOS || _platform.isMacOS) {
@@ -2351,10 +2407,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
 
   // MARK: - ExternalPurchaseCustomLink (iOS 18.1+)
 
-  /// Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
-  /// Returns true if the app can use custom external purchase links.
+  /// Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
   ///
-  /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+  /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
   gentype.QueryIsEligibleForExternalPurchaseCustomLinkIOSHandler
       get isEligibleForExternalPurchaseCustomLinkIOS => () async {
             if (!_platform.isIOS && !_platform.isMacOS) {
@@ -2380,12 +2435,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             }
           };
 
-  /// Get external purchase token for reporting to Apple (iOS 18.1+).
-  /// Use this token with Apple's External Purchase Server API to report transactions.
+  /// Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
   ///
-  /// [tokenType] - Token type: 'acquisition' (new customers) or 'services' (existing customers)
-  ///
-  /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+  /// See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
   gentype.QueryGetExternalPurchaseCustomLinkTokenIOSHandler
       get getExternalPurchaseCustomLinkTokenIOS =>
           (gentype.ExternalPurchaseCustomLinkTokenTypeIOS tokenType) async {
@@ -2417,13 +2469,9 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
             }
           };
 
-  /// Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-  /// Displays the system disclosure notice sheet for custom external purchase links.
-  /// Call this after a deliberate customer interaction before linking out to external purchases.
+  /// Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
   ///
-  /// [noticeType] - Notice type: 'browser' (external purchases displayed in browser)
-  ///
-  /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+  /// See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
   gentype.MutationShowExternalPurchaseCustomLinkNoticeIOSHandler
       get showExternalPurchaseCustomLinkNoticeIOS =>
           (gentype.ExternalPurchaseCustomLinkNoticeTypeIOS noticeType) async {

--- a/libraries/flutter_inapp_purchase/lib/flutter_inapp_purchase.dart
+++ b/libraries/flutter_inapp_purchase/lib/flutter_inapp_purchase.dart
@@ -1676,7 +1676,7 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
         );
       };
 
-  /// Verify via a managed provider (IAPKit, Apple, Google, Horizon).
+  /// Verify via a managed provider (currently IAPKit; the PurchaseVerificationProvider enum exposes only Iapkit today).
   ///
   /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
   gentype.MutationVerifyPurchaseWithProviderHandler

--- a/libraries/flutter_inapp_purchase/lib/types.dart
+++ b/libraries/flutter_inapp_purchase/lib/types.dart
@@ -4846,118 +4846,138 @@ sealed class VerifyPurchaseResult {
 
 /// GraphQL root mutation operations.
 abstract class MutationResolver {
-  /// Acknowledge a non-consumable purchase or subscription
+  /// Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+  /// See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
   Future<bool> acknowledgePurchaseAndroid(String purchaseToken);
-  /// Initiate a refund request for a product (iOS 15+)
+  /// Present the refund request sheet (iOS 15+). See also Features → Refund.
+  /// See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
   Future<String?> beginRefundRequestIOS(String sku);
-  /// Check if alternative billing is available for this user/device
-  /// Step 1 of alternative billing flow
+  /// Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
   /// 
-  /// Returns true if available, false otherwise
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Returns true if available, false otherwise.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
   Future<bool> checkAlternativeBillingAvailabilityAndroid();
-  /// Clear pending transactions from the StoreKit payment queue
+  /// Clear pending transactions in the queue (sandbox helper).
+  /// See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
   Future<bool> clearTransactionIOS();
-  /// Consume a purchase token so it can be repurchased
+  /// Consume a consumable purchase so it can be re-bought.
+  /// See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
   Future<bool> consumePurchaseAndroid(String purchaseToken);
-  /// Create external transaction token for Google Play reporting
-  /// Step 3 of alternative billing flow
-  /// Must be called AFTER successful payment in your payment system
-  /// Token must be reported to Google Play backend within 24 hours
+  /// Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
+  /// Must be called AFTER successful payment in your payment system.
+  /// Token must be reported to Google Play backend within 24 hours.
   /// 
-  /// Returns token string, or null if creation failed
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Returns token string, or null if creation failed.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
   Future<String?> createAlternativeBillingTokenAndroid();
-  /// Create reporting details for a billing program
-  /// Replaces the deprecated createExternalOfferReportingDetailsAsync API
+  /// Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+  /// Replaces the deprecated createExternalOfferReportingDetailsAsync API.
   /// 
-  /// Available in Google Play Billing Library 8.2.0+
-  /// Returns external transaction token needed for reporting external transactions
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Returns external transaction token needed for reporting external transactions.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
   Future<BillingProgramReportingDetailsAndroid> createBillingProgramReportingDetailsAndroid(BillingProgramAndroid program);
-  /// Open the native subscription management surface
+  /// Open the platform's subscription management UI.
+  /// See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
   Future<void> deepLinkToSubscriptions({
     String? packageNameAndroid,
     String? skuAndroid,
   });
-  /// Close the platform billing connection
+  /// Close the store connection and release resources.
+  /// See: https://www.openiap.dev/docs/apis/end-connection
   Future<bool> endConnection();
-  /// Finish a transaction after validating receipts
+  /// Complete a transaction after server-side verification. Required on Android within 3 days.
+  /// See: https://www.openiap.dev/docs/apis/finish-transaction
   Future<void> finishTransaction({
     required PurchaseInput purchase,
     bool? isConsumable,
   });
-  /// Establish the platform billing connection
+  /// Initialize the store connection. Call before any IAP API.
+  /// See: https://www.openiap.dev/docs/apis/init-connection
   Future<bool> initConnection({
     AlternativeBillingModeAndroid? alternativeBillingModeAndroid,
     BillingProgramAndroid? enableBillingProgramAndroid,
   });
-  /// Check if a billing program is available for the current user
-  /// Replaces the deprecated isExternalOfferAvailableAsync API
+  /// Check whether a billing program (e.g., External Payments) is available for the current user.
+  /// Replaces the deprecated isExternalOfferAvailableAsync API.
   /// 
-  /// Available in Google Play Billing Library 8.2.0+
-  /// Returns availability result with isAvailable flag
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Available in Google Play Billing Library 8.2.0+.
+  /// Returns availability result with isAvailable flag.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
   Future<BillingProgramAvailabilityResultAndroid> isBillingProgramAvailableAndroid(BillingProgramAndroid program);
-  /// Launch external link flow for external billing programs
-  /// Replaces the deprecated showExternalOfferInformationDialog API
+  /// Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+  /// Replaces the deprecated showExternalOfferInformationDialog API.
   /// 
-  /// Available in Google Play Billing Library 8.2.0+
-  /// Shows Play Store dialog and optionally launches external URL
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Shows Play Store dialog and optionally launches external URL.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
   Future<bool> launchExternalLinkAndroid({
     required BillingProgramAndroid billingProgram,
     required ExternalLinkLaunchModeAndroid launchMode,
     required ExternalLinkTypeAndroid linkType,
     required String linkUri,
   });
-  /// Present the App Store code redemption sheet
+  /// Show the App Store offer code redemption sheet.
+  /// See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
   Future<bool> presentCodeRedemptionSheetIOS();
-  /// Present external purchase custom link with StoreKit UI
+  /// Present an external purchase link, StoreKit External (iOS 16+).
+  /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
   Future<ExternalPurchaseLinkResultIOS> presentExternalPurchaseLinkIOS(String url);
-  /// Present external purchase notice sheet (iOS 17.4+).
-  /// Uses ExternalPurchase.presentNoticeSheet() which returns a token when user continues.
+  /// Present the external purchase notice sheet (iOS 17.4+).
+  /// Uses ExternalPurchase.presentNoticeSheet() which returns a token when the user continues.
   /// Reference: https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()
+  /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
   Future<ExternalPurchaseNoticeResultIOS> presentExternalPurchaseNoticeSheetIOS();
-  /// Initiate a purchase flow; rely on events for final state
+  /// Initiate a purchase or subscription flow; rely on events for final state.
+  /// See: https://www.openiap.dev/docs/apis/request-purchase
   Future<RequestPurchaseResult?> requestPurchase(RequestPurchaseProps params);
-  /// Purchase the promoted product surfaced by the App Store.
+  /// Buy the currently promoted product.
   /// 
   /// @deprecated Use promotedProductListenerIOS to receive the productId,
   /// then call requestPurchase with that SKU instead. In StoreKit 2,
   /// promoted products can be purchased directly via the standard purchase flow.
+  /// See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
   Future<bool> requestPurchaseOnPromotedProductIOS();
-  /// Restore completed purchases across platforms
+  /// Restore non-consumable and active subscription purchases.
+  /// See: https://www.openiap.dev/docs/apis/restore-purchases
   Future<void> restorePurchases();
-  /// Show alternative billing information dialog to user
-  /// Step 2 of alternative billing flow
-  /// Must be called BEFORE processing payment in your payment system
+  /// Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
+  /// Must be called BEFORE processing payment in your payment system.
   /// 
-  /// Returns true if user accepted, false if user canceled
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Returns true if user accepted, false if user canceled.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
   Future<bool> showAlternativeBillingDialogAndroid();
-  /// Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-  /// Displays the system disclosure notice sheet for custom external purchase links.
+  /// Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
   /// Call this after a deliberate customer interaction before linking out to external purchases.
   /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+  /// See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
   Future<ExternalPurchaseCustomLinkNoticeResultIOS> showExternalPurchaseCustomLinkNoticeIOS(ExternalPurchaseCustomLinkNoticeTypeIOS noticeType);
-  /// Open subscription management UI and return changed purchases (iOS 15+)
+  /// Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
+  /// See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
   Future<List<PurchaseIOS>> showManageSubscriptionsIOS();
-  /// Force a StoreKit sync for transactions (iOS 15+)
+  /// Force sync transactions with the App Store (iOS 15+).
+  /// See: https://www.openiap.dev/docs/apis/ios/sync-ios
   Future<bool> syncIOS();
-  /// Validate purchase receipts with the configured providers
+  /// Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
+  /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
   Future<VerifyPurchaseResult> validateReceipt({
     VerifyPurchaseAppleOptions? apple,
     VerifyPurchaseGoogleOptions? google,
     VerifyPurchaseHorizonOptions? horizon,
   });
-  /// Verify purchases with the configured providers
+  /// Verify a purchase against your own backend (returns isValid + raw store metadata).
+  /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
   Future<VerifyPurchaseResult> verifyPurchase({
     VerifyPurchaseAppleOptions? apple,
     VerifyPurchaseGoogleOptions? google,
     VerifyPurchaseHorizonOptions? horizon,
   });
-  /// Verify purchases with a specific provider (e.g., IAPKit)
+  /// Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+  /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
   Future<VerifyPurchaseWithProviderResult> verifyPurchaseWithProvider({
     RequestVerifyPurchaseWithIapkitProps? iapkit,
     required PurchaseVerificationProvider provider,
@@ -4966,62 +4986,83 @@ abstract class MutationResolver {
 
 /// GraphQL root query operations.
 abstract class QueryResolver {
-  /// Check if external purchase notice sheet can be presented (iOS 17.4+)
-  /// Uses ExternalPurchase.canPresent
+  /// Check eligibility for the external purchase notice sheet (iOS 17.4+).
+  /// Uses ExternalPurchase.canPresent.
+  /// See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
   Future<bool> canPresentExternalPurchaseNoticeIOS();
-  /// Get current StoreKit 2 entitlements (iOS 15+)
+  /// Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
+  /// See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
   Future<PurchaseIOS?> currentEntitlementIOS(String sku);
-  /// Retrieve products or subscriptions from the store
+  /// Fetch products or subscriptions from the store.
+  /// See: https://www.openiap.dev/docs/apis/fetch-products
   Future<FetchProductsResult> fetchProducts({
     required List<String> skus,
     ProductQueryType? type,
   });
-  /// Get active subscriptions (filters by subscriptionIds when provided)
+  /// Get details of all currently active subscriptions (filters by subscriptionIds when provided).
+  /// See: https://www.openiap.dev/docs/apis/get-active-subscriptions
   Future<List<ActiveSubscription>> getActiveSubscriptions([List<String>? subscriptionIds]);
-  /// Get the full StoreKit 2 transaction history as PurchaseIOS values.
+  /// List every StoreKit transaction (finished + unfinished) for the current user.
   /// Requires the SK2ConsumableTransactionHistory Info.plist key in the host app
   /// for finished consumables to be included (iOS 18+).
   /// Unlike getAvailablePurchases, always returns the iOS-specific PurchaseIOS shape.
+  /// See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
   Future<List<PurchaseIOS>> getAllTransactionsIOS();
-  /// Fetch the current app transaction (iOS 16+)
+  /// Fetch the app transaction (iOS 16+).
+  /// See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
   Future<AppTransaction?> getAppTransactionIOS();
-  /// Get all available purchases for the current user
+  /// List active purchases for the current user.
+  /// See: https://www.openiap.dev/docs/apis/get-available-purchases
   Future<List<Purchase>> getAvailablePurchases({
     bool? alsoPublishToEventListenerIOS,
     bool? includeSuspendedAndroid,
     bool? onlyIncludeActiveItemsIOS,
   });
-  /// Get external purchase token for reporting to Apple (iOS 18.1+).
-  /// Use this token with Apple's External Purchase Server API to report transactions.
+  /// Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+  /// Use this token to report transactions made through ExternalPurchaseCustomLink.
   /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+  /// See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
   Future<ExternalPurchaseCustomLinkTokenResultIOS> getExternalPurchaseCustomLinkTokenIOS(ExternalPurchaseCustomLinkTokenTypeIOS tokenType);
-  /// Retrieve all pending transactions in the StoreKit queue
+  /// List unfinished StoreKit transactions in the queue.
+  /// See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
   Future<List<PurchaseIOS>> getPendingTransactionsIOS();
-  /// Get the currently promoted product (iOS 11+)
+  /// Read the App Store-promoted product, if any (iOS 11+).
+  /// See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
   Future<ProductIOS?> getPromotedProductIOS();
-  /// Get base64-encoded receipt data for validation
+  /// Get base64-encoded receipt data (legacy validation).
+  /// See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
   Future<String?> getReceiptDataIOS();
-  /// Get the current storefront country code
+  /// Return the user's storefront country code.
+  /// See: https://www.openiap.dev/docs/apis/get-storefront
   Future<String> getStorefront();
-  /// Get the current App Store storefront country code
+  /// Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
+  /// See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
   Future<String> getStorefrontIOS();
-  /// Get the transaction JWS (StoreKit 2)
+  /// Return the JWS string for a transaction (StoreKit 2).
+  /// See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
   Future<String?> getTransactionJwsIOS(String sku);
-  /// Check whether the user has active subscriptions
+  /// Check whether the user has any active subscription.
+  /// See: https://www.openiap.dev/docs/apis/has-active-subscriptions
   Future<bool> hasActiveSubscriptions([List<String>? subscriptionIds]);
-  /// Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+  /// Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
   /// Returns true if the app can use custom external purchase links.
   /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+  /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
   Future<bool> isEligibleForExternalPurchaseCustomLinkIOS();
-  /// Check introductory offer eligibility for a subscription group
+  /// Check intro-offer eligibility for a subscription group.
+  /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
   Future<bool> isEligibleForIntroOfferIOS(String groupID);
-  /// Verify a StoreKit 2 transaction signature
+  /// Check whether a transaction's JWS verification passed (StoreKit 2).
+  /// See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
   Future<bool> isTransactionVerifiedIOS(String sku);
-  /// Get the latest transaction for a product using StoreKit 2
+  /// Get the latest verified transaction for a product, using StoreKit 2.
+  /// See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
   Future<PurchaseIOS?> latestTransactionIOS(String sku);
-  /// Get StoreKit 2 subscription status details (iOS 15+)
+  /// Get subscription status objects from StoreKit 2 (iOS 15+).
+  /// See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
   Future<List<SubscriptionStatusIOS>> subscriptionStatusIOS(String sku);
-  /// Validate a receipt for a specific product
+  /// Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
+  /// See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
   Future<VerifyPurchaseResultIOS> validateReceiptIOS({
     VerifyPurchaseAppleOptions? apple,
     VerifyPurchaseGoogleOptions? google,

--- a/libraries/flutter_inapp_purchase/lib/types.dart
+++ b/libraries/flutter_inapp_purchase/lib/types.dart
@@ -4969,7 +4969,11 @@ abstract class MutationResolver {
     VerifyPurchaseGoogleOptions? google,
     VerifyPurchaseHorizonOptions? horizon,
   });
-  /// Verify a purchase against your own backend (returns isValid + raw store metadata).
+  /// Verify a purchase against your own backend. Returns a platform-specific
+  /// variant of VerifyPurchaseResult — VerifyPurchaseResultIOS exposes isValid
+  /// + receipt/JWS metadata, VerifyPurchaseResultAndroid carries Play Store
+  /// receipt fields (no isValid), and VerifyPurchaseResultHorizon uses success.
+  /// Inspect the concrete variant before reading fields.
   /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
   Future<VerifyPurchaseResult> verifyPurchase({
     VerifyPurchaseAppleOptions? apple,

--- a/libraries/flutter_inapp_purchase/lib/types.dart
+++ b/libraries/flutter_inapp_purchase/lib/types.dart
@@ -4976,7 +4976,9 @@ abstract class MutationResolver {
     VerifyPurchaseGoogleOptions? google,
     VerifyPurchaseHorizonOptions? horizon,
   });
-  /// Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+  /// Verify via a managed provider without standing up your own server. The
+  /// PurchaseVerificationProvider enum currently exposes only IAPKit; platform
+  /// availability may differ by implementation.
   /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
   Future<VerifyPurchaseWithProviderResult> verifyPurchaseWithProvider({
     RequestVerifyPurchaseWithIapkitProps? iapkit,

--- a/libraries/godot-iap/addons/godot-iap/godot_iap.gd
+++ b/libraries/godot-iap/addons/godot-iap/godot_iap.gd
@@ -202,19 +202,14 @@ func _on_android_subscription_billing_issue(purchase_json: String) -> void:
 
 ## Initialize the store connection. Must be called before any other IAP API.
 ##
-## [param config] (optional): [InitConnectionConfig]. Use [code]enable_billing_program_android[/code]
-## (Android, Play Billing 8.2.0+) to opt into External Payments etc. iOS ignores Android fields.
+## This wrapper currently takes no arguments — Android billing-program flags
+## (e.g. [code]enable_billing_program_android[/code]) live on the underlying
+## [InitConnectionConfig] but are not yet plumbed through the GDScript API.
 ##
 ## Returns [code]true[/code] once the platform billing client is connected.
 ##
 ## [codeblock]
-## # Standard
 ## var ok = await iap.init_connection()
-##
-## # With Android billing program
-## var config = InitConnectionConfig.new()
-## config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_OFFER
-## var ok = await iap.init_connection(config)
 ## [/codeblock]
 ##
 ## See: https://www.openiap.dev/docs/apis/init-connection
@@ -272,8 +267,11 @@ func is_store_connected() -> bool:
 ## [code]type[/code] ([code]ProductQueryType.IN_APP[/code], [code]SUBS[/code], or [code]ALL[/code]).
 ##
 ## Returns an Array — typed as [Array] because GDScript can't express heterogeneous element
-## types. The runtime variant is [Array][[Product]] for IN_APP, [Array][[ProductSubscription]]
-## for SUBS, or a mixed Array for ALL.
+## types. The wrapper maps results to platform-specific objects:
+## [Array][[Types.ProductAndroid]] on Android and [Array][[Types.ProductIOS]] on iOS,
+## regardless of whether the request was IN_APP, SUBS, or ALL. Use the platform-specific
+## fields ([code]subscription_offer_details_android[/code], [code]subscription_*_ios[/code])
+## to distinguish subscriptions from one-time products at the call site.
 ##
 ## [codeblock]
 ## var request = ProductRequest.new()

--- a/libraries/godot-iap/addons/godot-iap/godot_iap.gd
+++ b/libraries/godot-iap/addons/godot-iap/godot_iap.gd
@@ -200,8 +200,24 @@ func _on_android_subscription_billing_issue(purchase_json: String) -> void:
 # Connection (OpenIAP Mutation)
 # ==========================================
 
-## Initialize the IAP connection.
-## @return bool - true if connection was successful
+## Initialize the store connection. Must be called before any other IAP API.
+##
+## [param config] (optional): [InitConnectionConfig]. Use [code]enable_billing_program_android[/code]
+## (Android, Play Billing 8.2.0+) to opt into External Payments etc. iOS ignores Android fields.
+##
+## Returns [code]true[/code] once the platform billing client is connected.
+##
+## [codeblock]
+## # Standard
+## var ok = await iap.init_connection()
+##
+## # With Android billing program
+## var config = InitConnectionConfig.new()
+## config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_OFFER
+## var ok = await iap.init_connection(config)
+## [/codeblock]
+##
+## See: https://www.openiap.dev/docs/apis/init-connection
 func init_connection() -> bool:
 	print("[GodotIap] init_connection called")
 	if _native_plugin:
@@ -229,6 +245,8 @@ func init_connection() -> bool:
 
 ## End the IAP connection.
 ## @return bool - true if disconnection was successful
+##
+## See: https://www.openiap.dev/docs/apis/end-connection
 func end_connection() -> bool:
 	print("[GodotIap] end_connection called")
 	if _native_plugin:
@@ -248,11 +266,26 @@ func is_store_connected() -> bool:
 # Products (OpenIAP Query)
 # ==========================================
 
-## Fetch products from the store.
-## Note: This function is asynchronous and must be called with 'await'.
-## On iOS, it awaits the 'products_fetched' signal internally.
-## @param request: Types.ProductRequest - product request with SKUs and type
-## @return Array[Types.ProductAndroid] or Array[Types.ProductIOS] depending on platform
+## Retrieve products or subscriptions from the store by SKU.
+##
+## [param request]: [ProductRequest] with [code]skus[/code] (Array[String]) and optional
+## [code]type[/code] ([code]ProductQueryType.IN_APP[/code], [code]SUBS[/code], or [code]ALL[/code]).
+##
+## Returns an Array — typed as [Array] because GDScript can't express heterogeneous element
+## types. The runtime variant is [Array][[Product]] for IN_APP, [Array][[ProductSubscription]]
+## for SUBS, or a mixed Array for ALL.
+##
+## [codeblock]
+## var request = ProductRequest.new()
+## request.skus = ["com.app.coins_100", "com.app.premium"]
+## request.type = ProductQueryType.IN_APP
+## var products = await iap.fetch_products(request)
+## [/codeblock]
+##
+## [b]Note:[/b] This is a regular awaitable call. Don't confuse with [code]request_*[/code]
+## APIs (e.g. [method request_purchase]), which are event-based.
+##
+## See: https://www.openiap.dev/docs/apis/fetch-products
 func fetch_products(request) -> Array:
 	print("[GodotIap] fetch_products called")
 	var result = await _fetch_products_raw(request.to_dict())
@@ -303,9 +336,28 @@ func _fetch_products_raw(request: Dictionary) -> Dictionary:
 # Purchases (OpenIAP Mutation)
 # ==========================================
 
-## Request a purchase from the store.
-## @param props: Types.RequestPurchaseProps - purchase request properties
-## @return Types.PurchaseAndroid or Types.PurchaseIOS on success, null on failure
+## Initiate a purchase or subscription flow. The result is delivered via the
+## [signal purchase_updated] / [signal purchase_error] signals — NOT the return value.
+##
+## [param props]: [RequestPurchaseProps]. Set [code]props.request.apple.sku[/code] for iOS
+## and/or [code]props.request.google.skus[/code] for Android. Subscriptions also need
+## [code]subscription_offers[/code] on Android.
+##
+## Returns the dispatched purchase payload — [b]do not rely on it[/b] for the outcome.
+##
+## [codeblock]
+## var props = RequestPurchaseProps.new()
+## props.request = RequestPurchasePropsByPlatforms.new()
+## props.request.apple = RequestPurchaseIosProps.new()
+## props.request.apple.sku = "com.app.premium"
+## props.type = ProductQueryType.IN_APP
+## await iap.request_purchase(props)
+## [/codeblock]
+##
+## [b]Warning:[/b] Event-based. Connect to [signal purchase_updated] /
+## [signal purchase_error] before calling this.
+##
+## See: https://www.openiap.dev/docs/apis/request-purchase
 func request_purchase(props) -> Variant:
 	var result = _request_purchase_raw(props.to_dict())
 	if result.get("success", false):
@@ -374,10 +426,20 @@ func _request_purchase_raw(args: Dictionary) -> Dictionary:
 	print("[GodotIap] requestPurchase parse error for: ", result_json)
 	return { "success": false, "error": "Failed to parse response" }
 
-## Finish a transaction (acknowledge or consume).
-## @param purchase: Types.PurchaseInput - the purchase to finish
-## @param is_consumable: bool - whether to consume (true) or acknowledge (false)
-## @return Types.VoidResult
+## Complete a purchase transaction. Call after server-side verification.
+##
+## [param purchase]: the [Purchase] to finalize.
+## [param is_consumable]: [code]true[/code] for consumables (re-buyable like coins),
+## [code]false[/code] (default) for non-consumables and subscriptions.
+##
+## [codeblock]
+## await iap.finish_transaction(purchase, false)
+## [/codeblock]
+##
+## [b]Critical:[/b] Android purchases must be finalized within 3 days or Google auto-refunds.
+## iOS unfinished transactions replay on every app launch.
+##
+## See: https://www.openiap.dev/docs/apis/finish-transaction
 func finish_transaction(purchase, is_consumable: bool = false) -> Variant:
 	print("[GodotIap] finish_transaction called, consumable: ", is_consumable)
 	var result = _finish_transaction_raw(purchase.to_dict(), is_consumable)
@@ -435,6 +497,8 @@ func _finish_transaction_raw(purchase: Dictionary, is_consumable: bool) -> Dicti
 ## iOS: Performs a lightweight sync then fetches available purchases.
 ## Android: Simply fetches available purchases.
 ## @return Types.VoidResult
+##
+## See: https://www.openiap.dev/docs/apis/restore-purchases
 func restore_purchases() -> Variant:
 	print("[GodotIap] restore_purchases called")
 
@@ -447,9 +511,22 @@ func restore_purchases() -> Variant:
 	result.success = true
 	return result
 
-## Get available (owned) purchases.
-## @param options: Types.PurchaseOptions or null - optional purchase query options
-## @return Array[Types.PurchaseAndroid] or Array[Types.PurchaseIOS] depending on platform
+## List the user's unfinished purchases — non-consumables, active subscriptions, and any
+## pending transactions not finished previously.
+##
+## [param options] (optional): [PurchaseOptions]. iOS-only flags
+## ([code]also_publish_to_event_listener_ios[/code], [code]only_include_active_items_ios[/code]).
+##
+## Returns [Array][[Purchase]] currently held by the store.
+##
+## [codeblock]
+## var purchases = await iap.get_available_purchases()
+## for purchase in purchases:
+##     if await verify_on_server(purchase):
+##         await iap.finish_transaction(purchase, false)
+## [/codeblock]
+##
+## See: https://www.openiap.dev/docs/apis/get-available-purchases
 func get_available_purchases(options = null) -> Array:
 	print("[GodotIap] get_available_purchases called")
 	var raw_purchases = _get_available_purchases_raw()
@@ -484,6 +561,8 @@ func _get_available_purchases_raw() -> Array:
 ## Get active subscriptions.
 ## @param subscription_ids: Array[String] - optional array of subscription IDs to filter
 ## @return Array[Types.ActiveSubscription]
+##
+## See: https://www.openiap.dev/docs/apis/get-active-subscriptions
 func get_active_subscriptions(subscription_ids: Array[String] = []) -> Array:
 	print("[GodotIap] get_active_subscriptions called")
 	var raw_subs = _get_active_subscriptions_raw(subscription_ids)
@@ -512,6 +591,8 @@ func _get_active_subscriptions_raw(subscription_ids: Array = []) -> Array:
 ## Check if user has any active subscriptions.
 ## @param subscription_ids: Array[String] - optional array of subscription IDs to check
 ## @return bool - true if any subscription is active
+##
+## See: https://www.openiap.dev/docs/apis/has-active-subscriptions
 func has_active_subscriptions(subscription_ids: Array[String] = []) -> bool:
 	print("[GodotIap] has_active_subscriptions called")
 	if _native_plugin and (_platform == "Android" or _platform == "iOS"):
@@ -533,6 +614,8 @@ func has_active_subscriptions(subscription_ids: Array[String] = []) -> bool:
 
 ## Get the current storefront country code.
 ## @return String - country code (e.g., "US")
+##
+## See: https://www.openiap.dev/docs/apis/get-storefront
 func get_storefront() -> String:
 	print("[GodotIap] get_storefront called")
 	if _native_plugin:
@@ -556,6 +639,8 @@ func get_storefront() -> String:
 ## Verify a purchase locally.
 ## @param props: Types.VerifyPurchaseProps - verification properties
 ## @return Types.VerifyPurchaseResultIOS or Types.VerifyPurchaseResultAndroid, or null on failure
+##
+## See: https://www.openiap.dev/docs/features/validation#verify-purchase
 func verify_purchase(props) -> Variant:
 	print("[GodotIap] verify_purchase called")
 	var result = _verify_purchase_raw(props.to_dict())
@@ -580,6 +665,8 @@ func _verify_purchase_raw(props: Dictionary) -> Dictionary:
 ## Verify a purchase using external provider (IAPKit).
 ## @param props: Types.VerifyPurchaseWithProviderProps - provider verification properties
 ## @return Types.VerifyPurchaseWithProviderResult
+##
+## See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
 func verify_purchase_with_provider(props) -> Variant:
 	print("[GodotIap] verify_purchase_with_provider called")
 	var result = _verify_purchase_with_provider_raw(props.to_dict())
@@ -603,6 +690,8 @@ func _verify_purchase_with_provider_raw(props: Dictionary) -> Dictionary:
 
 ## Sync with App Store (iOS only).
 ## @return Types.VoidResult
+##
+## See: https://www.openiap.dev/docs/apis/ios/sync-ios
 func sync_ios() -> Variant:
 	var result = Types.VoidResult.new()
 	result.success = false
@@ -615,6 +704,8 @@ func sync_ios() -> Variant:
 
 ## Clear pending transactions from the StoreKit payment queue (iOS only).
 ## @return Types.VoidResult
+##
+## See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
 func clear_transaction_ios() -> Variant:
 	var result = Types.VoidResult.new()
 	result.success = false
@@ -627,6 +718,8 @@ func clear_transaction_ios() -> Variant:
 
 ## Get pending transactions (iOS only).
 ## @return Array[Types.PurchaseIOS]
+##
+## See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
 func get_pending_transactions_ios() -> Array:
 	var purchases: Array = []
 	if _native_plugin and _platform == "iOS":
@@ -644,6 +737,8 @@ func get_pending_transactions_ios() -> Array:
 ## Get all transactions including finished consumables (iOS only).
 ## Requires SK2ConsumableTransactionHistory Info.plist key for finished consumables (iOS 18+).
 ## @return Array of Types.PurchaseIOS
+##
+## See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
 func get_all_transactions_ios() -> Array:
 	var purchases: Array = []
 	if _native_plugin and _platform == "iOS":
@@ -660,6 +755,8 @@ func get_all_transactions_ios() -> Array:
 
 ## Present code redemption sheet (iOS only).
 ## @return Types.VoidResult
+##
+## See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
 func present_code_redemption_sheet_ios() -> Variant:
 	var result = Types.VoidResult.new()
 	result.success = false
@@ -672,6 +769,8 @@ func present_code_redemption_sheet_ios() -> Variant:
 
 ## Show manage subscriptions UI (iOS only).
 ## @return Array[Types.PurchaseIOS] - changed purchases
+##
+## See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
 func show_manage_subscriptions_ios() -> Array:
 	var purchases: Array = []
 	if _native_plugin and _platform == "iOS":
@@ -689,6 +788,8 @@ func show_manage_subscriptions_ios() -> Array:
 ## Begin refund request (iOS only).
 ## @param product_id: String - the product ID to request refund for
 ## @return Types.RefundResultIOS
+##
+## See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
 func begin_refund_request_ios(product_id: String) -> Variant:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("beginRefundRequestIOS", product_id)
@@ -701,6 +802,8 @@ func begin_refund_request_ios(product_id: String) -> Variant:
 ## Get current entitlement for a product (iOS only).
 ## @param sku: String - product SKU
 ## @return Types.PurchaseIOS or null
+##
+## See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
 func current_entitlement_ios(sku: String) -> Variant:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("currentEntitlementIOS", sku)
@@ -716,6 +819,8 @@ func current_entitlement_ios(sku: String) -> Variant:
 ## Get the latest transaction for a product (iOS only).
 ## @param sku: String - product SKU
 ## @return Types.PurchaseIOS or null
+##
+## See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
 func latest_transaction_ios(sku: String) -> Variant:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("latestTransactionIOS", sku)
@@ -730,6 +835,8 @@ func latest_transaction_ios(sku: String) -> Variant:
 
 ## Get app transaction (iOS 16+).
 ## @return Types.AppTransaction or null
+##
+## See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
 func get_app_transaction_ios() -> Variant:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("getAppTransactionIOS")
@@ -744,6 +851,8 @@ func get_app_transaction_ios() -> Variant:
 ## Get subscription status (iOS only).
 ## @param sku: String - product SKU
 ## @return Array[Types.SubscriptionStatusIOS]
+##
+## See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
 func subscription_status_ios(sku: String) -> Array:
 	var statuses: Array = []
 	if _native_plugin and _platform == "iOS":
@@ -761,6 +870,8 @@ func subscription_status_ios(sku: String) -> Array:
 ## Check if eligible for intro offer (iOS only).
 ## @param group_id: String - subscription group ID
 ## @return bool - true if eligible for introductory offer
+##
+## See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
 func is_eligible_for_intro_offer_ios(group_id: String) -> bool:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("isEligibleForIntroOfferIOS", group_id)
@@ -771,6 +882,8 @@ func is_eligible_for_intro_offer_ios(group_id: String) -> bool:
 
 ## Get promoted product (iOS only).
 ## @return Types.ProductIOS or null
+##
+## See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
 func get_promoted_product_ios() -> Variant:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("getPromotedProductIOS")
@@ -785,6 +898,8 @@ func get_promoted_product_ios() -> Variant:
 
 ## Request purchase on promoted product (iOS only).
 ## @return Types.VoidResult
+##
+## See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
 func request_purchase_on_promoted_product_ios() -> Variant:
 	var result = Types.VoidResult.new()
 	result.success = false
@@ -797,6 +912,8 @@ func request_purchase_on_promoted_product_ios() -> Variant:
 
 ## Check if can present external purchase notice (iOS 18.2+).
 ## @return bool - true if external purchase notice can be presented
+##
+## See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
 func can_present_external_purchase_notice_ios() -> bool:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("canPresentExternalPurchaseNoticeIOS")
@@ -807,6 +924,8 @@ func can_present_external_purchase_notice_ios() -> bool:
 
 ## Present external purchase notice sheet (iOS 18.2+).
 ## @return Types.ExternalPurchaseNoticeResultIOS
+##
+## See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
 func present_external_purchase_notice_sheet_ios() -> Variant:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("presentExternalPurchaseNoticeSheetIOS")
@@ -819,6 +938,8 @@ func present_external_purchase_notice_sheet_ios() -> Variant:
 ## Present external purchase link (iOS 18.2+).
 ## @param url: String - external purchase URL
 ## @return Types.ExternalPurchaseLinkResultIOS
+##
+## See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
 func present_external_purchase_link_ios(url: String) -> Variant:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("presentExternalPurchaseLinkIOS", url)
@@ -830,6 +951,8 @@ func present_external_purchase_link_ios(url: String) -> Variant:
 
 ## Get receipt data (iOS only).
 ## @return String - receipt data as base64
+##
+## See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
 func get_receipt_data_ios() -> String:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("getReceiptDataIOS")
@@ -841,6 +964,8 @@ func get_receipt_data_ios() -> String:
 ## Check if transaction is verified (iOS only).
 ## @param sku: String - product SKU
 ## @return bool - true if transaction is verified
+##
+## See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
 func is_transaction_verified_ios(sku: String) -> bool:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("isTransactionVerifiedIOS", sku)
@@ -852,6 +977,8 @@ func is_transaction_verified_ios(sku: String) -> bool:
 ## Get transaction JWS (iOS only).
 ## @param sku: String - product SKU
 ## @return String - JWS representation of the transaction
+##
+## See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
 func get_transaction_jws_ios(sku: String) -> String:
 	if _native_plugin and _platform == "iOS":
 		var result_json = _native_plugin.call("getTransactionJwsIOS", sku)
@@ -887,6 +1014,8 @@ func _parse_request_id(pending_json) -> String:
 ## code, so callers can use it like a synchronous getter.
 ## @deprecated Prefer cross-platform get_storefront() which also works on iOS.
 ## @return String ISO 3166-1 alpha-2 country code, or empty string on failure
+##
+## See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
 func get_storefront_ios() -> String:
 	if not (_native_plugin and _platform == "iOS"):
 		return ""
@@ -903,6 +1032,8 @@ func get_storefront_ios() -> String:
 ## @deprecated Use verify_purchase or verify_purchase_with_provider instead.
 ## @param props: Types.VerifyPurchaseProps with `apple: {sku: String}` set
 ## @return Variant Types.VerifyPurchaseResultIOS on success, null otherwise
+##
+## See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
 func validate_receipt_ios(props) -> Variant:
 	if not (_native_plugin and _platform == "iOS"):
 		return null
@@ -922,6 +1053,8 @@ func validate_receipt_ios(props) -> Variant:
 ## @deprecated Use verify_purchase instead.
 ## @param props: Types.VerifyPurchaseProps with platform-specific fields
 ## @return Variant Types.VerifyPurchaseResultIOS | Types.VerifyPurchaseResultAndroid | null
+##
+## See: https://www.openiap.dev/docs/apis/validate-receipt
 func validate_receipt(props) -> Variant:
 	if _platform == "iOS":
 		return await validate_receipt_ios(props)
@@ -938,6 +1071,8 @@ func validate_receipt(props) -> Variant:
 ## emit tagged with method == "isEligibleForExternalPurchaseCustomLinkIOS";
 ## returns false on any error.
 ## @return bool true if the current context can show external purchase custom link
+##
+## See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
 func is_eligible_for_external_purchase_custom_link_ios() -> bool:
 	if not (_native_plugin and _platform == "iOS"):
 		return false
@@ -954,6 +1089,8 @@ func is_eligible_for_external_purchase_custom_link_ios() -> bool:
 ## Returns null on error or on unsupported platforms (i.e. iOS < 18.1).
 ## @param token_type: String "acquisition" | "services"
 ## @return Variant Types.ExternalPurchaseCustomLinkTokenResultIOS or null
+##
+## See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
 func get_external_purchase_custom_link_token_ios(token_type: String) -> Variant:
 	if not (_native_plugin and _platform == "iOS"):
 		return null
@@ -973,6 +1110,8 @@ func get_external_purchase_custom_link_token_ios(token_type: String) -> Variant:
 ## null on error.
 ## @param notice_type: String "browser"
 ## @return Variant Types.ExternalPurchaseCustomLinkNoticeResultIOS or null
+##
+## See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
 func show_external_purchase_custom_link_notice_ios(notice_type: String) -> Variant:
 	if not (_native_plugin and _platform == "iOS"):
 		return null
@@ -993,6 +1132,8 @@ func show_external_purchase_custom_link_notice_ios(notice_type: String) -> Varia
 ## Acknowledge a purchase (Android only, for non-consumables).
 ## @param purchase_token: String - the purchase token to acknowledge
 ## @return Types.VoidResult
+##
+## See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
 func acknowledge_purchase_android(purchase_token: String) -> Variant:
 	var result = _acknowledge_purchase_android_raw(purchase_token)
 	return Types.VoidResult.from_dict(result)
@@ -1012,6 +1153,8 @@ func _acknowledge_purchase_android_raw(purchase_token: String) -> Dictionary:
 ## Consume a purchase (Android only, for consumables).
 ## @param purchase_token: String - the purchase token to consume
 ## @return Types.VoidResult
+##
+## See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
 func consume_purchase_android(purchase_token: String) -> Variant:
 	var result = _consume_purchase_android_raw(purchase_token)
 	return Types.VoidResult.from_dict(result)
@@ -1030,6 +1173,8 @@ func _consume_purchase_android_raw(purchase_token: String) -> Dictionary:
 
 ## Check alternative billing availability (Android).
 ## @return Types.BillingProgramAvailabilityResultAndroid
+##
+## See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
 func check_alternative_billing_availability_android() -> Variant:
 	if _native_plugin and _platform == "Android":
 		var result_json = _native_plugin.call("checkAlternativeBillingAvailabilityAndroid")
@@ -1042,6 +1187,8 @@ func check_alternative_billing_availability_android() -> Variant:
 
 ## Show alternative billing dialog (Android).
 ## @return Types.UserChoiceBillingDetails
+##
+## See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
 func show_alternative_billing_dialog_android() -> Variant:
 	if _native_plugin and _platform == "Android":
 		var result_json = _native_plugin.call("showAlternativeBillingDialogAndroid")
@@ -1053,6 +1200,8 @@ func show_alternative_billing_dialog_android() -> Variant:
 
 ## Create alternative billing token (Android).
 ## @return Types.BillingProgramReportingDetailsAndroid
+##
+## See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
 func create_alternative_billing_token_android() -> Variant:
 	if _native_plugin and _platform == "Android":
 		var result_json = _native_plugin.call("createAlternativeBillingTokenAndroid")
@@ -1065,6 +1214,8 @@ func create_alternative_billing_token_android() -> Variant:
 ## Check if a billing program is available (Android 8.2.0+).
 ## @param billing_program: Types.BillingProgramAndroid - billing program enum value
 ## @return Types.BillingProgramAvailabilityResultAndroid
+##
+## See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
 func is_billing_program_available_android(billing_program) -> Variant:
 	if _native_plugin and _platform == "Android":
 		var result_json = _native_plugin.call("isBillingProgramAvailableAndroid", billing_program)
@@ -1079,6 +1230,8 @@ func is_billing_program_available_android(billing_program) -> Variant:
 ## Launch external link (Android 8.2.0+).
 ## @param params: Types.LaunchExternalLinkParamsAndroid - external link parameters
 ## @return Types.VoidResult
+##
+## See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
 func launch_external_link_android(params) -> Variant:
 	if _native_plugin and _platform == "Android":
 		var params_json = JSON.stringify(params.to_dict())
@@ -1093,6 +1246,8 @@ func launch_external_link_android(params) -> Variant:
 ## Create billing program reporting details (Android 8.2.0+).
 ## @param billing_program: Types.BillingProgramAndroid - billing program enum value
 ## @return Types.BillingProgramReportingDetailsAndroid
+##
+## See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
 func create_billing_program_reporting_details_android(billing_program) -> Variant:
 	if _native_plugin and _platform == "Android":
 		var result_json = _native_plugin.call("createBillingProgramReportingDetailsAndroid", billing_program)
@@ -1117,6 +1272,8 @@ func get_package_name_android() -> String:
 ## Open subscription management deep link.
 ## @param options: Types.DeepLinkOptions or null - optional deep link configuration
 ## @return void
+##
+## See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
 func deep_link_to_subscriptions(options = null) -> void:
 	var opts = options if options != null else Types.DeepLinkOptions.new()
 	if _native_plugin and (_platform == "Android" or _platform == "iOS"):

--- a/libraries/godot-iap/addons/godot-iap/types.gd
+++ b/libraries/godot-iap/addons/godot-iap/types.gd
@@ -4800,7 +4800,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Retrieve products or subscriptions from the store
+	## Fetch products or subscriptions from the store.
 	class fetchProductsField:
 		const name = "fetchProducts"
 		const snake_name = "fetch_products"
@@ -4820,7 +4820,7 @@ class Query:
 		const return_type = "FetchProductsResult"
 		const is_array = false
 
-	## Get all available purchases for the current user
+	## List active purchases for the current user.
 	class getAvailablePurchasesField:
 		const name = "getAvailablePurchases"
 		const snake_name = "get_available_purchases"
@@ -4840,7 +4840,7 @@ class Query:
 		const return_type = "Purchase"
 		const is_array = true
 
-	## Get active subscriptions (filters by subscriptionIds when provided)
+	## Get details of all currently active subscriptions (filters by subscriptionIds when provided).
 	class getActiveSubscriptionsField:
 		const name = "getActiveSubscriptions"
 		const snake_name = "get_active_subscriptions"
@@ -4860,7 +4860,7 @@ class Query:
 		const return_type = "ActiveSubscription"
 		const is_array = true
 
-	## Check whether the user has active subscriptions
+	## Check whether the user has any active subscription.
 	class hasActiveSubscriptionsField:
 		const name = "hasActiveSubscriptions"
 		const snake_name = "has_active_subscriptions"
@@ -4880,7 +4880,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Get the current storefront country code
+	## Return the user's storefront country code.
 	class getStorefrontField:
 		const name = "getStorefront"
 		const snake_name = "get_storefront"
@@ -4889,7 +4889,7 @@ class Query:
 		const return_type = "String"
 		const is_array = false
 
-	## Get the current App Store storefront country code
+	## Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
 	class getStorefrontIOSField:
 		const name = "getStorefrontIOS"
 		const snake_name = "get_storefront_ios"
@@ -4898,7 +4898,7 @@ class Query:
 		const return_type = "String"
 		const is_array = false
 
-	## Get the currently promoted product (iOS 11+)
+	## Read the App Store-promoted product, if any (iOS 11+).
 	class getPromotedProductIOSField:
 		const name = "getPromotedProductIOS"
 		const snake_name = "get_promoted_product_ios"
@@ -4907,7 +4907,7 @@ class Query:
 		const return_type = "ProductIOS"
 		const is_array = false
 
-	## Check if external purchase notice sheet can be presented (iOS 17.4+)
+	## Check eligibility for the external purchase notice sheet (iOS 17.4+).
 	class canPresentExternalPurchaseNoticeIOSField:
 		const name = "canPresentExternalPurchaseNoticeIOS"
 		const snake_name = "can_present_external_purchase_notice_ios"
@@ -4916,7 +4916,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+	## Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
 	class isEligibleForExternalPurchaseCustomLinkIOSField:
 		const name = "isEligibleForExternalPurchaseCustomLinkIOS"
 		const snake_name = "is_eligible_for_external_purchase_custom_link_ios"
@@ -4925,7 +4925,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Get external purchase token for reporting to Apple (iOS 18.1+).
+	## Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
 	class getExternalPurchaseCustomLinkTokenIOSField:
 		const name = "getExternalPurchaseCustomLinkTokenIOS"
 		const snake_name = "get_external_purchase_custom_link_token_ios"
@@ -4953,7 +4953,7 @@ class Query:
 		const return_type = "ExternalPurchaseCustomLinkTokenResultIOS"
 		const is_array = false
 
-	## Retrieve all pending transactions in the StoreKit queue
+	## List unfinished StoreKit transactions in the queue.
 	class getPendingTransactionsIOSField:
 		const name = "getPendingTransactionsIOS"
 		const snake_name = "get_pending_transactions_ios"
@@ -4962,7 +4962,7 @@ class Query:
 		const return_type = "PurchaseIOS"
 		const is_array = true
 
-	## Check introductory offer eligibility for a subscription group
+	## Check intro-offer eligibility for a subscription group.
 	class isEligibleForIntroOfferIOSField:
 		const name = "isEligibleForIntroOfferIOS"
 		const snake_name = "is_eligible_for_intro_offer_ios"
@@ -4982,7 +4982,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Get StoreKit 2 subscription status details (iOS 15+)
+	## Get subscription status objects from StoreKit 2 (iOS 15+).
 	class subscriptionStatusIOSField:
 		const name = "subscriptionStatusIOS"
 		const snake_name = "subscription_status_ios"
@@ -5002,7 +5002,7 @@ class Query:
 		const return_type = "SubscriptionStatusIOS"
 		const is_array = true
 
-	## Get current StoreKit 2 entitlements (iOS 15+)
+	## Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
 	class currentEntitlementIOSField:
 		const name = "currentEntitlementIOS"
 		const snake_name = "current_entitlement_ios"
@@ -5022,7 +5022,7 @@ class Query:
 		const return_type = "PurchaseIOS"
 		const is_array = false
 
-	## Get the latest transaction for a product using StoreKit 2
+	## Get the latest verified transaction for a product, using StoreKit 2.
 	class latestTransactionIOSField:
 		const name = "latestTransactionIOS"
 		const snake_name = "latest_transaction_ios"
@@ -5042,7 +5042,7 @@ class Query:
 		const return_type = "PurchaseIOS"
 		const is_array = false
 
-	## Verify a StoreKit 2 transaction signature
+	## Check whether a transaction's JWS verification passed (StoreKit 2).
 	class isTransactionVerifiedIOSField:
 		const name = "isTransactionVerifiedIOS"
 		const snake_name = "is_transaction_verified_ios"
@@ -5062,7 +5062,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Get the transaction JWS (StoreKit 2)
+	## Return the JWS string for a transaction (StoreKit 2).
 	class getTransactionJwsIOSField:
 		const name = "getTransactionJwsIOS"
 		const snake_name = "get_transaction_jws_ios"
@@ -5082,7 +5082,7 @@ class Query:
 		const return_type = "String"
 		const is_array = false
 
-	## Get base64-encoded receipt data for validation
+	## Get base64-encoded receipt data (legacy validation).
 	class getReceiptDataIOSField:
 		const name = "getReceiptDataIOS"
 		const snake_name = "get_receipt_data_ios"
@@ -5091,7 +5091,7 @@ class Query:
 		const return_type = "String"
 		const is_array = false
 
-	## Fetch the current app transaction (iOS 16+)
+	## Fetch the app transaction (iOS 16+).
 	class getAppTransactionIOSField:
 		const name = "getAppTransactionIOS"
 		const snake_name = "get_app_transaction_ios"
@@ -5100,7 +5100,7 @@ class Query:
 		const return_type = "AppTransaction"
 		const is_array = false
 
-	## Get the full StoreKit 2 transaction history as PurchaseIOS values.
+	## List every StoreKit transaction (finished + unfinished) for the current user.
 	class getAllTransactionsIOSField:
 		const name = "getAllTransactionsIOS"
 		const snake_name = "get_all_transactions_ios"
@@ -5109,7 +5109,7 @@ class Query:
 		const return_type = "PurchaseIOS"
 		const is_array = true
 
-	## Validate a receipt for a specific product
+	## Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
 	class validateReceiptIOSField:
 		const name = "validateReceiptIOS"
 		const snake_name = "validate_receipt_ios"
@@ -5143,7 +5143,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Establish the platform billing connection
+	## Initialize the store connection. Call before any IAP API.
 	class initConnectionField:
 		const name = "initConnection"
 		const snake_name = "init_connection"
@@ -5163,7 +5163,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Close the platform billing connection
+	## Close the store connection and release resources.
 	class endConnectionField:
 		const name = "endConnection"
 		const snake_name = "end_connection"
@@ -5172,7 +5172,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Initiate a purchase flow; rely on events for final state
+	## Initiate a purchase or subscription flow; rely on events for final state.
 	class requestPurchaseField:
 		const name = "requestPurchase"
 		const snake_name = "request_purchase"
@@ -5192,7 +5192,7 @@ class Mutation:
 		const return_type = "RequestPurchaseResult"
 		const is_array = false
 
-	## Finish a transaction after validating receipts
+	## Complete a transaction after server-side verification. Required on Android within 3 days.
 	class finishTransactionField:
 		const name = "finishTransaction"
 		const snake_name = "finish_transaction"
@@ -5216,7 +5216,7 @@ class Mutation:
 		const return_type = "VoidResult"
 		const is_array = false
 
-	## Restore completed purchases across platforms
+	## Restore non-consumable and active subscription purchases.
 	class restorePurchasesField:
 		const name = "restorePurchases"
 		const snake_name = "restore_purchases"
@@ -5225,7 +5225,7 @@ class Mutation:
 		const return_type = "VoidResult"
 		const is_array = false
 
-	## Open the native subscription management surface
+	## Open the platform's subscription management UI.
 	class deepLinkToSubscriptionsField:
 		const name = "deepLinkToSubscriptions"
 		const snake_name = "deep_link_to_subscriptions"
@@ -5245,7 +5245,7 @@ class Mutation:
 		const return_type = "VoidResult"
 		const is_array = false
 
-	## Validate purchase receipts with the configured providers
+	## Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
 	class validateReceiptField:
 		const name = "validateReceipt"
 		const snake_name = "validate_receipt"
@@ -5265,7 +5265,7 @@ class Mutation:
 		const return_type = "VerifyPurchaseResult"
 		const is_array = false
 
-	## Verify purchases with the configured providers
+	## Verify a purchase against your own backend (returns isValid + raw store metadata).
 	class verifyPurchaseField:
 		const name = "verifyPurchase"
 		const snake_name = "verify_purchase"
@@ -5285,7 +5285,7 @@ class Mutation:
 		const return_type = "VerifyPurchaseResult"
 		const is_array = false
 
-	## Verify purchases with a specific provider (e.g., IAPKit)
+	## Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
 	class verifyPurchaseWithProviderField:
 		const name = "verifyPurchaseWithProvider"
 		const snake_name = "verify_purchase_with_provider"
@@ -5305,7 +5305,7 @@ class Mutation:
 		const return_type = "VerifyPurchaseWithProviderResult"
 		const is_array = false
 
-	## Clear pending transactions from the StoreKit payment queue
+	## Clear pending transactions in the queue (sandbox helper).
 	class clearTransactionIOSField:
 		const name = "clearTransactionIOS"
 		const snake_name = "clear_transaction_ios"
@@ -5314,7 +5314,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Purchase the promoted product surfaced by the App Store.
+	## Buy the currently promoted product.
 	class requestPurchaseOnPromotedProductIOSField:
 		const name = "requestPurchaseOnPromotedProductIOS"
 		const snake_name = "request_purchase_on_promoted_product_ios"
@@ -5323,7 +5323,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Open subscription management UI and return changed purchases (iOS 15+)
+	## Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
 	class showManageSubscriptionsIOSField:
 		const name = "showManageSubscriptionsIOS"
 		const snake_name = "show_manage_subscriptions_ios"
@@ -5332,7 +5332,7 @@ class Mutation:
 		const return_type = "PurchaseIOS"
 		const is_array = true
 
-	## Initiate a refund request for a product (iOS 15+)
+	## Present the refund request sheet (iOS 15+). See also Features → Refund.
 	class beginRefundRequestIOSField:
 		const name = "beginRefundRequestIOS"
 		const snake_name = "begin_refund_request_ios"
@@ -5352,7 +5352,7 @@ class Mutation:
 		const return_type = "String"
 		const is_array = false
 
-	## Force a StoreKit sync for transactions (iOS 15+)
+	## Force sync transactions with the App Store (iOS 15+).
 	class syncIOSField:
 		const name = "syncIOS"
 		const snake_name = "sync_ios"
@@ -5361,7 +5361,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Present the App Store code redemption sheet
+	## Show the App Store offer code redemption sheet.
 	class presentCodeRedemptionSheetIOSField:
 		const name = "presentCodeRedemptionSheetIOS"
 		const snake_name = "present_code_redemption_sheet_ios"
@@ -5370,7 +5370,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Present external purchase notice sheet (iOS 17.4+).
+	## Present the external purchase notice sheet (iOS 17.4+).
 	class presentExternalPurchaseNoticeSheetIOSField:
 		const name = "presentExternalPurchaseNoticeSheetIOS"
 		const snake_name = "present_external_purchase_notice_sheet_ios"
@@ -5379,7 +5379,7 @@ class Mutation:
 		const return_type = "ExternalPurchaseNoticeResultIOS"
 		const is_array = false
 
-	## Present external purchase custom link with StoreKit UI
+	## Present an external purchase link, StoreKit External (iOS 16+).
 	class presentExternalPurchaseLinkIOSField:
 		const name = "presentExternalPurchaseLinkIOS"
 		const snake_name = "present_external_purchase_link_ios"
@@ -5399,7 +5399,7 @@ class Mutation:
 		const return_type = "ExternalPurchaseLinkResultIOS"
 		const is_array = false
 
-	## Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
+	## Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
 	class showExternalPurchaseCustomLinkNoticeIOSField:
 		const name = "showExternalPurchaseCustomLinkNoticeIOS"
 		const snake_name = "show_external_purchase_custom_link_notice_ios"
@@ -5427,7 +5427,7 @@ class Mutation:
 		const return_type = "ExternalPurchaseCustomLinkNoticeResultIOS"
 		const is_array = false
 
-	## Acknowledge a non-consumable purchase or subscription
+	## Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
 	class acknowledgePurchaseAndroidField:
 		const name = "acknowledgePurchaseAndroid"
 		const snake_name = "acknowledge_purchase_android"
@@ -5447,7 +5447,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Consume a purchase token so it can be repurchased
+	## Consume a consumable purchase so it can be re-bought.
 	class consumePurchaseAndroidField:
 		const name = "consumePurchaseAndroid"
 		const snake_name = "consume_purchase_android"
@@ -5467,7 +5467,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Check if alternative billing is available for this user/device
+	## Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
 	class checkAlternativeBillingAvailabilityAndroidField:
 		const name = "checkAlternativeBillingAvailabilityAndroid"
 		const snake_name = "check_alternative_billing_availability_android"
@@ -5476,7 +5476,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Show alternative billing information dialog to user
+	## Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
 	class showAlternativeBillingDialogAndroidField:
 		const name = "showAlternativeBillingDialogAndroid"
 		const snake_name = "show_alternative_billing_dialog_android"
@@ -5485,7 +5485,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Create external transaction token for Google Play reporting
+	## Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
 	class createAlternativeBillingTokenAndroidField:
 		const name = "createAlternativeBillingTokenAndroid"
 		const snake_name = "create_alternative_billing_token_android"
@@ -5494,7 +5494,7 @@ class Mutation:
 		const return_type = "String"
 		const is_array = false
 
-	## Check if a billing program is available for the current user
+	## Check whether a billing program (e.g., External Payments) is available for the current user.
 	class isBillingProgramAvailableAndroidField:
 		const name = "isBillingProgramAvailableAndroid"
 		const snake_name = "is_billing_program_available_android"
@@ -5521,7 +5521,7 @@ class Mutation:
 		const return_type = "BillingProgramAvailabilityResultAndroid"
 		const is_array = false
 
-	## Create reporting details for a billing program
+	## Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
 	class createBillingProgramReportingDetailsAndroidField:
 		const name = "createBillingProgramReportingDetailsAndroid"
 		const snake_name = "create_billing_program_reporting_details_android"
@@ -5548,7 +5548,7 @@ class Mutation:
 		const return_type = "BillingProgramReportingDetailsAndroid"
 		const is_array = false
 
-	## Launch external link flow for external billing programs
+	## Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
 	class launchExternalLinkAndroidField:
 		const name = "launchExternalLinkAndroid"
 		const snake_name = "launch_external_link_android"
@@ -5576,7 +5576,7 @@ class Mutation:
 
 # Query API helpers
 
-## Retrieve products or subscriptions from the store
+## Fetch products or subscriptions from the store.
 static func fetch_products_args(params: ProductRequest) -> Dictionary:
 	var args = {}
 	if params != null:
@@ -5586,7 +5586,7 @@ static func fetch_products_args(params: ProductRequest) -> Dictionary:
 			args["params"] = params
 	return args
 
-## Get all available purchases for the current user
+## List active purchases for the current user.
 static func get_available_purchases_args(options: PurchaseOptions) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5596,97 +5596,97 @@ static func get_available_purchases_args(options: PurchaseOptions) -> Dictionary
 			args["options"] = options
 	return args
 
-## Get active subscriptions (filters by subscriptionIds when provided)
+## Get details of all currently active subscriptions (filters by subscriptionIds when provided).
 static func get_active_subscriptions_args(subscription_ids: Array[String]) -> Dictionary:
 	var args = {}
 	args["subscriptionIds"] = subscription_ids
 	return args
 
-## Check whether the user has active subscriptions
+## Check whether the user has any active subscription.
 static func has_active_subscriptions_args(subscription_ids: Array[String]) -> Dictionary:
 	var args = {}
 	args["subscriptionIds"] = subscription_ids
 	return args
 
-## Get the current storefront country code
+## Return the user's storefront country code.
 static func get_storefront_args() -> Dictionary:
 	return {}
 
-## Get the current App Store storefront country code
+## Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
 static func get_storefront_ios_args() -> Dictionary:
 	return {}
 
-## Get the currently promoted product (iOS 11+)
+## Read the App Store-promoted product, if any (iOS 11+).
 static func get_promoted_product_ios_args() -> Dictionary:
 	return {}
 
-## Check if external purchase notice sheet can be presented (iOS 17.4+)
+## Check eligibility for the external purchase notice sheet (iOS 17.4+).
 static func can_present_external_purchase_notice_ios_args() -> Dictionary:
 	return {}
 
-## Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+## Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
 static func is_eligible_for_external_purchase_custom_link_ios_args() -> Dictionary:
 	return {}
 
-## Get external purchase token for reporting to Apple (iOS 18.1+).
+## Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
 static func get_external_purchase_custom_link_token_ios_args(token_type: ExternalPurchaseCustomLinkTokenTypeIOS) -> Dictionary:
 	var args = {}
 	args["tokenType"] = token_type
 	return args
 
-## Retrieve all pending transactions in the StoreKit queue
+## List unfinished StoreKit transactions in the queue.
 static func get_pending_transactions_ios_args() -> Dictionary:
 	return {}
 
-## Check introductory offer eligibility for a subscription group
+## Check intro-offer eligibility for a subscription group.
 static func is_eligible_for_intro_offer_ios_args(group_id: String) -> Dictionary:
 	var args = {}
 	args["groupID"] = group_id
 	return args
 
-## Get StoreKit 2 subscription status details (iOS 15+)
+## Get subscription status objects from StoreKit 2 (iOS 15+).
 static func subscription_status_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Get current StoreKit 2 entitlements (iOS 15+)
+## Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
 static func current_entitlement_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Get the latest transaction for a product using StoreKit 2
+## Get the latest verified transaction for a product, using StoreKit 2.
 static func latest_transaction_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Verify a StoreKit 2 transaction signature
+## Check whether a transaction's JWS verification passed (StoreKit 2).
 static func is_transaction_verified_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Get the transaction JWS (StoreKit 2)
+## Return the JWS string for a transaction (StoreKit 2).
 static func get_transaction_jws_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Get base64-encoded receipt data for validation
+## Get base64-encoded receipt data (legacy validation).
 static func get_receipt_data_ios_args() -> Dictionary:
 	return {}
 
-## Fetch the current app transaction (iOS 16+)
+## Fetch the app transaction (iOS 16+).
 static func get_app_transaction_ios_args() -> Dictionary:
 	return {}
 
-## Get the full StoreKit 2 transaction history as PurchaseIOS values.
+## List every StoreKit transaction (finished + unfinished) for the current user.
 static func get_all_transactions_ios_args() -> Dictionary:
 	return {}
 
-## Validate a receipt for a specific product
+## Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
 static func validate_receipt_ios_args(options: VerifyPurchaseProps) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5698,7 +5698,7 @@ static func validate_receipt_ios_args(options: VerifyPurchaseProps) -> Dictionar
 
 # Mutation API helpers
 
-## Establish the platform billing connection
+## Initialize the store connection. Call before any IAP API.
 static func init_connection_args(config: InitConnectionConfig) -> Dictionary:
 	var args = {}
 	if config != null:
@@ -5708,11 +5708,11 @@ static func init_connection_args(config: InitConnectionConfig) -> Dictionary:
 			args["config"] = config
 	return args
 
-## Close the platform billing connection
+## Close the store connection and release resources.
 static func end_connection_args() -> Dictionary:
 	return {}
 
-## Initiate a purchase flow; rely on events for final state
+## Initiate a purchase or subscription flow; rely on events for final state.
 static func request_purchase_args(params: RequestPurchaseProps) -> Dictionary:
 	var args = {}
 	if params != null:
@@ -5722,7 +5722,7 @@ static func request_purchase_args(params: RequestPurchaseProps) -> Dictionary:
 			args["params"] = params
 	return args
 
-## Finish a transaction after validating receipts
+## Complete a transaction after server-side verification. Required on Android within 3 days.
 static func finish_transaction_args(purchase: PurchaseInput, is_consumable: bool) -> Dictionary:
 	var args = {}
 	if purchase != null:
@@ -5733,11 +5733,11 @@ static func finish_transaction_args(purchase: PurchaseInput, is_consumable: bool
 	args["isConsumable"] = is_consumable
 	return args
 
-## Restore completed purchases across platforms
+## Restore non-consumable and active subscription purchases.
 static func restore_purchases_args() -> Dictionary:
 	return {}
 
-## Open the native subscription management surface
+## Open the platform's subscription management UI.
 static func deep_link_to_subscriptions_args(options: DeepLinkOptions) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5747,7 +5747,7 @@ static func deep_link_to_subscriptions_args(options: DeepLinkOptions) -> Diction
 			args["options"] = options
 	return args
 
-## Validate purchase receipts with the configured providers
+## Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
 static func validate_receipt_args(options: VerifyPurchaseProps) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5757,7 +5757,7 @@ static func validate_receipt_args(options: VerifyPurchaseProps) -> Dictionary:
 			args["options"] = options
 	return args
 
-## Verify purchases with the configured providers
+## Verify a purchase against your own backend (returns isValid + raw store metadata).
 static func verify_purchase_args(options: VerifyPurchaseProps) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5767,7 +5767,7 @@ static func verify_purchase_args(options: VerifyPurchaseProps) -> Dictionary:
 			args["options"] = options
 	return args
 
-## Verify purchases with a specific provider (e.g., IAPKit)
+## Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
 static func verify_purchase_with_provider_args(options: VerifyPurchaseWithProviderProps) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5777,85 +5777,85 @@ static func verify_purchase_with_provider_args(options: VerifyPurchaseWithProvid
 			args["options"] = options
 	return args
 
-## Clear pending transactions from the StoreKit payment queue
+## Clear pending transactions in the queue (sandbox helper).
 static func clear_transaction_ios_args() -> Dictionary:
 	return {}
 
-## Purchase the promoted product surfaced by the App Store.
+## Buy the currently promoted product.
 static func request_purchase_on_promoted_product_ios_args() -> Dictionary:
 	return {}
 
-## Open subscription management UI and return changed purchases (iOS 15+)
+## Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
 static func show_manage_subscriptions_ios_args() -> Dictionary:
 	return {}
 
-## Initiate a refund request for a product (iOS 15+)
+## Present the refund request sheet (iOS 15+). See also Features → Refund.
 static func begin_refund_request_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Force a StoreKit sync for transactions (iOS 15+)
+## Force sync transactions with the App Store (iOS 15+).
 static func sync_ios_args() -> Dictionary:
 	return {}
 
-## Present the App Store code redemption sheet
+## Show the App Store offer code redemption sheet.
 static func present_code_redemption_sheet_ios_args() -> Dictionary:
 	return {}
 
-## Present external purchase notice sheet (iOS 17.4+).
+## Present the external purchase notice sheet (iOS 17.4+).
 static func present_external_purchase_notice_sheet_ios_args() -> Dictionary:
 	return {}
 
-## Present external purchase custom link with StoreKit UI
+## Present an external purchase link, StoreKit External (iOS 16+).
 static func present_external_purchase_link_ios_args(url: String) -> Dictionary:
 	var args = {}
 	args["url"] = url
 	return args
 
-## Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
+## Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
 static func show_external_purchase_custom_link_notice_ios_args(notice_type: ExternalPurchaseCustomLinkNoticeTypeIOS) -> Dictionary:
 	var args = {}
 	args["noticeType"] = notice_type
 	return args
 
-## Acknowledge a non-consumable purchase or subscription
+## Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
 static func acknowledge_purchase_android_args(purchase_token: String) -> Dictionary:
 	var args = {}
 	args["purchaseToken"] = purchase_token
 	return args
 
-## Consume a purchase token so it can be repurchased
+## Consume a consumable purchase so it can be re-bought.
 static func consume_purchase_android_args(purchase_token: String) -> Dictionary:
 	var args = {}
 	args["purchaseToken"] = purchase_token
 	return args
 
-## Check if alternative billing is available for this user/device
+## Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
 static func check_alternative_billing_availability_android_args() -> Dictionary:
 	return {}
 
-## Show alternative billing information dialog to user
+## Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
 static func show_alternative_billing_dialog_android_args() -> Dictionary:
 	return {}
 
-## Create external transaction token for Google Play reporting
+## Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
 static func create_alternative_billing_token_android_args() -> Dictionary:
 	return {}
 
-## Check if a billing program is available for the current user
+## Check whether a billing program (e.g., External Payments) is available for the current user.
 static func is_billing_program_available_android_args(program: BillingProgramAndroid) -> Dictionary:
 	var args = {}
 	args["program"] = program
 	return args
 
-## Create reporting details for a billing program
+## Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
 static func create_billing_program_reporting_details_android_args(program: BillingProgramAndroid) -> Dictionary:
 	var args = {}
 	args["program"] = program
 	return args
 
-## Launch external link flow for external billing programs
+## Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
 static func launch_external_link_android_args(params: LaunchExternalLinkParamsAndroid) -> Dictionary:
 	var args = {}
 	if params != null:

--- a/libraries/godot-iap/addons/godot-iap/types.gd
+++ b/libraries/godot-iap/addons/godot-iap/types.gd
@@ -5285,7 +5285,7 @@ class Mutation:
 		const return_type = "VerifyPurchaseResult"
 		const is_array = false
 
-	## Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+	## Verify via a managed provider without standing up your own server. The
 	class verifyPurchaseWithProviderField:
 		const name = "verifyPurchaseWithProvider"
 		const snake_name = "verify_purchase_with_provider"
@@ -5767,7 +5767,7 @@ static func verify_purchase_args(options: VerifyPurchaseProps) -> Dictionary:
 			args["options"] = options
 	return args
 
-## Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+## Verify via a managed provider without standing up your own server. The
 static func verify_purchase_with_provider_args(options: VerifyPurchaseWithProviderProps) -> Dictionary:
 	var args = {}
 	if options != null:

--- a/libraries/godot-iap/addons/godot-iap/types.gd
+++ b/libraries/godot-iap/addons/godot-iap/types.gd
@@ -5265,7 +5265,7 @@ class Mutation:
 		const return_type = "VerifyPurchaseResult"
 		const is_array = false
 
-	## Verify a purchase against your own backend (returns isValid + raw store metadata).
+	## Verify a purchase against your own backend. Returns a platform-specific
 	class verifyPurchaseField:
 		const name = "verifyPurchase"
 		const snake_name = "verify_purchase"
@@ -5757,7 +5757,7 @@ static func validate_receipt_args(options: VerifyPurchaseProps) -> Dictionary:
 			args["options"] = options
 	return args
 
-## Verify a purchase against your own backend (returns isValid + raw store metadata).
+## Verify a purchase against your own backend. Returns a platform-specific
 static func verify_purchase_args(options: VerifyPurchaseProps) -> Dictionary:
 	var args = {}
 	if options != null:

--- a/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
+++ b/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
@@ -523,8 +523,10 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
      * Initiate a purchase or subscription flow. Result is delivered via the
      * purchaseUpdated event flow — NOT the return value.
      *
-     * @param props [RequestPurchaseProps]. Pass `request.apple.sku` (iOS) and/or
-     *   `request.google.skus` (Android); subscriptions need `subscriptionOffers`.
+     * @param request [RequestPurchaseProps]. The OUTER `request` is the props envelope;
+     *   the INNER `RequestPurchaseProps.request` field carries the per-platform payload —
+     *   set `request.request.apple.sku` (iOS) and/or `request.request.google.skus`
+     *   (Android). Subscriptions also need `subscriptionOffers` on Android.
      * @return The dispatched purchase payload (do not rely on this for the outcome).
      * @throws PurchaseException on synchronous rejection (billing not ready, missing offerToken).
      *

--- a/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
+++ b/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
@@ -484,47 +484,160 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
     // ---------------------------------------------------------------------
     // Interface implementation
     // ---------------------------------------------------------------------
+    /**
+     * Initialize the store connection. Must be called before any other IAP API.
+     *
+     * @param config Optional [InitConnectionConfig]. Use `enableBillingProgramAndroid`
+     *   (Android, Play Billing 8.2.0+) to opt into External Payments etc.; iOS ignores
+     *   Android-specific fields.
+     * @return `true` once the platform billing client is connected.
+     * @throws PurchaseException when the billing client fails to initialize.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/init-connection">init-connection</a>
+     */
     override suspend fun initConnection(config: InitConnectionConfig?): Boolean = initConnectionHandler(config)
 
+    /**
+     * Close the store connection and release resources.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/end-connection">https://www.openiap.dev/docs/apis/end-connection</a>
+     */
     override suspend fun endConnection(): Boolean = endConnectionHandler()
 
+    /**
+     * Retrieve products or subscriptions from the store by SKU.
+     *
+     * @param params [ProductRequest] with `skus` and optional `type`
+     *   ([ProductQueryType.InApp], [ProductQueryType.Subs], or [ProductQueryType.All];
+     *   defaults to InApp).
+     * @return [FetchProductsResult] sealed variant — Products for InApp, Subscriptions
+     *   for Subs, mixed for All.
+     * @throws PurchaseException on store rejection (unknown SKU, network, not connected).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/fetch-products">fetch-products</a>
+     */
     override suspend fun fetchProducts(params: ProductRequest): FetchProductsResult =
         fetchProductsHandler(params)
 
+    /**
+     * Initiate a purchase or subscription flow. Result is delivered via the
+     * purchaseUpdated event flow — NOT the return value.
+     *
+     * @param props [RequestPurchaseProps]. Pass `request.apple.sku` (iOS) and/or
+     *   `request.google.skus` (Android); subscriptions need `subscriptionOffers`.
+     * @return The dispatched purchase payload (do not rely on this for the outcome).
+     * @throws PurchaseException on synchronous rejection (billing not ready, missing offerToken).
+     *
+     * Warning: Event-based. Collect from `purchaseUpdatedListener` / `purchaseErrorListener`
+     * (or the equivalent flows on `KmpIAP`) for the final state.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/request-purchase">request-purchase</a>
+     */
     override suspend fun requestPurchase(request: RequestPurchaseProps): RequestPurchaseResult? =
         requestPurchaseHandler(request)
 
+    /**
+     * List the user's unfinished purchases — non-consumables, active subscriptions, and
+     * any pending transactions not finished previously.
+     *
+     * @param options Optional [PurchaseOptions]. iOS-only fields
+     *   (`alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`) are ignored on Android.
+     * @return List of [Purchase] currently held by the platform store.
+     * @throws PurchaseException when the platform query fails.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/get-available-purchases">get-available-purchases</a>
+     */
     override suspend fun getAvailablePurchases(options: PurchaseOptions?): List<Purchase> =
         getAvailablePurchasesHandler(options)
 
     suspend fun getPurchaseHistories(options: PurchaseOptions?): List<Purchase> = emptyList()
 
+    /**
+     * Get details of all currently active subscriptions.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/get-active-subscriptions">https://www.openiap.dev/docs/apis/get-active-subscriptions</a>
+     */
     override suspend fun getActiveSubscriptions(subscriptionIds: List<String>?): List<ActiveSubscription> =
         getActiveSubscriptionsHandler(subscriptionIds)
 
+    /**
+     * Check whether the user has any active subscription.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/has-active-subscriptions">https://www.openiap.dev/docs/apis/has-active-subscriptions</a>
+     */
     override suspend fun hasActiveSubscriptions(subscriptionIds: List<String>?): Boolean =
         hasActiveSubscriptionsHandler(subscriptionIds)
 
+    /**
+     * Restore non-consumable and active subscription purchases.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/restore-purchases">https://www.openiap.dev/docs/apis/restore-purchases</a>
+     */
     override suspend fun restorePurchases() {
         getAvailablePurchasesHandler.invoke(null)
     }
 
+    /**
+     * Get the user's current entitlement for a product.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/current-entitlement-ios">https://www.openiap.dev/docs/apis/ios/current-entitlement-ios</a>
+     */
     override suspend fun currentEntitlementIOS(sku: String): PurchaseIOS? = null
 
+    /**
+     * Fetch the app transaction (iOS 16+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios">https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios</a>
+     */
     override suspend fun getAppTransactionIOS(): AppTransaction? = null
 
+    /**
+     * List unfinished StoreKit transactions.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios">https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios</a>
+     */
     override suspend fun getPendingTransactionsIOS(): List<PurchaseIOS> = emptyList()
 
+    /**
+     * List every StoreKit transaction (finished + unfinished).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios">https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios</a>
+     */
     override suspend fun getAllTransactionsIOS(): List<PurchaseIOS> = emptyList()
 
+    /**
+     * Get base64 receipt data (legacy validation).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios">https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios</a>
+     */
     override suspend fun getReceiptDataIOS(): String? = null
 
+    /**
+     * Return the JWS string for a transaction.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios">https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios</a>
+     */
     override suspend fun getTransactionJwsIOS(sku: String): String? = null
 
+    /**
+     * Check intro-offer eligibility for a subscription group.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios">https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios</a>
+     */
     override suspend fun isEligibleForIntroOfferIOS(groupID: String): Boolean = false
 
+    /**
+     * Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios">https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios</a>
+     */
     override suspend fun isEligibleForExternalPurchaseCustomLinkIOS(): Boolean = false
 
+    /**
+     * Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios">https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios</a>
+     */
     override suspend fun showExternalPurchaseCustomLinkNoticeIOS(
         noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS
     ): ExternalPurchaseCustomLinkNoticeResultIOS {
@@ -536,6 +649,11 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
         )
     }
 
+    /**
+     * Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios">https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios</a>
+     */
     override suspend fun getExternalPurchaseCustomLinkTokenIOS(
         tokenType: ExternalPurchaseCustomLinkTokenTypeIOS
     ): ExternalPurchaseCustomLinkTokenResultIOS {
@@ -547,12 +665,32 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
         )
     }
 
+    /**
+     * Check whether a transaction's JWS verification passed.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios">https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios</a>
+     */
     override suspend fun isTransactionVerifiedIOS(sku: String): Boolean = false
 
+    /**
+     * Get the latest verified transaction for a product.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/latest-transaction-ios">https://www.openiap.dev/docs/apis/ios/latest-transaction-ios</a>
+     */
     override suspend fun latestTransactionIOS(sku: String): PurchaseIOS? = null
 
+    /**
+     * Get subscription status objects from StoreKit 2.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/subscription-status-ios">https://www.openiap.dev/docs/apis/ios/subscription-status-ios</a>
+     */
     override suspend fun subscriptionStatusIOS(sku: String): List<SubscriptionStatusIOS> = emptyList()
 
+    /**
+     * Deprecated. Legacy App Store receipt validation.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/validate-receipt-ios">https://www.openiap.dev/docs/apis/ios/validate-receipt-ios</a>
+     */
     override suspend fun validateReceiptIOS(options: VerifyPurchaseProps): VerifyPurchaseResultIOS {
         failWith(
             PurchaseError(
@@ -572,10 +710,28 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
 
     override suspend fun subscriptionBillingIssue(): Purchase = subscriptionBillingIssueListener.first()
 
+    /**
+     * Complete a purchase transaction. Call after server-side verification.
+     *
+     * @param purchase The [Purchase] to finalize.
+     * @param isConsumable `true` for consumables (Android consume — token can be re-bought),
+     *   `false` for non-consumables and subscriptions (acknowledge only). Default `false`.
+     * @throws PurchaseException when the platform finalize call fails.
+     *
+     * Important: Android auto-refunds purchases NOT acknowledged/consumed within 3 days.
+     * iOS unfinished transactions replay on every app launch.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/finish-transaction">finish-transaction</a>
+     */
     override suspend fun finishTransaction(purchase: PurchaseInput, isConsumable: Boolean?) {
         finishTransactionHandler(purchase, isConsumable)
     }
 
+    /**
+     * Open the platform's subscription management UI.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/deep-link-to-subscriptions">https://www.openiap.dev/docs/apis/deep-link-to-subscriptions</a>
+     */
     override suspend fun deepLinkToSubscriptions(options: DeepLinkOptions?) {
         deepLinkToSubscriptionsHandler(options)
     }
@@ -805,6 +961,11 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
     // ---------------------------------------------------------------------
     // Android specific overrides
     // ---------------------------------------------------------------------
+    /**
+     * Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android">https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android</a>
+     */
     override suspend fun acknowledgePurchaseAndroid(purchaseToken: String): Boolean {
         ensureConnectedOrFail(isConnected, ::failWith)
         val params = AcknowledgePurchaseParams.newBuilder()
@@ -829,6 +990,11 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
         }
     }
 
+    /**
+     * Consume a consumable purchase so it can be re-bought.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/consume-purchase-android">https://www.openiap.dev/docs/apis/android/consume-purchase-android</a>
+     */
     override suspend fun consumePurchaseAndroid(purchaseToken: String): Boolean {
         ensureConnectedOrFail(isConnected, ::failWith)
         val params = ConsumeParams.newBuilder()
@@ -851,18 +1017,78 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
         }
     }
 
+    /**
+     * Deprecated. Use cross-platform getStorefront instead.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-storefront-ios">https://www.openiap.dev/docs/apis/ios/get-storefront-ios</a>
+     */
     override suspend fun getStorefrontIOS(): String = ""
+
+    /**
+     * Show the App Store offer code redemption sheet.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios">https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios</a>
+     */
     override suspend fun presentCodeRedemptionSheetIOS(): Boolean = false
+
     suspend fun finishTransactionIOS(transactionId: String) {}
+
+    /**
+     * Clear pending transactions in the queue (sandbox helper).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/clear-transaction-ios">https://www.openiap.dev/docs/apis/ios/clear-transaction-ios</a>
+     */
     override suspend fun clearTransactionIOS(): Boolean = false
+
     suspend fun clearProductsIOS() {}
+
+    /**
+     * Read the App Store-promoted product, if any.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios">https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios</a>
+     */
     override suspend fun getPromotedProductIOS(): ProductIOS? = null
+
+    /**
+     * Buy the currently promoted product.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios">https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios</a>
+     */
     override suspend fun requestPurchaseOnPromotedProductIOS(): Boolean = false
+
+    /**
+     * Present the refund request sheet (iOS 15+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios">https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios</a>
+     */
     override suspend fun beginRefundRequestIOS(sku: String): String? = null
+
+    /**
+     * Present the manage-subscriptions sheet.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios">https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios</a>
+     */
     override suspend fun showManageSubscriptionsIOS(): List<PurchaseIOS> = emptyList()
+
+    /**
+     * Force sync transactions with the App Store.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/sync-ios">https://www.openiap.dev/docs/apis/ios/sync-ios</a>
+     */
     override suspend fun syncIOS(): Boolean = false
+
+    /**
+     * Deprecated. Use verifyPurchase instead.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/validate-receipt">https://www.openiap.dev/docs/apis/validate-receipt</a>
+     */
     override suspend fun validateReceipt(options: ValidationOptions): ValidationResult = validateReceiptHandler(options)
 
+    /**
+     * Verify a purchase against your own backend.
+     *
+     * @see <a href="https://www.openiap.dev/docs/features/validation#verify-purchase">https://www.openiap.dev/docs/features/validation#verify-purchase</a>
+     */
     override suspend fun verifyPurchase(options: VerifyPurchaseProps): VerifyPurchaseResult {
         // Android doesn't support native receipt verification like iOS
         // Use verifyPurchaseWithProvider for server-side verification via IAPKit
@@ -874,6 +1100,11 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
         )
     }
 
+    /**
+     * Verify via a managed provider (IAPKit, Apple, Google, Horizon).
+     *
+     * @see <a href="https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider">https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider</a>
+     */
     override suspend fun verifyPurchaseWithProvider(options: VerifyPurchaseWithProviderProps): VerifyPurchaseWithProviderResult {
         if (options.provider != PurchaseVerificationProvider.Iapkit) {
             failWith(
@@ -961,6 +1192,11 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
         activity.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
     }
 
+    /**
+     * Return the user's storefront country code.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/get-storefront">https://www.openiap.dev/docs/apis/get-storefront</a>
+     */
     override suspend fun getStorefront(): String {
         // Android doesn't have a storefront concept like iOS
         // Return a default value or country code based on locale
@@ -971,14 +1207,29 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
     // iOS External Purchase Methods (stubs for Android)
     // ---------------------------------------------------------------------
 
+    /**
+     * Present an external purchase link (iOS 16+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios">https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios</a>
+     */
     override suspend fun presentExternalPurchaseLinkIOS(url: String): ExternalPurchaseLinkResultIOS {
         failWith(PurchaseError(code = ErrorCode.FeatureNotSupported, message = "External purchase links are iOS only"))
     }
 
+    /**
+     * Present the external purchase notice sheet (iOS 17.4+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios">https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios</a>
+     */
     override suspend fun presentExternalPurchaseNoticeSheetIOS(): ExternalPurchaseNoticeResultIOS {
         failWith(PurchaseError(code = ErrorCode.FeatureNotSupported, message = "External purchase notice sheet is iOS only"))
     }
 
+    /**
+     * Check eligibility for the external purchase notice sheet (iOS 17.4+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios">https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios</a>
+     */
     override suspend fun canPresentExternalPurchaseNoticeIOS(): Boolean {
         return false // Not supported on Android
     }
@@ -1000,11 +1251,9 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
     // ---------------------------------------------------------------------
 
     /**
-     * Check if alternative billing is available for this user/device (Android only).
-     * Step 1 of alternative billing flow.
+     * Check whether alternative billing is available for the user.
      *
-     * For AlternativeOnly mode: Uses isAlternativeBillingOnlyAvailableAsync
-     * For UserChoice mode: Uses isFeatureSupported with ALTERNATIVE_BILLING feature
+     * @see <a href="https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android">https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android</a>
      */
     override suspend fun checkAlternativeBillingAvailabilityAndroid(): Boolean {
         return withContext(Dispatchers.IO) {
@@ -1032,12 +1281,9 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
     }
 
     /**
-     * Show alternative billing information dialog to user (Android only).
-     * Step 2 of alternative billing flow.
-     * Must be called BEFORE processing payment in your payment system.
+     * Display Google's alternative billing information dialog.
      *
-     * Note: This is only applicable for AlternativeOnly mode.
-     * For UserChoice mode, Google automatically shows selection dialog.
+     * @see <a href="https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android">https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android</a>
      */
     override suspend fun showAlternativeBillingDialogAndroid(): Boolean {
         // Only applicable for AlternativeOnly mode
@@ -1063,13 +1309,9 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
     }
 
     /**
-     * Create external transaction token for Google Play reporting (Android only).
-     * Step 3 of alternative billing flow.
-     * Must be called AFTER successful payment in your payment system.
-     * Token must be reported to Google Play backend within 24 hours.
+     * Create a reporting token for an alternative billing flow.
      *
-     * Note: This is only applicable for AlternativeOnly mode.
-     * For UserChoice mode, the token is provided in UserChoiceBillingDetails.
+     * @see <a href="https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android">https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android</a>
      */
     override suspend fun createAlternativeBillingTokenAndroid(): String? {
         // Only applicable for AlternativeOnly mode
@@ -1100,6 +1342,11 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
     // Full implementation uses Google Play Billing Library 8.2.1
     // ---------------------------------------------------------------------
 
+    /**
+     * Check whether a billing program is available.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/is-billing-program-available-android">https://www.openiap.dev/docs/apis/android/is-billing-program-available-android</a>
+     */
     override suspend fun isBillingProgramAvailableAndroid(
         program: BillingProgramAndroid
     ): BillingProgramAvailabilityResultAndroid {
@@ -1173,6 +1420,11 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
         }
     }
 
+    /**
+     * Create the reporting payload Google requires (Play Billing 8.3.0+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android">https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android</a>
+     */
     override suspend fun createBillingProgramReportingDetailsAndroid(
         program: BillingProgramAndroid
     ): BillingProgramReportingDetailsAndroid {
@@ -1275,6 +1527,11 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
         }
     }
 
+    /**
+     * Launch an external content/offer link (Play Billing 8.2.0+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/launch-external-link-android">https://www.openiap.dev/docs/apis/android/launch-external-link-android</a>
+     */
     override suspend fun launchExternalLinkAndroid(params: LaunchExternalLinkParamsAndroid): Boolean {
         val client = billingClient ?: throw PurchaseException(
             PurchaseError(

--- a/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
+++ b/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
@@ -1101,7 +1101,7 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
     }
 
     /**
-     * Verify via a managed provider (IAPKit, Apple, Google, Horizon).
+     * Verify via a managed provider (currently IAPKit; the PurchaseVerificationProvider enum exposes only Iapkit today).
      *
      * @see <a href="https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider">https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider</a>
      */

--- a/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/openiap/Types.kt
+++ b/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/openiap/Types.kt
@@ -4993,7 +4993,9 @@ public interface MutationResolver {
      */
     suspend fun verifyPurchase(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+     * Verify via a managed provider without standing up your own server. The
+     * PurchaseVerificationProvider enum currently exposes only IAPKit; platform
+     * availability may differ by implementation.
      * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
      */
     suspend fun verifyPurchaseWithProvider(options: VerifyPurchaseWithProviderProps): VerifyPurchaseWithProviderResult

--- a/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/openiap/Types.kt
+++ b/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/openiap/Types.kt
@@ -4835,146 +4835,166 @@ public sealed interface VerifyPurchaseResult {
  */
 public interface MutationResolver {
     /**
-     * Acknowledge a non-consumable purchase or subscription
+     * Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+     * See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
      */
     suspend fun acknowledgePurchaseAndroid(purchaseToken: String): Boolean
     /**
-     * Initiate a refund request for a product (iOS 15+)
+     * Present the refund request sheet (iOS 15+). See also Features → Refund.
+     * See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
      */
     suspend fun beginRefundRequestIOS(sku: String): String?
     /**
-     * Check if alternative billing is available for this user/device
-     * Step 1 of alternative billing flow
+     * Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
      * 
-     * Returns true if available, false otherwise
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns true if available, false otherwise.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
      */
     suspend fun checkAlternativeBillingAvailabilityAndroid(): Boolean
     /**
-     * Clear pending transactions from the StoreKit payment queue
+     * Clear pending transactions in the queue (sandbox helper).
+     * See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
      */
     suspend fun clearTransactionIOS(): Boolean
     /**
-     * Consume a purchase token so it can be repurchased
+     * Consume a consumable purchase so it can be re-bought.
+     * See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
      */
     suspend fun consumePurchaseAndroid(purchaseToken: String): Boolean
     /**
-     * Create external transaction token for Google Play reporting
-     * Step 3 of alternative billing flow
-     * Must be called AFTER successful payment in your payment system
-     * Token must be reported to Google Play backend within 24 hours
+     * Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
+     * Must be called AFTER successful payment in your payment system.
+     * Token must be reported to Google Play backend within 24 hours.
      * 
-     * Returns token string, or null if creation failed
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns token string, or null if creation failed.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
      */
     suspend fun createAlternativeBillingTokenAndroid(): String?
     /**
-     * Create reporting details for a billing program
-     * Replaces the deprecated createExternalOfferReportingDetailsAsync API
+     * Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+     * Replaces the deprecated createExternalOfferReportingDetailsAsync API.
      * 
-     * Available in Google Play Billing Library 8.2.0+
-     * Returns external transaction token needed for reporting external transactions
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns external transaction token needed for reporting external transactions.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
      */
     suspend fun createBillingProgramReportingDetailsAndroid(program: BillingProgramAndroid): BillingProgramReportingDetailsAndroid
     /**
-     * Open the native subscription management surface
+     * Open the platform's subscription management UI.
+     * See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
      */
     suspend fun deepLinkToSubscriptions(options: DeepLinkOptions? = null): Unit
     /**
-     * Close the platform billing connection
+     * Close the store connection and release resources.
+     * See: https://www.openiap.dev/docs/apis/end-connection
      */
     suspend fun endConnection(): Boolean
     /**
-     * Finish a transaction after validating receipts
+     * Complete a transaction after server-side verification. Required on Android within 3 days.
+     * See: https://www.openiap.dev/docs/apis/finish-transaction
      */
     suspend fun finishTransaction(purchase: PurchaseInput, isConsumable: Boolean? = null): Unit
     /**
-     * Establish the platform billing connection
+     * Initialize the store connection. Call before any IAP API.
+     * See: https://www.openiap.dev/docs/apis/init-connection
      */
     suspend fun initConnection(config: InitConnectionConfig? = null): Boolean
     /**
-     * Check if a billing program is available for the current user
-     * Replaces the deprecated isExternalOfferAvailableAsync API
+     * Check whether a billing program (e.g., External Payments) is available for the current user.
+     * Replaces the deprecated isExternalOfferAvailableAsync API.
      * 
-     * Available in Google Play Billing Library 8.2.0+
-     * Returns availability result with isAvailable flag
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Available in Google Play Billing Library 8.2.0+.
+     * Returns availability result with isAvailable flag.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
      */
     suspend fun isBillingProgramAvailableAndroid(program: BillingProgramAndroid): BillingProgramAvailabilityResultAndroid
     /**
-     * Launch external link flow for external billing programs
-     * Replaces the deprecated showExternalOfferInformationDialog API
+     * Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+     * Replaces the deprecated showExternalOfferInformationDialog API.
      * 
-     * Available in Google Play Billing Library 8.2.0+
-     * Shows Play Store dialog and optionally launches external URL
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Shows Play Store dialog and optionally launches external URL.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
      */
     suspend fun launchExternalLinkAndroid(params: LaunchExternalLinkParamsAndroid): Boolean
     /**
-     * Present the App Store code redemption sheet
+     * Show the App Store offer code redemption sheet.
+     * See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
      */
     suspend fun presentCodeRedemptionSheetIOS(): Boolean
     /**
-     * Present external purchase custom link with StoreKit UI
+     * Present an external purchase link, StoreKit External (iOS 16+).
+     * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
      */
     suspend fun presentExternalPurchaseLinkIOS(url: String): ExternalPurchaseLinkResultIOS
     /**
-     * Present external purchase notice sheet (iOS 17.4+).
-     * Uses ExternalPurchase.presentNoticeSheet() which returns a token when user continues.
+     * Present the external purchase notice sheet (iOS 17.4+).
+     * Uses ExternalPurchase.presentNoticeSheet() which returns a token when the user continues.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()
+     * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
      */
     suspend fun presentExternalPurchaseNoticeSheetIOS(): ExternalPurchaseNoticeResultIOS
     /**
-     * Initiate a purchase flow; rely on events for final state
+     * Initiate a purchase or subscription flow; rely on events for final state.
+     * See: https://www.openiap.dev/docs/apis/request-purchase
      */
     suspend fun requestPurchase(params: RequestPurchaseProps): RequestPurchaseResult?
     /**
-     * Purchase the promoted product surfaced by the App Store.
+     * Buy the currently promoted product.
      * 
      * @deprecated Use promotedProductListenerIOS to receive the productId,
      * then call requestPurchase with that SKU instead. In StoreKit 2,
      * promoted products can be purchased directly via the standard purchase flow.
+     * See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
      */
     suspend fun requestPurchaseOnPromotedProductIOS(): Boolean
     /**
-     * Restore completed purchases across platforms
+     * Restore non-consumable and active subscription purchases.
+     * See: https://www.openiap.dev/docs/apis/restore-purchases
      */
     suspend fun restorePurchases(): Unit
     /**
-     * Show alternative billing information dialog to user
-     * Step 2 of alternative billing flow
-     * Must be called BEFORE processing payment in your payment system
+     * Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
+     * Must be called BEFORE processing payment in your payment system.
      * 
-     * Returns true if user accepted, false if user canceled
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns true if user accepted, false if user canceled.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
      */
     suspend fun showAlternativeBillingDialogAndroid(): Boolean
     /**
-     * Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-     * Displays the system disclosure notice sheet for custom external purchase links.
+     * Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
      * Call this after a deliberate customer interaction before linking out to external purchases.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+     * See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
      */
     suspend fun showExternalPurchaseCustomLinkNoticeIOS(noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS): ExternalPurchaseCustomLinkNoticeResultIOS
     /**
-     * Open subscription management UI and return changed purchases (iOS 15+)
+     * Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
      */
     suspend fun showManageSubscriptionsIOS(): List<PurchaseIOS>
     /**
-     * Force a StoreKit sync for transactions (iOS 15+)
+     * Force sync transactions with the App Store (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/sync-ios
      */
     suspend fun syncIOS(): Boolean
     /**
-     * Validate purchase receipts with the configured providers
+     * Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
+     * See: https://www.openiap.dev/docs/features/validation#verify-purchase
      */
     suspend fun validateReceipt(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify purchases with the configured providers
+     * Verify a purchase against your own backend (returns isValid + raw store metadata).
+     * See: https://www.openiap.dev/docs/features/validation#verify-purchase
      */
     suspend fun verifyPurchase(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify purchases with a specific provider (e.g., IAPKit)
+     * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+     * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
      */
     suspend fun verifyPurchaseWithProvider(options: VerifyPurchaseWithProviderProps): VerifyPurchaseWithProviderResult
 }
@@ -4984,95 +5004,116 @@ public interface MutationResolver {
  */
 public interface QueryResolver {
     /**
-     * Check if external purchase notice sheet can be presented (iOS 17.4+)
-     * Uses ExternalPurchase.canPresent
+     * Check eligibility for the external purchase notice sheet (iOS 17.4+).
+     * Uses ExternalPurchase.canPresent.
+     * See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
      */
     suspend fun canPresentExternalPurchaseNoticeIOS(): Boolean
     /**
-     * Get current StoreKit 2 entitlements (iOS 15+)
+     * Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
      */
     suspend fun currentEntitlementIOS(sku: String): PurchaseIOS?
     /**
-     * Retrieve products or subscriptions from the store
+     * Fetch products or subscriptions from the store.
+     * See: https://www.openiap.dev/docs/apis/fetch-products
      */
     suspend fun fetchProducts(params: ProductRequest): FetchProductsResult
     /**
-     * Get active subscriptions (filters by subscriptionIds when provided)
+     * Get details of all currently active subscriptions (filters by subscriptionIds when provided).
+     * See: https://www.openiap.dev/docs/apis/get-active-subscriptions
      */
     suspend fun getActiveSubscriptions(subscriptionIds: List<String>? = null): List<ActiveSubscription>
     /**
-     * Get the full StoreKit 2 transaction history as PurchaseIOS values.
+     * List every StoreKit transaction (finished + unfinished) for the current user.
      * Requires the SK2ConsumableTransactionHistory Info.plist key in the host app
      * for finished consumables to be included (iOS 18+).
      * Unlike getAvailablePurchases, always returns the iOS-specific PurchaseIOS shape.
+     * See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
      */
     suspend fun getAllTransactionsIOS(): List<PurchaseIOS>
     /**
-     * Fetch the current app transaction (iOS 16+)
+     * Fetch the app transaction (iOS 16+).
+     * See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
      */
     suspend fun getAppTransactionIOS(): AppTransaction?
     /**
-     * Get all available purchases for the current user
+     * List active purchases for the current user.
+     * See: https://www.openiap.dev/docs/apis/get-available-purchases
      */
     suspend fun getAvailablePurchases(options: PurchaseOptions? = null): List<Purchase>
     /**
-     * Get external purchase token for reporting to Apple (iOS 18.1+).
-     * Use this token with Apple's External Purchase Server API to report transactions.
+     * Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+     * Use this token to report transactions made through ExternalPurchaseCustomLink.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+     * See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
      */
     suspend fun getExternalPurchaseCustomLinkTokenIOS(tokenType: ExternalPurchaseCustomLinkTokenTypeIOS): ExternalPurchaseCustomLinkTokenResultIOS
     /**
-     * Retrieve all pending transactions in the StoreKit queue
+     * List unfinished StoreKit transactions in the queue.
+     * See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
      */
     suspend fun getPendingTransactionsIOS(): List<PurchaseIOS>
     /**
-     * Get the currently promoted product (iOS 11+)
+     * Read the App Store-promoted product, if any (iOS 11+).
+     * See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
      */
     suspend fun getPromotedProductIOS(): ProductIOS?
     /**
-     * Get base64-encoded receipt data for validation
+     * Get base64-encoded receipt data (legacy validation).
+     * See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
      */
     suspend fun getReceiptDataIOS(): String?
     /**
-     * Get the current storefront country code
+     * Return the user's storefront country code.
+     * See: https://www.openiap.dev/docs/apis/get-storefront
      */
     suspend fun getStorefront(): String
     /**
-     * Get the current App Store storefront country code
+     * Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
+     * See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
      */
     suspend fun getStorefrontIOS(): String
     /**
-     * Get the transaction JWS (StoreKit 2)
+     * Return the JWS string for a transaction (StoreKit 2).
+     * See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
      */
     suspend fun getTransactionJwsIOS(sku: String): String?
     /**
-     * Check whether the user has active subscriptions
+     * Check whether the user has any active subscription.
+     * See: https://www.openiap.dev/docs/apis/has-active-subscriptions
      */
     suspend fun hasActiveSubscriptions(subscriptionIds: List<String>? = null): Boolean
     /**
-     * Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+     * Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
      * Returns true if the app can use custom external purchase links.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+     * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
      */
     suspend fun isEligibleForExternalPurchaseCustomLinkIOS(): Boolean
     /**
-     * Check introductory offer eligibility for a subscription group
+     * Check intro-offer eligibility for a subscription group.
+     * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
      */
     suspend fun isEligibleForIntroOfferIOS(groupID: String): Boolean
     /**
-     * Verify a StoreKit 2 transaction signature
+     * Check whether a transaction's JWS verification passed (StoreKit 2).
+     * See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
      */
     suspend fun isTransactionVerifiedIOS(sku: String): Boolean
     /**
-     * Get the latest transaction for a product using StoreKit 2
+     * Get the latest verified transaction for a product, using StoreKit 2.
+     * See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
      */
     suspend fun latestTransactionIOS(sku: String): PurchaseIOS?
     /**
-     * Get StoreKit 2 subscription status details (iOS 15+)
+     * Get subscription status objects from StoreKit 2 (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
      */
     suspend fun subscriptionStatusIOS(sku: String): List<SubscriptionStatusIOS>
     /**
-     * Validate a receipt for a specific product
+     * Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
+     * See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
      */
     suspend fun validateReceiptIOS(options: VerifyPurchaseProps): VerifyPurchaseResultIOS
 }

--- a/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/openiap/Types.kt
+++ b/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/openiap/Types.kt
@@ -4988,7 +4988,11 @@ public interface MutationResolver {
      */
     suspend fun validateReceipt(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify a purchase against your own backend (returns isValid + raw store metadata).
+     * Verify a purchase against your own backend. Returns a platform-specific
+     * variant of VerifyPurchaseResult — VerifyPurchaseResultIOS exposes isValid
+     * + receipt/JWS metadata, VerifyPurchaseResultAndroid carries Play Store
+     * receipt fields (no isValid), and VerifyPurchaseResultHorizon uses success.
+     * Inspect the concrete variant before reading fields.
      * See: https://www.openiap.dev/docs/features/validation#verify-purchase
      */
     suspend fun verifyPurchase(options: VerifyPurchaseProps): VerifyPurchaseResult

--- a/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
+++ b/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
@@ -133,6 +133,17 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
     // MutationResolver Implementation
     // -------------------------------------------------------------------------
 
+    /**
+     * Initialize the store connection. Must be called before any other IAP API.
+     *
+     * @param config Optional [InitConnectionConfig]. Use `enableBillingProgramAndroid`
+     *   (Android, Play Billing 8.2.0+) to opt into External Payments etc.; iOS ignores
+     *   Android-specific fields.
+     * @return `true` once the platform billing client is connected.
+     * @throws PurchaseException when the billing client fails to initialize.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/init-connection">init-connection</a>
+     */
     override suspend fun initConnection(config: InitConnectionConfig?): Boolean = suspendCoroutine { continuation ->
         // iOS doesn't use alternative billing config, it's Android only
         openIapModule.initConnectionWithCompletion { success, error ->
@@ -151,6 +162,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
         }
     }
 
+    /**
+     * Close the store connection and release resources.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/end-connection">https://www.openiap.dev/docs/apis/end-connection</a>
+     */
     override suspend fun endConnection(): Boolean = suspendCoroutine { continuation ->
         // Remove all listeners and null the subscription tokens so initConnection()
         // can freshly re-register without orphaning the previous subscriptions.
@@ -173,6 +189,20 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
         }
     }
 
+    /**
+     * Initiate a purchase or subscription flow. Result is delivered via the
+     * purchaseUpdated event flow — NOT the return value.
+     *
+     * @param props [RequestPurchaseProps]. Pass `request.apple.sku` (iOS) and/or
+     *   `request.google.skus` (Android); subscriptions need `subscriptionOffers`.
+     * @return The dispatched purchase payload (do not rely on this for the outcome).
+     * @throws PurchaseException on synchronous rejection (billing not ready, missing offerToken).
+     *
+     * Warning: Event-based. Collect from `purchaseUpdatedListener` / `purchaseErrorListener`
+     * (or the equivalent flows on `KmpIAP`) for the final state.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/request-purchase">request-purchase</a>
+     */
     override suspend fun requestPurchase(params: RequestPurchaseProps): RequestPurchaseResult? =
         suspendCoroutine { continuation ->
             when (val request = params.request) {
@@ -243,6 +273,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Buy the currently promoted product.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios">https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios</a>
+     */
     override suspend fun requestPurchaseOnPromotedProductIOS(): Boolean =
         suspendCoroutine { continuation ->
             openIapModule.requestPurchaseOnPromotedProductIOSWithCompletion { success, error ->
@@ -254,6 +289,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Restore non-consumable and active subscription purchases.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/restore-purchases">https://www.openiap.dev/docs/apis/restore-purchases</a>
+     */
     override suspend fun restorePurchases(): Unit = suspendCoroutine { continuation ->
         openIapModule.restorePurchasesWithCompletion { error ->
             if (error != null) {
@@ -264,6 +304,19 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
         }
     }
 
+    /**
+     * Complete a purchase transaction. Call after server-side verification.
+     *
+     * @param purchase The [Purchase] to finalize.
+     * @param isConsumable `true` for consumables (Android consume — token can be re-bought),
+     *   `false` for non-consumables and subscriptions (acknowledge only). Default `false`.
+     * @throws PurchaseException when the platform finalize call fails.
+     *
+     * Important: Android auto-refunds purchases NOT acknowledged/consumed within 3 days.
+     * iOS unfinished transactions replay on every app launch.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/finish-transaction">finish-transaction</a>
+     */
     override suspend fun finishTransaction(purchase: PurchaseInput, isConsumable: Boolean?): Unit =
         suspendCoroutine { continuation ->
             val transactionId = purchase.id
@@ -282,6 +335,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Open the platform's subscription management UI.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/deep-link-to-subscriptions">https://www.openiap.dev/docs/apis/deep-link-to-subscriptions</a>
+     */
     override suspend fun deepLinkToSubscriptions(options: DeepLinkOptions?): Unit =
         suspendCoroutine { continuation ->
             openIapModule.deepLinkToSubscriptionsWithCompletion { error ->
@@ -293,6 +351,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Show the App Store offer code redemption sheet.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios">https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios</a>
+     */
     override suspend fun presentCodeRedemptionSheetIOS(): Boolean =
         suspendCoroutine { continuation ->
             openIapModule.presentCodeRedemptionSheetIOSWithCompletion { success, error ->
@@ -304,6 +367,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Present the refund request sheet (iOS 15+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios">https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios</a>
+     */
     override suspend fun beginRefundRequestIOS(sku: String): String? =
         suspendCoroutine { continuation ->
             openIapModule.beginRefundRequestIOSWithSku(sku) { status, error ->
@@ -315,6 +383,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Clear pending transactions in the queue (sandbox helper).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/clear-transaction-ios">https://www.openiap.dev/docs/apis/ios/clear-transaction-ios</a>
+     */
     override suspend fun clearTransactionIOS(): Boolean = suspendCoroutine { continuation ->
         openIapModule.clearTransactionIOSWithCompletion { success, error ->
             if (error != null) {
@@ -325,6 +398,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
         }
     }
 
+    /**
+     * Present the manage-subscriptions sheet.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios">https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios</a>
+     */
     override suspend fun showManageSubscriptionsIOS(): List<PurchaseIOS> =
         suspendCoroutine { continuation ->
             openIapModule.showManageSubscriptionsIOSWithCompletion { result, error ->
@@ -339,6 +417,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Force sync transactions with the App Store.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/sync-ios">https://www.openiap.dev/docs/apis/ios/sync-ios</a>
+     */
     override suspend fun syncIOS(): Boolean = suspendCoroutine { continuation ->
         openIapModule.syncIOSWithCompletion { success, error ->
             if (error != null) {
@@ -349,6 +432,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
         }
     }
 
+    /**
+     * Deprecated. Use verifyPurchase instead.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/validate-receipt">https://www.openiap.dev/docs/apis/validate-receipt</a>
+     */
     override suspend fun validateReceipt(options: VerifyPurchaseProps): VerifyPurchaseResult {
         // Call the iOS-specific version and return the result directly
         return validateReceiptIOS(options)
@@ -358,6 +446,18 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
     // QueryResolver Implementation
     // -------------------------------------------------------------------------
 
+    /**
+     * Retrieve products or subscriptions from the store by SKU.
+     *
+     * @param params [ProductRequest] with `skus` and optional `type`
+     *   ([ProductQueryType.InApp], [ProductQueryType.Subs], or [ProductQueryType.All];
+     *   defaults to InApp).
+     * @return [FetchProductsResult] sealed variant — Products for InApp, Subscriptions
+     *   for Subs, mixed for All.
+     * @throws PurchaseException on store rejection (unknown SKU, network, not connected).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/fetch-products">fetch-products</a>
+     */
     override suspend fun fetchProducts(params: ProductRequest): FetchProductsResult =
         suspendCoroutine { continuation ->
             val skus = params.skus
@@ -396,6 +496,17 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * List the user's unfinished purchases — non-consumables, active subscriptions, and
+     * any pending transactions not finished previously.
+     *
+     * @param options Optional [PurchaseOptions]. iOS-only fields
+     *   (`alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`) are ignored on Android.
+     * @return List of [Purchase] currently held by the platform store.
+     * @throws PurchaseException when the platform query fails.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/get-available-purchases">get-available-purchases</a>
+     */
     override suspend fun getAvailablePurchases(options: PurchaseOptions?): List<Purchase> =
         suspendCoroutine { continuation ->
             openIapModule.getAvailablePurchasesWithCompletion { result, error ->
@@ -410,10 +521,20 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Return the user's storefront country code.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/get-storefront">https://www.openiap.dev/docs/apis/get-storefront</a>
+     */
     override suspend fun getStorefront(): String {
         return getStorefrontIOS()
     }
 
+    /**
+     * Deprecated. Use cross-platform getStorefront instead.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-storefront-ios">https://www.openiap.dev/docs/apis/ios/get-storefront-ios</a>
+     */
     override suspend fun getStorefrontIOS(): String = suspendCoroutine { continuation ->
         openIapModule.getStorefrontIOSWithCompletion { result, error ->
             if (error != null) {
@@ -424,6 +545,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
         }
     }
 
+    /**
+     * List unfinished StoreKit transactions.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios">https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios</a>
+     */
     override suspend fun getPendingTransactionsIOS(): List<PurchaseIOS> =
         suspendCoroutine { continuation ->
             openIapModule.getPendingTransactionsIOSWithCompletion { result, error ->
@@ -438,6 +564,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * List every StoreKit transaction (finished + unfinished).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios">https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios</a>
+     */
     override suspend fun getAllTransactionsIOS(): List<PurchaseIOS> =
         suspendCoroutine { continuation ->
             openIapModule.getAllTransactionsIOSWithCompletion { result, error ->
@@ -452,6 +583,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Get base64 receipt data (legacy validation).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios">https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios</a>
+     */
     override suspend fun getReceiptDataIOS(): String? = suspendCoroutine { continuation ->
         openIapModule.getReceiptDataIOSWithCompletion { result, error ->
             if (error != null) {
@@ -462,6 +598,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
         }
     }
 
+    /**
+     * Read the App Store-promoted product, if any.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios">https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios</a>
+     */
     override suspend fun getPromotedProductIOS(): ProductIOS? = suspendCoroutine { continuation ->
         openIapModule.getPromotedProductIOSWithCompletion { result, error ->
             if (error != null) {
@@ -475,6 +616,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
         }
     }
 
+    /**
+     * Get details of all currently active subscriptions.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/get-active-subscriptions">https://www.openiap.dev/docs/apis/get-active-subscriptions</a>
+     */
     override suspend fun getActiveSubscriptions(subscriptionIds: List<String>?): List<ActiveSubscription> =
         suspendCoroutine { continuation ->
             openIapModule.getActiveSubscriptionsWithCompletion { result, error ->
@@ -497,6 +643,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Fetch the app transaction (iOS 16+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios">https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios</a>
+     */
     override suspend fun getAppTransactionIOS(): AppTransaction? =
         suspendCoroutine { continuation ->
             // Note: getAppTransactionIOS requires iOS 16.0+
@@ -521,6 +672,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Get the user's current entitlement for a product.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/current-entitlement-ios">https://www.openiap.dev/docs/apis/ios/current-entitlement-ios</a>
+     */
     override suspend fun currentEntitlementIOS(sku: String): PurchaseIOS? =
         suspendCoroutine { continuation ->
             openIapModule.currentEntitlementIOSWithSku(sku) { result, error ->
@@ -534,6 +690,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Return the JWS string for a transaction.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios">https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios</a>
+     */
     override suspend fun getTransactionJwsIOS(sku: String): String? =
         suspendCoroutine { continuation ->
             openIapModule.getTransactionJwsIOSWithSku(sku) { result, error ->
@@ -546,6 +707,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Check whether the user has any active subscription.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/has-active-subscriptions">https://www.openiap.dev/docs/apis/has-active-subscriptions</a>
+     */
     override suspend fun hasActiveSubscriptions(subscriptionIds: List<String>?): Boolean =
         suspendCoroutine { continuation ->
             openIapModule.hasActiveSubscriptionsWithCompletion { hasActive, error ->
@@ -558,6 +724,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Check intro-offer eligibility for a subscription group.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios">https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios</a>
+     */
     override suspend fun isEligibleForIntroOfferIOS(groupID: String): Boolean =
         suspendCoroutine { continuation ->
             openIapModule.isEligibleForIntroOfferIOSWithGroupID(groupID) { isEligible, error ->
@@ -570,6 +741,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios">https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios</a>
+     */
     override suspend fun isEligibleForExternalPurchaseCustomLinkIOS(): Boolean =
         suspendCoroutine { continuation ->
             openIapModule.isEligibleForExternalPurchaseCustomLinkIOSWithCompletion { isEligible, error ->
@@ -582,6 +758,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios">https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios</a>
+     */
     override suspend fun showExternalPurchaseCustomLinkNoticeIOS(
         noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS
     ): ExternalPurchaseCustomLinkNoticeResultIOS =
@@ -612,6 +793,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios">https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios</a>
+     */
     override suspend fun getExternalPurchaseCustomLinkTokenIOS(
         tokenType: ExternalPurchaseCustomLinkTokenTypeIOS
     ): ExternalPurchaseCustomLinkTokenResultIOS =
@@ -642,6 +828,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Check whether a transaction's JWS verification passed.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios">https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios</a>
+     */
     override suspend fun isTransactionVerifiedIOS(sku: String): Boolean =
         suspendCoroutine { continuation ->
             openIapModule.isTransactionVerifiedIOSWithSku(sku) { isVerified, error ->
@@ -654,6 +845,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Get the latest verified transaction for a product.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/latest-transaction-ios">https://www.openiap.dev/docs/apis/ios/latest-transaction-ios</a>
+     */
     override suspend fun latestTransactionIOS(sku: String): PurchaseIOS? =
         suspendCoroutine { continuation ->
             openIapModule.latestTransactionIOSWithSku(sku) { result, error ->
@@ -667,6 +863,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Get subscription status objects from StoreKit 2.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/subscription-status-ios">https://www.openiap.dev/docs/apis/ios/subscription-status-ios</a>
+     */
     override suspend fun subscriptionStatusIOS(sku: String): List<SubscriptionStatusIOS> =
         suspendCoroutine { continuation ->
             openIapModule.subscriptionStatusIOSWithSku(sku) { result, error ->
@@ -689,6 +890,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Deprecated. Legacy App Store receipt validation.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/validate-receipt-ios">https://www.openiap.dev/docs/apis/ios/validate-receipt-ios</a>
+     */
     override suspend fun validateReceiptIOS(options: VerifyPurchaseProps): VerifyPurchaseResultIOS {
         // Get receipt data
         val receiptData = getReceiptDataIOS() ?: ""
@@ -702,11 +908,21 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
         )
     }
 
+    /**
+     * Verify a purchase against your own backend.
+     *
+     * @see <a href="https://www.openiap.dev/docs/features/validation#verify-purchase">https://www.openiap.dev/docs/features/validation#verify-purchase</a>
+     */
     override suspend fun verifyPurchase(options: VerifyPurchaseProps): VerifyPurchaseResult {
         // Call the iOS-specific validation method
         return validateReceiptIOS(options)
     }
 
+    /**
+     * Verify via a managed provider (IAPKit, Apple, Google, Horizon).
+     *
+     * @see <a href="https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider">https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider</a>
+     */
     override suspend fun verifyPurchaseWithProvider(options: VerifyPurchaseWithProviderProps): VerifyPurchaseWithProviderResult =
         suspendCoroutine { continuation ->
             val provider = options.provider.rawValue
@@ -1054,10 +1270,20 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
     // Android-specific stubs (not implemented on iOS)
     // -------------------------------------------------------------------------
 
+    /**
+     * Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android">https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android</a>
+     */
     override suspend fun acknowledgePurchaseAndroid(purchaseToken: String): Boolean {
         throw UnsupportedOperationException("Android method not available on iOS")
     }
 
+    /**
+     * Consume a consumable purchase so it can be re-bought.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/consume-purchase-android">https://www.openiap.dev/docs/apis/android/consume-purchase-android</a>
+     */
     override suspend fun consumePurchaseAndroid(purchaseToken: String): Boolean {
         throw UnsupportedOperationException("Android method not available on iOS")
     }
@@ -1066,14 +1292,29 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
     // Android Alternative Billing Methods (stubs for iOS)
     // -------------------------------------------------------------------------
 
+    /**
+     * Check whether alternative billing is available for the user.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android">https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android</a>
+     */
     override suspend fun checkAlternativeBillingAvailabilityAndroid(): Boolean {
         return false // Not supported on iOS
     }
 
+    /**
+     * Display Google's alternative billing information dialog.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android">https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android</a>
+     */
     override suspend fun showAlternativeBillingDialogAndroid(): Boolean {
         throw UnsupportedOperationException("Android alternative billing not available on iOS")
     }
 
+    /**
+     * Create a reporting token for an alternative billing flow.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android">https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android</a>
+     */
     override suspend fun createAlternativeBillingTokenAndroid(): String? {
         return null // Not supported on iOS
     }
@@ -1086,6 +1327,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
     // iOS External Purchase Methods
     // -------------------------------------------------------------------------
 
+    /**
+     * Present an external purchase link (iOS 16+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios">https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios</a>
+     */
     override suspend fun presentExternalPurchaseLinkIOS(url: String): ExternalPurchaseLinkResultIOS =
         suspendCoroutine { continuation ->
             openIapModule.presentExternalPurchaseLinkIOSWithUrl(url) { result, error ->
@@ -1109,6 +1355,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Present the external purchase notice sheet (iOS 17.4+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios">https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios</a>
+     */
     override suspend fun presentExternalPurchaseNoticeSheetIOS(): ExternalPurchaseNoticeResultIOS =
         suspendCoroutine { continuation ->
             openIapModule.presentExternalPurchaseNoticeSheetIOSWithCompletion { result, error ->
@@ -1137,6 +1388,11 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
             }
         }
 
+    /**
+     * Check eligibility for the external purchase notice sheet (iOS 17.4+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios">https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios</a>
+     */
     override suspend fun canPresentExternalPurchaseNoticeIOS(): Boolean =
         suspendCoroutine { continuation ->
             openIapModule.canPresentExternalPurchaseNoticeIOSWithCompletion { canPresent, error ->
@@ -1145,14 +1401,29 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
         }
 
     // Billing Programs API (Android 8.2.0+ only) - iOS stubs
+    /**
+     * Check whether a billing program is available.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/is-billing-program-available-android">https://www.openiap.dev/docs/apis/android/is-billing-program-available-android</a>
+     */
     override suspend fun isBillingProgramAvailableAndroid(program: BillingProgramAndroid): BillingProgramAvailabilityResultAndroid {
         throw UnsupportedOperationException("isBillingProgramAvailableAndroid is only available on Android")
     }
 
+    /**
+     * Create the reporting payload Google requires (Play Billing 8.3.0+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android">https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android</a>
+     */
     override suspend fun createBillingProgramReportingDetailsAndroid(program: BillingProgramAndroid): BillingProgramReportingDetailsAndroid {
         throw UnsupportedOperationException("createBillingProgramReportingDetailsAndroid is only available on Android")
     }
 
+    /**
+     * Launch an external content/offer link (Play Billing 8.2.0+).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/launch-external-link-android">https://www.openiap.dev/docs/apis/android/launch-external-link-android</a>
+     */
     override suspend fun launchExternalLinkAndroid(params: LaunchExternalLinkParamsAndroid): Boolean {
         throw UnsupportedOperationException("launchExternalLinkAndroid is only available on Android")
     }

--- a/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
+++ b/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
@@ -919,7 +919,7 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
     }
 
     /**
-     * Verify via a managed provider (IAPKit, Apple, Google, Horizon).
+     * Verify via a managed provider (currently IAPKit; the PurchaseVerificationProvider enum exposes only Iapkit today).
      *
      * @see <a href="https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider">https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider</a>
      */

--- a/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
+++ b/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
@@ -193,8 +193,10 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
      * Initiate a purchase or subscription flow. Result is delivered via the
      * purchaseUpdated event flow — NOT the return value.
      *
-     * @param props [RequestPurchaseProps]. Pass `request.apple.sku` (iOS) and/or
-     *   `request.google.skus` (Android); subscriptions need `subscriptionOffers`.
+     * @param params [RequestPurchaseProps]. The OUTER `params` is the props envelope;
+     *   the INNER `RequestPurchaseProps.request` field carries the per-platform payload —
+     *   set `params.request.apple.sku` (iOS) and/or `params.request.google.skus` (Android).
+     *   Subscriptions also need `subscriptionOffers` on Android.
      * @return The dispatched purchase payload (do not rely on this for the outcome).
      * @throws PurchaseException on synchronous rejection (billing not ready, missing offerToken).
      *

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -181,7 +181,7 @@ type UseIap = {
     options: VerifyPurchaseProps,
   ) => Promise<VerifyPurchaseResult>;
   /**
-   * Verify via a managed provider (IAPKit, Apple, Google, Horizon).
+   * Verify via a managed provider (currently IAPKit; the PurchaseVerificationProvider enum exposes only Iapkit today).
    *
    * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider}
    */

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -197,7 +197,7 @@ type UseIap = {
     options: VerifyPurchaseProps,
   ) => Promise<VerifyPurchaseResult>;
   /**
-   * Verify via a managed provider (currently IAPKit; the PurchaseVerificationProvider enum exposes only Iapkit today).
+   * Verify via a managed provider — currently only `iapkit` (IAPKit). The PurchaseVerificationProvider enum exposes no other provider literal today.
    *
    * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider}
    */

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -93,18 +93,28 @@ type UseIap = {
    * List the user's unfinished purchases — non-consumables, active subscriptions, and any
    * pending transactions not yet finished.
    *
-   * @param options Optional `PurchaseOptions`. iOS-only flags:
-   *   `alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`.
+   * @param options Optional `PurchaseOptions`.
+   *   - iOS: `alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`.
+   *   - Android: `includeSuspendedAndroid` (include subscriptions in a paused/grace state).
    * @returns Promise that resolves when the request is dispatched; results land in the
-   *   hook's reactive `availablePurchases` state.
+   *   hook's reactive `availablePurchases` state — read from there, don't expect a return value.
    * @throws When the platform query fails.
    *
    * @example
    * ```ts
-   * const purchases = await getAvailablePurchases();
-   * for (const p of purchases) {
-   *   if (await verifyOnServer(p)) await finishTransaction({ purchase: p, isConsumable: false });
-   * }
+   * const { availablePurchases, getAvailablePurchases, finishTransaction } = useIAP();
+   *
+   * useEffect(() => {
+   *   void getAvailablePurchases();
+   * }, [getAvailablePurchases]);
+   *
+   * useEffect(() => {
+   *   for (const p of availablePurchases) {
+   *     void verifyOnServer(p).then((ok) => {
+   *       if (ok) finishTransaction({ purchase: p, isConsumable: false });
+   *     });
+   *   }
+   * }, [availablePurchases, finishTransaction]);
    * ```
    *
    * @see {@link https://www.openiap.dev/docs/apis/get-available-purchases}
@@ -116,15 +126,21 @@ type UseIap = {
    * @param params `ProductRequest` — `skus` (string[]) and optional `type`
    *   (`'in-app' | 'subs' | 'all'`, defaults to `'in-app'`).
    * @returns Promise that resolves when the request is dispatched; results land in the
-   *   hook's reactive `products` / `subscriptions` state.
+   *   hook's reactive `products` / `subscriptions` state — read from there, don't expect a return value.
    * @throws When the store rejects the request (unknown SKU, network, not connected).
    *
    * @example
    * ```ts
-   * const products = await fetchProducts({
-   *   skus: ['com.app.coins_100', 'com.app.premium'],
-   *   type: 'in-app',
-   * });
+   * const { products, fetchProducts } = useIAP();
+   *
+   * useEffect(() => {
+   *   void fetchProducts({
+   *     skus: ['com.app.coins_100', 'com.app.premium'],
+   *     type: 'in-app',
+   *   });
+   * }, [fetchProducts]);
+   *
+   * // Render `products` directly from hook state.
    * ```
    *
    * @remarks This is a regular promise-based call. Don't confuse with `request*` APIs

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -64,33 +64,161 @@ type UseIap = {
   availablePurchases: Purchase[];
   promotedProductIOS?: Product;
   activeSubscriptions: ActiveSubscription[];
+  /**
+   * Complete a purchase transaction. Call after server-side verification to remove it
+   * from the queue.
+   *
+   * @param args.purchase The `Purchase` to finalize.
+   * @param args.isConsumable `true` for consumables (consumes the token so the SKU can be
+   *   re-bought, e.g. coins); `false` (default) for non-consumables and subscriptions.
+   * @returns Promise that resolves once the platform finalizes the transaction.
+   * @throws When the platform finalize call fails.
+   *
+   * @example
+   * ```ts
+   * purchaseUpdatedListener(async (purchase) => {
+   *   if (await verifyOnServer(purchase)) {
+   *     await finishTransaction({ purchase, isConsumable: false });
+   *   }
+   * });
+   * ```
+   *
+   * @remarks **Critical:** Android purchases must be finalized within 3 days or Google
+   *   auto-refunds. iOS unfinished transactions replay on every app launch.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/finish-transaction}
+   */
   finishTransaction: (args: MutationFinishTransactionArgs) => Promise<void>;
+  /**
+   * List the user's unfinished purchases — non-consumables, active subscriptions, and any
+   * pending transactions not yet finished.
+   *
+   * @param options Optional `PurchaseOptions`. iOS-only flags:
+   *   `alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`.
+   * @returns Promise that resolves when the request is dispatched; results land in the
+   *   hook's reactive `availablePurchases` state.
+   * @throws When the platform query fails.
+   *
+   * @example
+   * ```ts
+   * const purchases = await getAvailablePurchases();
+   * for (const p of purchases) {
+   *   if (await verifyOnServer(p)) await finishTransaction({ purchase: p, isConsumable: false });
+   * }
+   * ```
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/get-available-purchases}
+   */
   getAvailablePurchases: (options?: PurchaseOptions) => Promise<void>;
+  /**
+   * Retrieve products or subscriptions from the store by SKU.
+   *
+   * @param params `ProductRequest` — `skus` (string[]) and optional `type`
+   *   (`'in-app' | 'subs' | 'all'`, defaults to `'in-app'`).
+   * @returns Promise that resolves when the request is dispatched; results land in the
+   *   hook's reactive `products` / `subscriptions` state.
+   * @throws When the store rejects the request (unknown SKU, network, not connected).
+   *
+   * @example
+   * ```ts
+   * const products = await fetchProducts({
+   *   skus: ['com.app.coins_100', 'com.app.premium'],
+   *   type: 'in-app',
+   * });
+   * ```
+   *
+   * @remarks This is a regular promise-based call. Don't confuse with `request*` APIs
+   *   (`requestPurchase`), which are event-based.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/fetch-products}
+   */
   fetchProducts: (params: {
     skus: string[];
     type?: ProductQueryType | null;
   }) => Promise<void>;
+  /**
+   * Initiate a purchase or subscription flow. The result is delivered through
+   * `purchaseUpdatedListener` — NOT the return value.
+   *
+   * @param props `RequestPurchaseProps`, discriminated by `type`:
+   *   - `type: 'in-app'` — pass `request.apple.sku` (iOS) and/or `request.google.skus` (Android).
+   *   - `type: 'subs'`  — same shape, plus `request.google.subscriptionOffers: [{ sku, offerToken }]`.
+   * @returns Promise that resolves when the request is dispatched; results land in the
+   *   hook's `onPurchaseSuccess` / `onPurchaseError` callbacks.
+   * @throws Synchronous rejection from the store (e.g. `E_NOT_PREPARED`, validation failure).
+   *
+   * @example
+   * ```ts
+   * await requestPurchase({
+   *   request: {
+   *     apple: { sku: 'com.app.premium' },
+   *     google: { skus: ['com.app.premium'] },
+   *   },
+   *   type: 'in-app',
+   * });
+   * ```
+   *
+   * @remarks Event-based. Listen for the result via {@link purchaseUpdatedListener} /
+   *   {@link purchaseErrorListener}, or use `useIAP({ onPurchaseSuccess, onPurchaseError })`.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/request-purchase}
+   */
   requestPurchase: (params: RequestPurchaseProps) => Promise<void>;
   /**
    * @deprecated Use `verifyPurchase` instead. This function will be removed in a future version.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/validate-receipt}
    */
   validateReceipt: (
     options: VerifyPurchaseProps,
   ) => Promise<VerifyPurchaseResult>;
-  /** Verify purchase with the configured providers */
+  /**
+   * Verify a purchase against your own backend (returns isValid + raw store metadata).
+   *
+   * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase}
+   */
   verifyPurchase: (
     options: VerifyPurchaseProps,
   ) => Promise<VerifyPurchaseResult>;
-  /** Verify purchase with a specific provider (e.g., IAPKit) */
+  /**
+   * Verify via a managed provider (IAPKit, Apple, Google, Horizon).
+   *
+   * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider}
+   */
   verifyPurchaseWithProvider: (
     options: VerifyPurchaseWithProviderProps,
   ) => Promise<VerifyPurchaseWithProviderResult>;
+  /**
+   * Restore non-consumable and active subscription purchases.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/restore-purchases}
+   */
   restorePurchases: (options?: PurchaseOptions) => Promise<void>;
+  /**
+   * Read the App Store-promoted product, if any.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios}
+   */
   getPromotedProductIOS: () => Promise<Product | null>;
+  /**
+   * Buy the currently promoted product.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios}
+   */
   requestPurchaseOnPromotedProductIOS: () => Promise<boolean>;
+  /**
+   * Get details of all currently active subscriptions.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/get-active-subscriptions}
+   */
   getActiveSubscriptions: (
     subscriptionIds?: string[],
   ) => Promise<ActiveSubscription[]>;
+  /**
+   * Check whether the user has any active subscription.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/has-active-subscriptions}
+   */
   hasActiveSubscriptions: (subscriptionIds?: string[]) => Promise<boolean>;
   /**
    * Manually retry the store connection.
@@ -99,8 +227,23 @@ type UseIap = {
    */
   reconnect: () => Promise<boolean>;
   // Alternative billing (Android)
+  /**
+   * Check whether alternative billing is available for the user.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android}
+   */
   checkAlternativeBillingAvailabilityAndroid?: () => Promise<boolean>;
+  /**
+   * Display Google's alternative billing information dialog.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android}
+   */
   showAlternativeBillingDialogAndroid?: () => Promise<boolean>;
+  /**
+   * Create a reporting token for an alternative billing flow.
+   *
+   * @see {@link https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android}
+   */
   createAlternativeBillingTokenAndroid?: (
     sku?: string,
   ) => Promise<string | null>;

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -127,7 +127,8 @@ type UseIap = {
    *   (`'in-app' | 'subs' | 'all'`, defaults to `'in-app'`).
    * @returns Promise that resolves when the request is dispatched; results land in the
    *   hook's reactive `products` / `subscriptions` state — read from there, don't expect a return value.
-   * @throws When the store rejects the request (unknown SKU, network, not connected).
+   * @throws When the store rejects the request (empty `skus`, not connected,
+   *   network/store error). Unknown SKUs are simply omitted from the result, not thrown.
    *
    * @example
    * ```ts

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -2895,7 +2895,11 @@ export const launchExternalLinkAndroid: MutationField<
 // ------------------------------
 
 /**
- * Check if the device can present an external purchase notice sheet (iOS 18.2+).
+ * Check if the device can present an external purchase notice sheet (iOS 17.4+).
+ *
+ * Wraps `ExternalPurchase.canPresent`, which Apple introduced in iOS 17.4.
+ * Note: the notice sheet itself (`presentExternalPurchaseNoticeSheetIOS`)
+ * still requires iOS 18.2+; only the eligibility check is available earlier.
  *
  * @returns Promise<boolean> - true if notice sheet can be presented
  * @platform iOS

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -662,20 +662,26 @@ export const subscriptionBillingIssueListener = (
 // ------------------------------
 
 /**
- * Fetch products from the store
- * @param params - Product request configuration
- * @param params.skus - Array of product SKUs to fetch
- * @param params.type - Optional filter: 'in-app' (default) for products, 'subs' for subscriptions, or 'all' for both.
- * @returns Promise<Product[]> - Array of products from the store
+ * Retrieve products or subscriptions from the store by SKU.
+ *
+ * @param params `ProductRequest` — `skus` (string[]) and optional `type`
+ *   (`'in-app' | 'subs' | 'all'`, defaults to `'in-app'`).
+ * @returns Promise resolving to a `FetchProductsResult` union — `Product[]` for `'in-app'`,
+ *   `ProductSubscription[]` for `'subs'`, or a mixed array for `'all'`.
+ * @throws When the store rejects the request (unknown SKU, network, not connected).
  *
  * @example
- * ```typescript
- * // Regular products
- * const products = await fetchProducts({ skus: ['product1', 'product2'] });
- *
- * // Subscriptions
- * const subscriptions = await fetchProducts({ skus: ['sub1', 'sub2'], type: 'subs' });
+ * ```ts
+ * const products = await fetchProducts({
+ *   skus: ['com.app.coins_100', 'com.app.premium'],
+ *   type: 'in-app',
+ * });
  * ```
+ *
+ * @remarks This is a regular promise-based call. Don't confuse with `request*` APIs
+ *   (`requestPurchase`), which are event-based.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/fetch-products}
  */
 export const fetchProducts: QueryField<'fetchProducts'> = async (request) => {
   const {skus, type} = request;
@@ -789,17 +795,23 @@ export const fetchProducts: QueryField<'fetchProducts'> = async (request) => {
 };
 
 /**
- * Get available purchases (purchased items not yet consumed/finished)
- * @param params - Options for getting available purchases
- * @param params.alsoPublishToEventListener - Whether to also publish to event listener
- * @param params.onlyIncludeActiveItems - Whether to only include active items
+ * List the user's unfinished purchases — non-consumables, active subscriptions, and any
+ * pending transactions not yet finished.
+ *
+ * @param options Optional `PurchaseOptions`. iOS-only flags:
+ *   `alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`.
+ * @returns Promise resolving to an array of `Purchase` currently held by the store.
+ * @throws When the platform query fails.
  *
  * @example
- * ```typescript
- * const purchases = await getAvailablePurchases({
- *   onlyIncludeActiveItemsIOS: true
- * });
+ * ```ts
+ * const purchases = await getAvailablePurchases();
+ * for (const p of purchases) {
+ *   if (await verifyOnServer(p)) await finishTransaction({ purchase: p, isConsumable: false });
+ * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/get-available-purchases}
  */
 export const getAvailablePurchases: QueryField<
   'getAvailablePurchases'
@@ -866,6 +878,8 @@ export const getAvailablePurchases: QueryField<
  * Request the promoted product from the App Store (iOS only)
  * @returns Promise<Product | null> - The promoted product or null if none available
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios}
  */
 export const getPromotedProductIOS: QueryField<
   'getPromotedProductIOS'
@@ -898,6 +912,19 @@ export const getPromotedProductIOS: QueryField<
 
 export const requestPromotedProductIOS = getPromotedProductIOS;
 
+/**
+ * Get the storefront identifier for the user's App Store account (iOS only)
+ * @returns Promise<string> - The storefront identifier (e.g., 'USA' for United States)
+ * @platform iOS
+ *
+ * @example
+ * ```typescript
+ * const storefront = await getStorefrontIOS();
+ * console.log('User storefront:', storefront); // e.g., 'USA', 'GBR', 'KOR'
+ * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-storefront-ios}
+ */
 export const getStorefrontIOS: QueryField<'getStorefrontIOS'> = async () => {
   if (Platform.OS !== 'ios') {
     throw new Error('getStorefrontIOS is only available on iOS');
@@ -912,6 +939,11 @@ export const getStorefrontIOS: QueryField<'getStorefrontIOS'> = async () => {
   }
 };
 
+/**
+ * Return the user's storefront country code.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/get-storefront}
+ */
 export const getStorefront: QueryField<'getStorefront'> = async () => {
   if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
     RnIapConsole.warn(
@@ -945,6 +977,27 @@ export const getStorefront: QueryField<'getStorefront'> = async () => {
   }
 };
 
+/**
+ * iOS only - Gets the original app transaction ID if the app was purchased from the App Store
+ * @platform iOS
+ * @description
+ * This function retrieves the original app transaction information if the app was purchased
+ * from the App Store. Returns null if the app was not purchased (e.g., free app or TestFlight).
+ *
+ * @returns {Promise<string | null>} The original app transaction ID or null
+ *
+ * @example
+ * ```typescript
+ * const appTransaction = await getAppTransactionIOS();
+ * if (appTransaction) {
+ *   console.log('App was purchased, transaction ID:', appTransaction);
+ * } else {
+ *   console.log('App was not purchased from App Store');
+ * }
+ * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios}
+ */
 export const getAppTransactionIOS: QueryField<
   'getAppTransactionIOS'
 > = async () => {
@@ -977,6 +1030,15 @@ export const getAppTransactionIOS: QueryField<
   }
 };
 
+/**
+ * Get subscription status for a product (iOS only)
+ * @param sku - The product SKU
+ * @returns Promise<SubscriptionStatusIOS[]> - Array of subscription status objects
+ * @throws Error when called on non-iOS platforms or when IAP is not initialized
+ * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/subscription-status-ios}
+ */
 export const subscriptionStatusIOS: QueryField<
   'subscriptionStatusIOS'
 > = async (sku) => {
@@ -1002,6 +1064,14 @@ export const subscriptionStatusIOS: QueryField<
   }
 };
 
+/**
+ * Get current entitlement for a product (iOS only)
+ * @param sku - The product SKU
+ * @returns Promise<Purchase | null> - Current entitlement or null
+ * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/current-entitlement-ios}
+ */
 export const currentEntitlementIOS: QueryField<
   'currentEntitlementIOS'
 > = async (sku) => {
@@ -1028,6 +1098,14 @@ export const currentEntitlementIOS: QueryField<
   }
 };
 
+/**
+ * Get latest transaction for a product (iOS only)
+ * @param sku - The product SKU
+ * @returns Promise<Purchase | null> - Latest transaction or null
+ * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/latest-transaction-ios}
+ */
 export const latestTransactionIOS: QueryField<'latestTransactionIOS'> = async (
   sku,
 ) => {
@@ -1054,6 +1132,13 @@ export const latestTransactionIOS: QueryField<'latestTransactionIOS'> = async (
   }
 };
 
+/**
+ * Get pending transactions (iOS only)
+ * @returns Promise<Purchase[]> - Array of pending transactions
+ * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios}
+ */
 export const getPendingTransactionsIOS: QueryField<
   'getPendingTransactionsIOS'
 > = async () => {
@@ -1080,6 +1165,11 @@ export const getPendingTransactionsIOS: QueryField<
   }
 };
 
+/**
+ * List every StoreKit transaction (finished + unfinished) for the current user.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios}
+ */
 export const getAllTransactionsIOS: QueryField<
   'getAllTransactionsIOS'
 > = async () => {
@@ -1106,6 +1196,13 @@ export const getAllTransactionsIOS: QueryField<
   }
 };
 
+/**
+ * Show manage subscriptions screen (iOS only)
+ * @returns Promise<Purchase[]> - Subscriptions where auto-renewal status changed
+ * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios}
+ */
 export const showManageSubscriptionsIOS: MutationField<
   'showManageSubscriptionsIOS'
 > = async () => {
@@ -1132,6 +1229,14 @@ export const showManageSubscriptionsIOS: MutationField<
   }
 };
 
+/**
+ * Check if user is eligible for intro offer (iOS only)
+ * @param groupID - The subscription group ID
+ * @returns Promise<boolean> - Eligibility status
+ * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios}
+ */
 export const isEligibleForIntroOfferIOS: QueryField<
   'isEligibleForIntroOfferIOS'
 > = async (groupID) => {
@@ -1153,6 +1258,13 @@ export const isEligibleForIntroOfferIOS: QueryField<
   }
 };
 
+/**
+ * Get receipt data (iOS only)
+ * @returns Promise<string> - Base64 encoded receipt data
+ * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios}
+ */
 export const getReceiptDataIOS: QueryField<'getReceiptDataIOS'> = async () => {
   if (Platform.OS !== 'ios') {
     throw new Error('getReceiptDataIOS is only available on iOS');
@@ -1234,6 +1346,14 @@ export const requestReceiptRefreshIOS = async (): Promise<string> => {
   }
 };
 
+/**
+ * Check if transaction is verified (iOS only)
+ * @param sku - The product SKU
+ * @returns Promise<boolean> - Verification status
+ * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios}
+ */
 export const isTransactionVerifiedIOS: QueryField<
   'isTransactionVerifiedIOS'
 > = async (sku) => {
@@ -1255,6 +1375,14 @@ export const isTransactionVerifiedIOS: QueryField<
   }
 };
 
+/**
+ * Get transaction JWS representation (iOS only)
+ * @param sku - The product SKU
+ * @returns Promise<string | null> - JWS representation or null
+ * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios}
+ */
 export const getTransactionJwsIOS: QueryField<'getTransactionJwsIOS'> = async (
   sku,
 ) => {
@@ -1281,25 +1409,23 @@ export const getTransactionJwsIOS: QueryField<'getTransactionJwsIOS'> = async (
 // ------------------------------
 
 /**
- * Initialize connection to the store
- * @param config - Optional configuration including alternative billing mode for Android
- * @param config.alternativeBillingModeAndroid - Alternative billing mode: 'none', 'user-choice', or 'alternative-only'
+ * Initialize the store connection. Must be called before any other IAP API.
+ *
+ * @param config Optional connection config. Use `enableBillingProgramAndroid` (Android,
+ *   Play Billing 8.2.0+) to opt into External Payments etc. iOS ignores Android-specific fields.
+ * @returns Promise resolving to `true` when the platform billing client is connected.
+ * @throws When the platform billing client fails to initialize.
  *
  * @example
- * ```typescript
- * // Standard billing (default)
+ * ```ts
  * await initConnection();
- *
- * // User choice billing (Android)
- * await initConnection({
- *   alternativeBillingModeAndroid: 'user-choice'
- * });
- *
- * // Alternative billing only (Android)
- * await initConnection({
- *   alternativeBillingModeAndroid: 'alternative-only'
- * });
+ * await initConnection({ enableBillingProgramAndroid: 'external-offer' });
  * ```
+ *
+ * @remarks When using `useIAP()`, connection is auto-managed on mount/unmount —
+ *   pass options to the hook instead of calling this directly.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/init-connection}
  */
 export const initConnection: MutationField<'initConnection'> = async (
   config,
@@ -1321,7 +1447,9 @@ export const initConnection: MutationField<'initConnection'> = async (
 };
 
 /**
- * End connection to the store
+ * Close the store connection and release resources.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/end-connection}
  */
 export const endConnection: MutationField<'endConnection'> = async () => {
   try {
@@ -1341,6 +1469,11 @@ export const endConnection: MutationField<'endConnection'> = async () => {
   }
 };
 
+/**
+ * Restore non-consumable and active subscription purchases.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/restore-purchases}
+ */
 export const restorePurchases: MutationField<'restorePurchases'> = async () => {
   try {
     if (Platform.OS === 'ios') {
@@ -1364,9 +1497,30 @@ export const restorePurchases: MutationField<'restorePurchases'> = async () => {
 };
 
 /**
- * Request a purchase for products or subscriptions
- * ⚠️ Important: This is an event-based operation, not promise-based.
- * Listen for events through purchaseUpdatedListener or purchaseErrorListener.
+ * Initiate a purchase or subscription flow. The result is delivered through
+ * `purchaseUpdatedListener` — NOT the return value.
+ *
+ * @param props `RequestPurchaseProps`, discriminated by `type`:
+ *   - `type: 'in-app'` — pass `request.apple.sku` (iOS) and/or `request.google.skus` (Android).
+ *   - `type: 'subs'`  — same shape, plus `request.google.subscriptionOffers: [{ sku, offerToken }]`.
+ * @returns The dispatched purchase payload. **Do not rely on it** for the actual outcome.
+ * @throws Synchronous rejection from the store (e.g. `E_NOT_PREPARED`, validation failure).
+ *
+ * @example
+ * ```ts
+ * await requestPurchase({
+ *   request: {
+ *     apple: { sku: 'com.app.premium' },
+ *     google: { skus: ['com.app.premium'] },
+ *   },
+ *   type: 'in-app',
+ * });
+ * ```
+ *
+ * @remarks Event-based. Listen for the result via {@link purchaseUpdatedListener} /
+ *   {@link purchaseErrorListener}, or use `useIAP({ onPurchaseSuccess, onPurchaseError })`.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/request-purchase}
  */
 export const requestPurchase: MutationField<'requestPurchase'> = async (
   request,
@@ -1513,19 +1667,28 @@ export const requestPurchase: MutationField<'requestPurchase'> = async (
 };
 
 /**
- * Finish a transaction (consume or acknowledge)
- * @param params - Transaction finish parameters
- * @param params.purchase - The purchase to finish
- * @param params.isConsumable - Whether this is a consumable product (Android only)
- * @returns Promise<void> - Resolves when the transaction is successfully finished
+ * Complete a purchase transaction. Call after server-side verification to remove it
+ * from the queue.
+ *
+ * @param args.purchase The `Purchase` to finalize.
+ * @param args.isConsumable `true` for consumables (consumes the token so the SKU can be
+ *   re-bought, e.g. coins); `false` (default) for non-consumables and subscriptions.
+ * @returns Promise that resolves once the platform finalizes the transaction.
+ * @throws When the platform finalize call fails.
  *
  * @example
- * ```typescript
- * await finishTransaction({
- *   purchase: myPurchase,
- *   isConsumable: true
+ * ```ts
+ * purchaseUpdatedListener(async (purchase) => {
+ *   if (await verifyOnServer(purchase)) {
+ *     await finishTransaction({ purchase, isConsumable: false });
+ *   }
  * });
  * ```
+ *
+ * @remarks **Critical:** Android purchases must be finalized within 3 days or Google
+ *   auto-refunds. iOS unfinished transactions replay on every app launch.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/finish-transaction}
  */
 export const finishTransaction: MutationField<'finishTransaction'> = async (
   args,
@@ -1593,6 +1756,8 @@ export const finishTransaction: MutationField<'finishTransaction'> = async (
  * ```typescript
  * await acknowledgePurchaseAndroid('purchase_token_here');
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android}
  */
 export const acknowledgePurchaseAndroid: MutationField<
   'acknowledgePurchaseAndroid'
@@ -1632,6 +1797,8 @@ export const acknowledgePurchaseAndroid: MutationField<
  * ```typescript
  * await consumePurchaseAndroid('purchase_token_here');
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/consume-purchase-android}
  */
 export const consumePurchaseAndroid: MutationField<
   'consumePurchaseAndroid'
@@ -1687,6 +1854,8 @@ export const consumePurchaseAndroid: MutationField<
  *   }
  * });
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/validate-receipt}
  */
 export const validateReceipt: MutationField<'validateReceipt'> = async (
   options,
@@ -1816,6 +1985,8 @@ export const validateReceipt: MutationField<'validateReceipt'> = async (
  *
  * @param options - Receipt validation options containing the SKU
  * @returns Promise resolving to receipt validation result
+ *
+ * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase}
  */
 export const verifyPurchase: MutationField<'verifyPurchase'> = validateReceipt;
 
@@ -1825,6 +1996,8 @@ export const verifyPurchase: MutationField<'verifyPurchase'> = validateReceipt;
  * @deprecated Use `verifyPurchase` (or `validateReceipt`) instead. Kept so
  * consumers who imported `validateReceiptIOS` — which is still declared on the
  * OpenIAP Query interface — keep working. Throws on non-iOS platforms.
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/validate-receipt-ios}
  */
 export const validateReceiptIOS: QueryField<'validateReceiptIOS'> = async (
   options,
@@ -1856,6 +2029,8 @@ export const validateReceiptIOS: QueryField<'validateReceiptIOS'> = async (
  *   },
  * });
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider}
  */
 export const verifyPurchaseWithProvider: MutationField<
   'verifyPurchaseWithProvider'
@@ -1899,6 +2074,8 @@ export const verifyPurchaseWithProvider: MutationField<
  * Sync iOS purchases with App Store (iOS only)
  * @returns Promise<boolean>
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/sync-ios}
  */
 export const syncIOS: MutationField<'syncIOS'> = async () => {
   if (Platform.OS !== 'ios') {
@@ -1924,6 +2101,8 @@ export const syncIOS: MutationField<'syncIOS'> = async () => {
  * Present the code redemption sheet for offer codes (iOS only)
  * @returns Promise<boolean> - Indicates whether the redemption sheet was presented
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios}
  */
 export const presentCodeRedemptionSheetIOS: MutationField<
   'presentCodeRedemptionSheetIOS'
@@ -1966,6 +2145,8 @@ export const presentCodeRedemptionSheetIOS: MutationField<
  *
  * @returns Promise<boolean> - true when the request triggers successfully
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios}
  */
 export const requestPurchaseOnPromotedProductIOS =
   async (): Promise<boolean> => {
@@ -2008,6 +2189,8 @@ export const requestPurchaseOnPromotedProductIOS =
  * Clear unfinished transactions on iOS
  * @returns Promise<boolean>
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/clear-transaction-ios}
  */
 export const clearTransactionIOS: MutationField<
   'clearTransactionIOS'
@@ -2036,6 +2219,8 @@ export const clearTransactionIOS: MutationField<
  * @param sku - The product SKU to refund
  * @returns Promise<string | null> - The refund status or null if not available
  * @platform iOS
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios}
  */
 export const beginRefundRequestIOS: MutationField<
   'beginRefundRequestIOS'
@@ -2060,71 +2245,10 @@ export const beginRefundRequestIOS: MutationField<
 };
 
 /**
- * Get subscription status for a product (iOS only)
- * @param sku - The product SKU
- * @returns Promise<SubscriptionStatusIOS[]> - Array of subscription status objects
- * @throws Error when called on non-iOS platforms or when IAP is not initialized
- * @platform iOS
- */
-/**
- * Get current entitlement for a product (iOS only)
- * @param sku - The product SKU
- * @returns Promise<Purchase | null> - Current entitlement or null
- * @platform iOS
- */
-/**
- * Get latest transaction for a product (iOS only)
- * @param sku - The product SKU
- * @returns Promise<Purchase | null> - Latest transaction or null
- * @platform iOS
- */
-/**
- * Get pending transactions (iOS only)
- * @returns Promise<Purchase[]> - Array of pending transactions
- * @platform iOS
- */
-/**
- * Show manage subscriptions screen (iOS only)
- * @returns Promise<Purchase[]> - Subscriptions where auto-renewal status changed
- * @platform iOS
- */
-/**
- * Check if user is eligible for intro offer (iOS only)
- * @param groupID - The subscription group ID
- * @returns Promise<boolean> - Eligibility status
- * @platform iOS
- */
-/**
- * Get receipt data (iOS only)
- * @returns Promise<string> - Base64 encoded receipt data
- * @platform iOS
- */
-/**
- * Check if transaction is verified (iOS only)
- * @param sku - The product SKU
- * @returns Promise<boolean> - Verification status
- * @platform iOS
- */
-/**
- * Get transaction JWS representation (iOS only)
- * @param sku - The product SKU
- * @returns Promise<string | null> - JWS representation or null
- * @platform iOS
- */
-/**
- * Get the storefront identifier for the user's App Store account (iOS only)
- * @returns Promise<string> - The storefront identifier (e.g., 'USA' for United States)
- * @platform iOS
- *
- * @example
- * ```typescript
- * const storefront = await getStorefrontIOS();
- * console.log('User storefront:', storefront); // e.g., 'USA', 'GBR', 'KOR'
- * ```
- */
-/**
  * Deeplinks to native interface that allows users to manage their subscriptions
  * Cross-platform alias aligning with expo-iap
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/deep-link-to-subscriptions}
  */
 export const deepLinkToSubscriptions: MutationField<
   'deepLinkToSubscriptions'
@@ -2175,25 +2299,6 @@ export const deepLinkToSubscriptionsIOS = async (): Promise<boolean> => {
 };
 
 /**
- * iOS only - Gets the original app transaction ID if the app was purchased from the App Store
- * @platform iOS
- * @description
- * This function retrieves the original app transaction information if the app was purchased
- * from the App Store. Returns null if the app was not purchased (e.g., free app or TestFlight).
- *
- * @returns {Promise<string | null>} The original app transaction ID or null
- *
- * @example
- * ```typescript
- * const appTransaction = await getAppTransactionIOS();
- * if (appTransaction) {
- *   console.log('App was purchased, transaction ID:', appTransaction);
- * } else {
- *   console.log('App was not purchased from App Store');
- * }
- * ```
- */
-/**
  * Get all active subscriptions with detailed information (OpenIAP compliant)
  * Returns an array of active subscriptions. If subscriptionIds is not provided,
  * returns all active subscriptions. Platform-specific fields are populated based
@@ -2205,6 +2310,8 @@ export const deepLinkToSubscriptionsIOS = async (): Promise<boolean> => {
  *
  * @param subscriptionIds - Optional array of subscription IDs to filter by
  * @returns Promise<ActiveSubscription[]> - Array of active subscriptions
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/get-active-subscriptions}
  */
 export const getActiveSubscriptions: QueryField<
   'getActiveSubscriptions'
@@ -2364,6 +2471,8 @@ export const getActiveSubscriptions_OLD: QueryField<
  *
  * @param subscriptionIds - Optional array of subscription IDs to check
  * @returns Promise<boolean> - True if there are active subscriptions
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/has-active-subscriptions}
  */
 export const hasActiveSubscriptions: QueryField<
   'hasActiveSubscriptions'
@@ -2491,6 +2600,8 @@ const normalizeProductQueryType = (
  *   // Proceed with alternative billing flow
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android}
  */
 export const checkAlternativeBillingAvailabilityAndroid: MutationField<
   'checkAlternativeBillingAvailabilityAndroid'
@@ -2531,6 +2642,8 @@ export const checkAlternativeBillingAvailabilityAndroid: MutationField<
  *   }
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android}
  */
 export const showAlternativeBillingDialogAndroid: MutationField<
   'showAlternativeBillingDialogAndroid'
@@ -2568,6 +2681,8 @@ export const showAlternativeBillingDialogAndroid: MutationField<
  *   });
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android}
  */
 export const createAlternativeBillingTokenAndroid: MutationField<
   'createAlternativeBillingTokenAndroid'
@@ -2663,6 +2778,8 @@ export const enableBillingProgramAndroid = (
  *   // External offers are available for this user
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/is-billing-program-available-android}
  */
 export const isBillingProgramAvailableAndroid: MutationField<
   'isBillingProgramAvailableAndroid'
@@ -2702,6 +2819,8 @@ export const isBillingProgramAvailableAndroid: MutationField<
  *   body: JSON.stringify({ token: details.externalTransactionToken })
  * });
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android}
  */
 export const createBillingProgramReportingDetailsAndroid: MutationField<
   'createBillingProgramReportingDetailsAndroid'
@@ -2747,6 +2866,8 @@ export const createBillingProgramReportingDetailsAndroid: MutationField<
  *   console.log('User accepted external link');
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/android/launch-external-link-android}
  */
 export const launchExternalLinkAndroid: MutationField<
   'launchExternalLinkAndroid'
@@ -2785,6 +2906,8 @@ export const launchExternalLinkAndroid: MutationField<
  *   const result = await presentExternalPurchaseNoticeSheetIOS();
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios}
  */
 export const canPresentExternalPurchaseNoticeIOS: QueryField<
   'canPresentExternalPurchaseNoticeIOS'
@@ -2818,6 +2941,8 @@ export const canPresentExternalPurchaseNoticeIOS: QueryField<
  *   await presentExternalPurchaseLinkIOS('https://your-website.com/purchase');
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios}
  */
 export const presentExternalPurchaseNoticeSheetIOS =
   async (): Promise<ExternalPurchaseNoticeResultIOS> => {
@@ -2849,6 +2974,8 @@ export const presentExternalPurchaseNoticeSheetIOS =
  *   console.log('User completed external purchase');
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios}
  */
 export const presentExternalPurchaseLinkIOS: MutationField<
   'presentExternalPurchaseLinkIOS'
@@ -2883,6 +3010,8 @@ export const presentExternalPurchaseLinkIOS: MutationField<
  *   // App can use custom external purchase links
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios}
  */
 export const isEligibleForExternalPurchaseCustomLinkIOS =
   async (): Promise<boolean> => {
@@ -2918,6 +3047,8 @@ export const isEligibleForExternalPurchaseCustomLinkIOS =
  *   await reportToApple(result.token);
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios}
  */
 export const getExternalPurchaseCustomLinkTokenIOS = async (
   tokenType: ExternalPurchaseCustomLinkTokenTypeIOS,
@@ -2956,6 +3087,8 @@ export const getExternalPurchaseCustomLinkTokenIOS = async (
  *   await Linking.openURL('https://your-store.com/checkout');
  * }
  * ```
+ *
+ * @see {@link https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios}
  */
 export const showExternalPurchaseCustomLinkNoticeIOS = async (
   noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS,

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -667,7 +667,8 @@ export const subscriptionBillingIssueListener = (
  * @param params `ProductRequest` — `skus` (string[]) and optional `type`
  *   (`'in-app' | 'subs' | 'all'`, defaults to `'in-app'`).
  * @returns Promise resolving to a `FetchProductsResult` union — `Product[]` for `'in-app'`,
- *   `ProductSubscription[]` for `'subs'`, or a mixed array for `'all'`.
+ *   `ProductSubscription[]` for `'subs'`, a mixed array for `'all'`, or `null`
+ *   (the schema retains the nullable branch for backwards compatibility).
  * @throws When the store rejects the request (unknown SKU, network, not connected).
  *
  * @example
@@ -798,8 +799,9 @@ export const fetchProducts: QueryField<'fetchProducts'> = async (request) => {
  * List the user's unfinished purchases — non-consumables, active subscriptions, and any
  * pending transactions not yet finished.
  *
- * @param options Optional `PurchaseOptions`. iOS-only flags:
- *   `alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`.
+ * @param options Optional `PurchaseOptions`.
+ *   - iOS: `alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`.
+ *   - Android: `includeSuspendedAndroid` (include subscriptions in a paused/grace state).
  * @returns Promise resolving to an array of `Purchase` currently held by the store.
  * @throws When the platform query fails.
  *

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -669,7 +669,8 @@ export const subscriptionBillingIssueListener = (
  * @returns Promise resolving to a `FetchProductsResult` union — `Product[]` for `'in-app'`,
  *   `ProductSubscription[]` for `'subs'`, a mixed array for `'all'`, or `null`
  *   (the schema retains the nullable branch for backwards compatibility).
- * @throws When the store rejects the request (unknown SKU, network, not connected).
+ * @throws When the store rejects the request (empty `skus`, not connected,
+ *   network/store error). Unknown SKUs are simply omitted from the result, not thrown.
  *
  * @example
  * ```ts

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -664,7 +664,7 @@ export const subscriptionBillingIssueListener = (
 /**
  * Retrieve products or subscriptions from the store by SKU.
  *
- * @param params `ProductRequest` — `skus` (string[]) and optional `type`
+ * @param request `ProductRequest` — `skus` (string[]) and optional `type`
  *   (`'in-app' | 'subs' | 'all'`, defaults to `'in-app'`).
  * @returns Promise resolving to a `FetchProductsResult` union — `Product[]` for `'in-app'`,
  *   `ProductSubscription[]` for `'subs'`, a mixed array for `'all'`, or `null`
@@ -1502,7 +1502,7 @@ export const restorePurchases: MutationField<'restorePurchases'> = async () => {
  * Initiate a purchase or subscription flow. The result is delivered through
  * `purchaseUpdatedListener` — NOT the return value.
  *
- * @param props `RequestPurchaseProps`, discriminated by `type`:
+ * @param request `RequestPurchaseProps`, discriminated by `type`:
  *   - `type: 'in-app'` — pass `request.apple.sku` (iOS) and/or `request.google.skus` (Android).
  *   - `type: 'subs'`  — same shape, plus `request.google.subscriptionOffers: [{ sku, offerToken }]`.
  * @returns The dispatched purchase payload. **Do not rely on it** for the actual outcome.

--- a/libraries/react-native-iap/src/types.ts
+++ b/libraries/react-native-iap/src/types.ts
@@ -746,7 +746,9 @@ export interface Mutation {
    */
   verifyPurchase: Promise<VerifyPurchaseResult>;
   /**
-   * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+   * Verify via a managed provider without standing up your own server. The
+   * PurchaseVerificationProvider enum currently exposes only IAPKit; platform
+   * availability may differ by implementation.
    * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
    */
   verifyPurchaseWithProvider: Promise<VerifyPurchaseWithProviderResult>;

--- a/libraries/react-native-iap/src/types.ts
+++ b/libraries/react-native-iap/src/types.ts
@@ -741,7 +741,11 @@ export interface Mutation {
    */
   validateReceipt: Promise<VerifyPurchaseResult>;
   /**
-   * Verify a purchase against your own backend (returns isValid + raw store metadata).
+   * Verify a purchase against your own backend. Returns a platform-specific
+   * variant of VerifyPurchaseResult — VerifyPurchaseResultIOS exposes isValid
+   * + receipt/JWS metadata, VerifyPurchaseResultAndroid carries Play Store
+   * receipt fields (no isValid), and VerifyPurchaseResultHorizon uses success.
+   * Inspect the concrete variant before reading fields.
    * See: https://www.openiap.dev/docs/features/validation#verify-purchase
    */
   verifyPurchase: Promise<VerifyPurchaseResult>;

--- a/libraries/react-native-iap/src/types.ts
+++ b/libraries/react-native-iap/src/types.ts
@@ -585,118 +585,170 @@ export interface LimitedQuantityInfoAndroid {
 }
 
 export interface Mutation {
-  /** Acknowledge a non-consumable purchase or subscription */
+  /**
+   * Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+   * See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
+   */
   acknowledgePurchaseAndroid: Promise<boolean>;
-  /** Initiate a refund request for a product (iOS 15+) */
+  /**
+   * Present the refund request sheet (iOS 15+). See also Features → Refund.
+   * See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
+   */
   beginRefundRequestIOS?: Promise<(string | null)>;
   /**
-   * Check if alternative billing is available for this user/device
-   * Step 1 of alternative billing flow
+   * Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
    *
-   * Returns true if available, false otherwise
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns true if available, false otherwise.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
    */
   checkAlternativeBillingAvailabilityAndroid: Promise<boolean>;
-  /** Clear pending transactions from the StoreKit payment queue */
+  /**
+   * Clear pending transactions in the queue (sandbox helper).
+   * See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
+   */
   clearTransactionIOS: Promise<boolean>;
-  /** Consume a purchase token so it can be repurchased */
+  /**
+   * Consume a consumable purchase so it can be re-bought.
+   * See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
+   */
   consumePurchaseAndroid: Promise<boolean>;
   /**
-   * Create external transaction token for Google Play reporting
-   * Step 3 of alternative billing flow
-   * Must be called AFTER successful payment in your payment system
-   * Token must be reported to Google Play backend within 24 hours
+   * Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
+   * Must be called AFTER successful payment in your payment system.
+   * Token must be reported to Google Play backend within 24 hours.
    *
-   * Returns token string, or null if creation failed
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns token string, or null if creation failed.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
    */
   createAlternativeBillingTokenAndroid?: Promise<(string | null)>;
   /**
-   * Create reporting details for a billing program
-   * Replaces the deprecated createExternalOfferReportingDetailsAsync API
+   * Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+   * Replaces the deprecated createExternalOfferReportingDetailsAsync API.
    *
-   * Available in Google Play Billing Library 8.2.0+
-   * Returns external transaction token needed for reporting external transactions
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns external transaction token needed for reporting external transactions.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
    */
   createBillingProgramReportingDetailsAndroid: Promise<BillingProgramReportingDetailsAndroid>;
-  /** Open the native subscription management surface */
+  /**
+   * Open the platform's subscription management UI.
+   * See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
+   */
   deepLinkToSubscriptions: Promise<void>;
-  /** Close the platform billing connection */
+  /**
+   * Close the store connection and release resources.
+   * See: https://www.openiap.dev/docs/apis/end-connection
+   */
   endConnection: Promise<boolean>;
-  /** Finish a transaction after validating receipts */
+  /**
+   * Complete a transaction after server-side verification. Required on Android within 3 days.
+   * See: https://www.openiap.dev/docs/apis/finish-transaction
+   */
   finishTransaction: Promise<void>;
-  /** Establish the platform billing connection */
+  /**
+   * Initialize the store connection. Call before any IAP API.
+   * See: https://www.openiap.dev/docs/apis/init-connection
+   */
   initConnection: Promise<boolean>;
   /**
-   * Check if a billing program is available for the current user
-   * Replaces the deprecated isExternalOfferAvailableAsync API
+   * Check whether a billing program (e.g., External Payments) is available for the current user.
+   * Replaces the deprecated isExternalOfferAvailableAsync API.
    *
-   * Available in Google Play Billing Library 8.2.0+
-   * Returns availability result with isAvailable flag
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Available in Google Play Billing Library 8.2.0+.
+   * Returns availability result with isAvailable flag.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
    */
   isBillingProgramAvailableAndroid: Promise<BillingProgramAvailabilityResultAndroid>;
   /**
-   * Launch external link flow for external billing programs
-   * Replaces the deprecated showExternalOfferInformationDialog API
+   * Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+   * Replaces the deprecated showExternalOfferInformationDialog API.
    *
-   * Available in Google Play Billing Library 8.2.0+
-   * Shows Play Store dialog and optionally launches external URL
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Shows Play Store dialog and optionally launches external URL.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
    */
   launchExternalLinkAndroid: Promise<boolean>;
-  /** Present the App Store code redemption sheet */
+  /**
+   * Show the App Store offer code redemption sheet.
+   * See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
+   */
   presentCodeRedemptionSheetIOS: Promise<boolean>;
-  /** Present external purchase custom link with StoreKit UI */
+  /**
+   * Present an external purchase link, StoreKit External (iOS 16+).
+   * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
+   */
   presentExternalPurchaseLinkIOS: Promise<ExternalPurchaseLinkResultIOS>;
   /**
-   * Present external purchase notice sheet (iOS 17.4+).
-   * Uses ExternalPurchase.presentNoticeSheet() which returns a token when user continues.
+   * Present the external purchase notice sheet (iOS 17.4+).
+   * Uses ExternalPurchase.presentNoticeSheet() which returns a token when the user continues.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()
+   * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
    */
   presentExternalPurchaseNoticeSheetIOS: Promise<ExternalPurchaseNoticeResultIOS>;
-  /** Initiate a purchase flow; rely on events for final state */
+  /**
+   * Initiate a purchase or subscription flow; rely on events for final state.
+   * See: https://www.openiap.dev/docs/apis/request-purchase
+   */
   requestPurchase?: Promise<(Purchase | Purchase[] | null)>;
   /**
-   * Purchase the promoted product surfaced by the App Store.
+   * Buy the currently promoted product.
    *
    * @deprecated Use promotedProductListenerIOS to receive the productId,
    * then call requestPurchase with that SKU instead. In StoreKit 2,
    * promoted products can be purchased directly via the standard purchase flow.
+   * See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
    * @deprecated Use promotedProductListenerIOS + requestPurchase instead
    */
   requestPurchaseOnPromotedProductIOS: Promise<boolean>;
-  /** Restore completed purchases across platforms */
+  /**
+   * Restore non-consumable and active subscription purchases.
+   * See: https://www.openiap.dev/docs/apis/restore-purchases
+   */
   restorePurchases: Promise<void>;
   /**
-   * Show alternative billing information dialog to user
-   * Step 2 of alternative billing flow
-   * Must be called BEFORE processing payment in your payment system
+   * Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
+   * Must be called BEFORE processing payment in your payment system.
    *
-   * Returns true if user accepted, false if user canceled
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns true if user accepted, false if user canceled.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
    */
   showAlternativeBillingDialogAndroid: Promise<boolean>;
   /**
-   * Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-   * Displays the system disclosure notice sheet for custom external purchase links.
+   * Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
    * Call this after a deliberate customer interaction before linking out to external purchases.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+   * See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
    */
   showExternalPurchaseCustomLinkNoticeIOS: Promise<ExternalPurchaseCustomLinkNoticeResultIOS>;
-  /** Open subscription management UI and return changed purchases (iOS 15+) */
+  /**
+   * Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
+   */
   showManageSubscriptionsIOS: Promise<PurchaseIOS[]>;
-  /** Force a StoreKit sync for transactions (iOS 15+) */
+  /**
+   * Force sync transactions with the App Store (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/sync-ios
+   */
   syncIOS: Promise<boolean>;
   /**
-   * Validate purchase receipts with the configured providers
+   * Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
+   * See: https://www.openiap.dev/docs/features/validation#verify-purchase
    * @deprecated Use verifyPurchase
    */
   validateReceipt: Promise<VerifyPurchaseResult>;
-  /** Verify purchases with the configured providers */
+  /**
+   * Verify a purchase against your own backend (returns isValid + raw store metadata).
+   * See: https://www.openiap.dev/docs/features/validation#verify-purchase
+   */
   verifyPurchase: Promise<VerifyPurchaseResult>;
-  /** Verify purchases with a specific provider (e.g., IAPKit) */
+  /**
+   * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+   * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
+   */
   verifyPurchaseWithProvider: Promise<VerifyPurchaseWithProviderResult>;
 }
 
@@ -1234,66 +1286,117 @@ export type PurchaseVerificationProvider = 'iapkit';
 
 export interface Query {
   /**
-   * Check if external purchase notice sheet can be presented (iOS 17.4+)
-   * Uses ExternalPurchase.canPresent
+   * Check eligibility for the external purchase notice sheet (iOS 17.4+).
+   * Uses ExternalPurchase.canPresent.
+   * See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
    */
   canPresentExternalPurchaseNoticeIOS: Promise<boolean>;
-  /** Get current StoreKit 2 entitlements (iOS 15+) */
+  /**
+   * Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
+   */
   currentEntitlementIOS?: Promise<(PurchaseIOS | null)>;
-  /** Retrieve products or subscriptions from the store */
+  /**
+   * Fetch products or subscriptions from the store.
+   * See: https://www.openiap.dev/docs/apis/fetch-products
+   */
   fetchProducts: Promise<(ProductOrSubscription[] | Product[] | ProductSubscription[] | null)>;
-  /** Get active subscriptions (filters by subscriptionIds when provided) */
+  /**
+   * Get details of all currently active subscriptions (filters by subscriptionIds when provided).
+   * See: https://www.openiap.dev/docs/apis/get-active-subscriptions
+   */
   getActiveSubscriptions: Promise<ActiveSubscription[]>;
   /**
-   * Get the full StoreKit 2 transaction history as PurchaseIOS values.
+   * List every StoreKit transaction (finished + unfinished) for the current user.
    * Requires the SK2ConsumableTransactionHistory Info.plist key in the host app
    * for finished consumables to be included (iOS 18+).
    * Unlike getAvailablePurchases, always returns the iOS-specific PurchaseIOS shape.
+   * See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
    */
   getAllTransactionsIOS: Promise<PurchaseIOS[]>;
-  /** Fetch the current app transaction (iOS 16+) */
+  /**
+   * Fetch the app transaction (iOS 16+).
+   * See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
+   */
   getAppTransactionIOS?: Promise<(AppTransaction | null)>;
-  /** Get all available purchases for the current user */
+  /**
+   * List active purchases for the current user.
+   * See: https://www.openiap.dev/docs/apis/get-available-purchases
+   */
   getAvailablePurchases: Promise<Purchase[]>;
   /**
-   * Get external purchase token for reporting to Apple (iOS 18.1+).
-   * Use this token with Apple's External Purchase Server API to report transactions.
+   * Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+   * Use this token to report transactions made through ExternalPurchaseCustomLink.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+   * See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
    */
   getExternalPurchaseCustomLinkTokenIOS: Promise<ExternalPurchaseCustomLinkTokenResultIOS>;
-  /** Retrieve all pending transactions in the StoreKit queue */
+  /**
+   * List unfinished StoreKit transactions in the queue.
+   * See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
+   */
   getPendingTransactionsIOS: Promise<PurchaseIOS[]>;
-  /** Get the currently promoted product (iOS 11+) */
+  /**
+   * Read the App Store-promoted product, if any (iOS 11+).
+   * See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
+   */
   getPromotedProductIOS?: Promise<(ProductIOS | null)>;
-  /** Get base64-encoded receipt data for validation */
+  /**
+   * Get base64-encoded receipt data (legacy validation).
+   * See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
+   */
   getReceiptDataIOS?: Promise<(string | null)>;
-  /** Get the current storefront country code */
+  /**
+   * Return the user's storefront country code.
+   * See: https://www.openiap.dev/docs/apis/get-storefront
+   */
   getStorefront: Promise<string>;
   /**
-   * Get the current App Store storefront country code
+   * Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
+   * See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
    * @deprecated Use getStorefront
    */
   getStorefrontIOS: Promise<string>;
-  /** Get the transaction JWS (StoreKit 2) */
+  /**
+   * Return the JWS string for a transaction (StoreKit 2).
+   * See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
+   */
   getTransactionJwsIOS?: Promise<(string | null)>;
-  /** Check whether the user has active subscriptions */
+  /**
+   * Check whether the user has any active subscription.
+   * See: https://www.openiap.dev/docs/apis/has-active-subscriptions
+   */
   hasActiveSubscriptions: Promise<boolean>;
   /**
-   * Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+   * Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
    * Returns true if the app can use custom external purchase links.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+   * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
    */
   isEligibleForExternalPurchaseCustomLinkIOS: Promise<boolean>;
-  /** Check introductory offer eligibility for a subscription group */
+  /**
+   * Check intro-offer eligibility for a subscription group.
+   * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
+   */
   isEligibleForIntroOfferIOS: Promise<boolean>;
-  /** Verify a StoreKit 2 transaction signature */
+  /**
+   * Check whether a transaction's JWS verification passed (StoreKit 2).
+   * See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
+   */
   isTransactionVerifiedIOS: Promise<boolean>;
-  /** Get the latest transaction for a product using StoreKit 2 */
+  /**
+   * Get the latest verified transaction for a product, using StoreKit 2.
+   * See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
+   */
   latestTransactionIOS?: Promise<(PurchaseIOS | null)>;
-  /** Get StoreKit 2 subscription status details (iOS 15+) */
+  /**
+   * Get subscription status objects from StoreKit 2 (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
+   */
   subscriptionStatusIOS: Promise<SubscriptionStatusIOS[]>;
   /**
-   * Validate a receipt for a specific product
+   * Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
+   * See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
    * @deprecated Use verifyPurchase
    */
   validateReceiptIOS: Promise<VerifyPurchaseResultIOS>;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "bun run --filter '*' dev",
     "test": "bun run --filter '*' test",
     "lint": "bun run --filter '*' lint",
+    "audit:docs": "bun run scripts/audit-docs.ts",
     "clean": "rm -rf packages/*/node_modules node_modules",
     "generate": "cd packages/gql && bun run generate && cd ../apple && ./scripts/generate-types.sh && cd ../google && ./scripts/generate-types.sh",
     "version:sync": "bun scripts/sync-versions.mjs",

--- a/packages/apple/Sources/Models/Types.swift
+++ b/packages/apple/Sources/Models/Types.swift
@@ -2439,7 +2439,11 @@ public protocol MutationResolver {
     /// Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
     /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
     func validateReceipt(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResult
-    /// Verify a purchase against your own backend (returns isValid + raw store metadata).
+    /// Verify a purchase against your own backend. Returns a platform-specific
+    /// variant of VerifyPurchaseResult — VerifyPurchaseResultIOS exposes isValid
+    /// + receipt/JWS metadata, VerifyPurchaseResultAndroid carries Play Store
+    /// receipt fields (no isValid), and VerifyPurchaseResultHorizon uses success.
+    /// Inspect the concrete variant before reading fields.
     /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
     func verifyPurchase(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResult
     /// Verify via a managed provider without standing up your own server. The

--- a/packages/apple/Sources/Models/Types.swift
+++ b/packages/apple/Sources/Models/Types.swift
@@ -2442,7 +2442,9 @@ public protocol MutationResolver {
     /// Verify a purchase against your own backend (returns isValid + raw store metadata).
     /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
     func verifyPurchase(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResult
-    /// Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+    /// Verify via a managed provider without standing up your own server. The
+    /// PurchaseVerificationProvider enum currently exposes only IAPKit; platform
+    /// availability may differ by implementation.
     /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
     func verifyPurchaseWithProvider(_ options: VerifyPurchaseWithProviderProps) async throws -> VerifyPurchaseWithProviderResult
 }

--- a/packages/apple/Sources/Models/Types.swift
+++ b/packages/apple/Sources/Models/Types.swift
@@ -2334,150 +2334,191 @@ public enum VerifyPurchaseResult: Codable {
 
 /// GraphQL root mutation operations.
 public protocol MutationResolver {
-    /// Acknowledge a non-consumable purchase or subscription
+    /// Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+    /// See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
     func acknowledgePurchaseAndroid(_ purchaseToken: String) async throws -> Bool
-    /// Initiate a refund request for a product (iOS 15+)
+    /// Present the refund request sheet (iOS 15+). See also Features → Refund.
+    /// See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
     func beginRefundRequestIOS(_ sku: String) async throws -> String?
-    /// Check if alternative billing is available for this user/device
-    /// Step 1 of alternative billing flow
+    /// Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
     /// 
-    /// Returns true if available, false otherwise
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Returns true if available, false otherwise.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
     func checkAlternativeBillingAvailabilityAndroid() async throws -> Bool
-    /// Clear pending transactions from the StoreKit payment queue
+    /// Clear pending transactions in the queue (sandbox helper).
+    /// See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
     func clearTransactionIOS() async throws -> Bool
-    /// Consume a purchase token so it can be repurchased
+    /// Consume a consumable purchase so it can be re-bought.
+    /// See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
     func consumePurchaseAndroid(_ purchaseToken: String) async throws -> Bool
-    /// Create external transaction token for Google Play reporting
-    /// Step 3 of alternative billing flow
-    /// Must be called AFTER successful payment in your payment system
-    /// Token must be reported to Google Play backend within 24 hours
+    /// Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
+    /// Must be called AFTER successful payment in your payment system.
+    /// Token must be reported to Google Play backend within 24 hours.
     /// 
-    /// Returns token string, or null if creation failed
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Returns token string, or null if creation failed.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
     func createAlternativeBillingTokenAndroid() async throws -> String?
-    /// Create reporting details for a billing program
-    /// Replaces the deprecated createExternalOfferReportingDetailsAsync API
+    /// Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+    /// Replaces the deprecated createExternalOfferReportingDetailsAsync API.
     /// 
-    /// Available in Google Play Billing Library 8.2.0+
-    /// Returns external transaction token needed for reporting external transactions
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Returns external transaction token needed for reporting external transactions.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
     func createBillingProgramReportingDetailsAndroid(_ program: BillingProgramAndroid) async throws -> BillingProgramReportingDetailsAndroid
-    /// Open the native subscription management surface
+    /// Open the platform's subscription management UI.
+    /// See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
     func deepLinkToSubscriptions(_ options: DeepLinkOptions?) async throws -> Void
-    /// Close the platform billing connection
+    /// Close the store connection and release resources.
+    /// See: https://www.openiap.dev/docs/apis/end-connection
     func endConnection() async throws -> Bool
-    /// Finish a transaction after validating receipts
+    /// Complete a transaction after server-side verification. Required on Android within 3 days.
+    /// See: https://www.openiap.dev/docs/apis/finish-transaction
     func finishTransaction(purchase: PurchaseInput, isConsumable: Bool?) async throws -> Void
-    /// Establish the platform billing connection
+    /// Initialize the store connection. Call before any IAP API.
+    /// See: https://www.openiap.dev/docs/apis/init-connection
     func initConnection(_ config: InitConnectionConfig?) async throws -> Bool
-    /// Check if a billing program is available for the current user
-    /// Replaces the deprecated isExternalOfferAvailableAsync API
+    /// Check whether a billing program (e.g., External Payments) is available for the current user.
+    /// Replaces the deprecated isExternalOfferAvailableAsync API.
     /// 
-    /// Available in Google Play Billing Library 8.2.0+
-    /// Returns availability result with isAvailable flag
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Available in Google Play Billing Library 8.2.0+.
+    /// Returns availability result with isAvailable flag.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
     func isBillingProgramAvailableAndroid(_ program: BillingProgramAndroid) async throws -> BillingProgramAvailabilityResultAndroid
-    /// Launch external link flow for external billing programs
-    /// Replaces the deprecated showExternalOfferInformationDialog API
+    /// Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+    /// Replaces the deprecated showExternalOfferInformationDialog API.
     /// 
-    /// Available in Google Play Billing Library 8.2.0+
-    /// Shows Play Store dialog and optionally launches external URL
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Shows Play Store dialog and optionally launches external URL.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
     func launchExternalLinkAndroid(_ params: LaunchExternalLinkParamsAndroid) async throws -> Bool
-    /// Present the App Store code redemption sheet
+    /// Show the App Store offer code redemption sheet.
+    /// See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
     func presentCodeRedemptionSheetIOS() async throws -> Bool
-    /// Present external purchase custom link with StoreKit UI
+    /// Present an external purchase link, StoreKit External (iOS 16+).
+    /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
     func presentExternalPurchaseLinkIOS(_ url: String) async throws -> ExternalPurchaseLinkResultIOS
-    /// Present external purchase notice sheet (iOS 17.4+).
-    /// Uses ExternalPurchase.presentNoticeSheet() which returns a token when user continues.
+    /// Present the external purchase notice sheet (iOS 17.4+).
+    /// Uses ExternalPurchase.presentNoticeSheet() which returns a token when the user continues.
     /// Reference: https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()
+    /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
     func presentExternalPurchaseNoticeSheetIOS() async throws -> ExternalPurchaseNoticeResultIOS
-    /// Initiate a purchase flow; rely on events for final state
+    /// Initiate a purchase or subscription flow; rely on events for final state.
+    /// See: https://www.openiap.dev/docs/apis/request-purchase
     func requestPurchase(_ params: RequestPurchaseProps) async throws -> RequestPurchaseResult?
-    /// Purchase the promoted product surfaced by the App Store.
+    /// Buy the currently promoted product.
     /// 
     /// @deprecated Use promotedProductListenerIOS to receive the productId,
     /// then call requestPurchase with that SKU instead. In StoreKit 2,
     /// promoted products can be purchased directly via the standard purchase flow.
+    /// See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
     func requestPurchaseOnPromotedProductIOS() async throws -> Bool
-    /// Restore completed purchases across platforms
+    /// Restore non-consumable and active subscription purchases.
+    /// See: https://www.openiap.dev/docs/apis/restore-purchases
     func restorePurchases() async throws -> Void
-    /// Show alternative billing information dialog to user
-    /// Step 2 of alternative billing flow
-    /// Must be called BEFORE processing payment in your payment system
+    /// Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
+    /// Must be called BEFORE processing payment in your payment system.
     /// 
-    /// Returns true if user accepted, false if user canceled
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Returns true if user accepted, false if user canceled.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
     func showAlternativeBillingDialogAndroid() async throws -> Bool
-    /// Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-    /// Displays the system disclosure notice sheet for custom external purchase links.
+    /// Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
     /// Call this after a deliberate customer interaction before linking out to external purchases.
     /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+    /// See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
     func showExternalPurchaseCustomLinkNoticeIOS(_ noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS) async throws -> ExternalPurchaseCustomLinkNoticeResultIOS
-    /// Open subscription management UI and return changed purchases (iOS 15+)
+    /// Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
+    /// See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
     func showManageSubscriptionsIOS() async throws -> [PurchaseIOS]
-    /// Force a StoreKit sync for transactions (iOS 15+)
+    /// Force sync transactions with the App Store (iOS 15+).
+    /// See: https://www.openiap.dev/docs/apis/ios/sync-ios
     func syncIOS() async throws -> Bool
-    /// Validate purchase receipts with the configured providers
+    /// Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
+    /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
     func validateReceipt(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResult
-    /// Verify purchases with the configured providers
+    /// Verify a purchase against your own backend (returns isValid + raw store metadata).
+    /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
     func verifyPurchase(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResult
-    /// Verify purchases with a specific provider (e.g., IAPKit)
+    /// Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+    /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
     func verifyPurchaseWithProvider(_ options: VerifyPurchaseWithProviderProps) async throws -> VerifyPurchaseWithProviderResult
 }
 
 /// GraphQL root query operations.
 public protocol QueryResolver {
-    /// Check if external purchase notice sheet can be presented (iOS 17.4+)
-    /// Uses ExternalPurchase.canPresent
+    /// Check eligibility for the external purchase notice sheet (iOS 17.4+).
+    /// Uses ExternalPurchase.canPresent.
+    /// See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
     func canPresentExternalPurchaseNoticeIOS() async throws -> Bool
-    /// Get current StoreKit 2 entitlements (iOS 15+)
+    /// Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
+    /// See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
     func currentEntitlementIOS(_ sku: String) async throws -> PurchaseIOS?
-    /// Retrieve products or subscriptions from the store
+    /// Fetch products or subscriptions from the store.
+    /// See: https://www.openiap.dev/docs/apis/fetch-products
     func fetchProducts(_ params: ProductRequest) async throws -> FetchProductsResult
-    /// Get active subscriptions (filters by subscriptionIds when provided)
+    /// Get details of all currently active subscriptions (filters by subscriptionIds when provided).
+    /// See: https://www.openiap.dev/docs/apis/get-active-subscriptions
     func getActiveSubscriptions(_ subscriptionIds: [String]?) async throws -> [ActiveSubscription]
-    /// Get the full StoreKit 2 transaction history as PurchaseIOS values.
+    /// List every StoreKit transaction (finished + unfinished) for the current user.
     /// Requires the SK2ConsumableTransactionHistory Info.plist key in the host app
     /// for finished consumables to be included (iOS 18+).
     /// Unlike getAvailablePurchases, always returns the iOS-specific PurchaseIOS shape.
+    /// See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
     func getAllTransactionsIOS() async throws -> [PurchaseIOS]
-    /// Fetch the current app transaction (iOS 16+)
+    /// Fetch the app transaction (iOS 16+).
+    /// See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
     func getAppTransactionIOS() async throws -> AppTransaction?
-    /// Get all available purchases for the current user
+    /// List active purchases for the current user.
+    /// See: https://www.openiap.dev/docs/apis/get-available-purchases
     func getAvailablePurchases(_ options: PurchaseOptions?) async throws -> [Purchase]
-    /// Get external purchase token for reporting to Apple (iOS 18.1+).
-    /// Use this token with Apple's External Purchase Server API to report transactions.
+    /// Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+    /// Use this token to report transactions made through ExternalPurchaseCustomLink.
     /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+    /// See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
     func getExternalPurchaseCustomLinkTokenIOS(_ tokenType: ExternalPurchaseCustomLinkTokenTypeIOS) async throws -> ExternalPurchaseCustomLinkTokenResultIOS
-    /// Retrieve all pending transactions in the StoreKit queue
+    /// List unfinished StoreKit transactions in the queue.
+    /// See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
     func getPendingTransactionsIOS() async throws -> [PurchaseIOS]
-    /// Get the currently promoted product (iOS 11+)
+    /// Read the App Store-promoted product, if any (iOS 11+).
+    /// See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
     func getPromotedProductIOS() async throws -> ProductIOS?
-    /// Get base64-encoded receipt data for validation
+    /// Get base64-encoded receipt data (legacy validation).
+    /// See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
     func getReceiptDataIOS() async throws -> String?
-    /// Get the current storefront country code
+    /// Return the user's storefront country code.
+    /// See: https://www.openiap.dev/docs/apis/get-storefront
     func getStorefront() async throws -> String
-    /// Get the current App Store storefront country code
+    /// Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
+    /// See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
     func getStorefrontIOS() async throws -> String
-    /// Get the transaction JWS (StoreKit 2)
+    /// Return the JWS string for a transaction (StoreKit 2).
+    /// See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
     func getTransactionJwsIOS(_ sku: String) async throws -> String?
-    /// Check whether the user has active subscriptions
+    /// Check whether the user has any active subscription.
+    /// See: https://www.openiap.dev/docs/apis/has-active-subscriptions
     func hasActiveSubscriptions(_ subscriptionIds: [String]?) async throws -> Bool
-    /// Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+    /// Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
     /// Returns true if the app can use custom external purchase links.
     /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+    /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
     func isEligibleForExternalPurchaseCustomLinkIOS() async throws -> Bool
-    /// Check introductory offer eligibility for a subscription group
+    /// Check intro-offer eligibility for a subscription group.
+    /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
     func isEligibleForIntroOfferIOS(_ groupID: String) async throws -> Bool
-    /// Verify a StoreKit 2 transaction signature
+    /// Check whether a transaction's JWS verification passed (StoreKit 2).
+    /// See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
     func isTransactionVerifiedIOS(_ sku: String) async throws -> Bool
-    /// Get the latest transaction for a product using StoreKit 2
+    /// Get the latest verified transaction for a product, using StoreKit 2.
+    /// See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
     func latestTransactionIOS(_ sku: String) async throws -> PurchaseIOS?
-    /// Get StoreKit 2 subscription status details (iOS 15+)
+    /// Get subscription status objects from StoreKit 2 (iOS 15+).
+    /// See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
     func subscriptionStatusIOS(_ sku: String) async throws -> [SubscriptionStatusIOS]
-    /// Validate a receipt for a specific product
+    /// Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
+    /// See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
     func validateReceiptIOS(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResultIOS
 }
 

--- a/packages/apple/Sources/OpenIapModule.swift
+++ b/packages/apple/Sources/OpenIapModule.swift
@@ -36,6 +36,14 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     // MARK: - Connection Management
 
+    /// Initialize the store connection. Must be called before any other IAP API.
+    ///
+    /// - Returns: `true` once StoreKit is connected.
+    /// - Throws: When StoreKit fails to initialize.
+    /// - Note: This wraps `OpenIapStoreKit2.initialize()`. Safe to call multiple times — the
+    ///   second call is a no-op.
+    ///
+    /// See: https://www.openiap.dev/docs/apis/init-connection
     public func initConnection() async throws -> Bool {
         if let task = initTask {
             return try await task.value
@@ -81,6 +89,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         }
     }
 
+    /// Close the store connection and release resources.
+    /// See: https://www.openiap.dev/docs/apis/end-connection
     public func endConnection() async throws -> Bool {
         initTask?.cancel()
         initTask = nil
@@ -90,6 +100,17 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     // MARK: - Product Management
 
+    /// Retrieve products or subscriptions from the App Store by SKU.
+    ///
+    /// - Parameter params: `ProductRequest` with `skus` (the product identifiers) and an
+    ///   optional `type` (`.inApp`, `.subs`, or `.all`; defaults to `.inApp`).
+    /// - Returns: A `FetchProductsResult` variant — `Product[]` for `.inApp`,
+    ///   `ProductSubscription[]` for `.subs`, or a mixed list for `.all`.
+    /// - Throws: When the store rejects the request (unknown SKU, network failure, not connected).
+    /// - Note: This is a regular promise-based call. Do not confuse with `request*` APIs,
+    ///   which are event-based.
+    ///
+    /// See: https://www.openiap.dev/docs/apis/fetch-products
     public func fetchProducts(_ params: ProductRequest) async throws -> FetchProductsResult {
         guard !params.skus.isEmpty else {
             let error = makePurchaseError(code: .emptySkuList)
@@ -188,6 +209,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         }
     }
 
+    /// Read the App Store-promoted product, if any.
+    /// See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
     public func getPromotedProductIOS() async throws -> ProductIOS? {
         // iOS-only: Promoted in-app purchases (App Store promotional purchases) only available on iOS
         // Reference: https://developer.apple.com/documentation/storekit/promoting-in-app-purchases
@@ -227,6 +250,16 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     // MARK: - Purchase Management
 
+    /// Initiate a purchase flow. The result is delivered via the purchase update listener,
+    /// NOT through the return value.
+    ///
+    /// - Parameter params: `RequestPurchaseProps` — discriminated by `type`:
+    ///   `.inApp` for one-time products (use `request.apple.sku`), `.subs` for subscriptions.
+    /// - Returns: The dispatched request payload. Do not rely on this for the purchase outcome.
+    /// - Throws: Synchronous rejections from StoreKit (e.g. user cancel before sheet, not prepared).
+    /// - Warning: Event-based. Listen via `purchaseUpdatedListener` / `purchaseErrorListener`.
+    ///
+    /// See: https://www.openiap.dev/docs/apis/request-purchase
     public func requestPurchase(_ params: RequestPurchaseProps) async throws -> RequestPurchaseResult? {
         try await ensureConnection()
         let iosProps = try resolveIOSPurchaseProps(from: params)
@@ -466,15 +499,28 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         }
     }
 
+    /// Buy the currently promoted product.
+    /// See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
     @available(*, deprecated, message: "Use promotedProductListenerIOS + requestPurchase instead")
     public func requestPurchaseOnPromotedProductIOS() async throws -> Bool {
         throw makePurchaseError(code: .featureNotSupported)
     }
 
+    /// Restore non-consumable and active subscription purchases.
+    /// See: https://www.openiap.dev/docs/apis/restore-purchases
     public func restorePurchases() async throws -> Void {
         _ = try await syncIOS()
     }
 
+    /// List the user's unfinished purchases. Use this to restore non-consumables / active
+    /// subscriptions, or to pick up transactions that weren't finished previously.
+    ///
+    /// - Parameter options: Optional iOS-specific flags
+    ///   (`alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`).
+    /// - Returns: An array of `Purchase` values currently held by StoreKit.
+    /// - Throws: When the StoreKit query fails.
+    ///
+    /// See: https://www.openiap.dev/docs/apis/get-available-purchases
     public func getAvailablePurchases(_ options: PurchaseOptions?) async throws -> [Purchase] {
         try await ensureConnection()
         let onlyActive = options?.onlyIncludeActiveItemsIOS ?? false
@@ -509,6 +555,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
     /// Unlike `getAvailablePurchases(_:)`, this method always reads from
     /// `Transaction.all` and returns the iOS-specific `PurchaseIOS` shape rather than
     /// the cross-platform `Purchase` type.
+    ///
+    /// See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
     public func getAllTransactionsIOS() async throws -> [PurchaseIOS] {
         try await ensureConnection()
         var transactions: [PurchaseIOS] = []
@@ -533,6 +581,19 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     // MARK: - Transaction Management
 
+    /// Complete a purchase transaction. Call after server-side verification to remove it
+    /// from the StoreKit queue.
+    ///
+    /// - Parameters:
+    ///   - purchase: The `PurchaseInput` to finalize.
+    ///   - isConsumable: Pass `true` for consumables (re-buyable like coins), `false` for
+    ///     subscriptions and non-consumables. Affects only Android consume vs acknowledge;
+    ///     iOS always calls `Transaction.finish()`.
+    /// - Throws: When the platform finalization fails.
+    /// - Important: iOS unfinished transactions replay on every app launch. (Android purchases
+    ///   must be acknowledged within 3 days, but that path lives in the Android module.)
+    ///
+    /// See: https://www.openiap.dev/docs/apis/finish-transaction
     public func finishTransaction(purchase: PurchaseInput, isConsumable: Bool?) async throws -> Void {
         try await ensureConnection()
         let identifier = purchase.id
@@ -578,6 +639,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         throw error
     }
 
+    /// List unfinished StoreKit transactions.
+    /// See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
     public func getPendingTransactionsIOS() async throws -> [PurchaseIOS] {
         try await ensureConnection()
         let snapshot = await state.pendingSnapshot()
@@ -588,6 +651,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         return purchases
     }
 
+    /// Clear pending transactions in the queue (sandbox helper).
+    /// See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
     public func clearTransactionIOS() async throws -> Bool {
         try await ensureConnection()
         for await result in Transaction.unfinished {
@@ -602,6 +667,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         return true
     }
 
+    /// Check whether a transaction's JWS verification passed.
+    /// See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
     public func isTransactionVerifiedIOS(sku: String) async throws -> Bool {
         try await ensureConnection()
         let product = try await storeProduct(for: sku)
@@ -614,6 +681,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         }
     }
 
+    /// Return the JWS string for a transaction.
+    /// See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
     public func getTransactionJwsIOS(sku: String) async throws -> String? {
         try await ensureConnection()
         let product = try await storeProduct(for: sku)
@@ -627,6 +696,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     // MARK: - Validation
 
+    /// Get base64 receipt data (legacy validation).
+    /// See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
     public func getReceiptDataIOS() async throws -> String? {
         guard let receiptURL = Bundle.main.appStoreReceiptURL,
               FileManager.default.fileExists(atPath: receiptURL.path) else {
@@ -636,6 +707,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         return data.base64EncodedString()
     }
 
+    /// Deprecated. Legacy App Store receipt validation. Use `verifyPurchase` instead.
+    /// See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
     @available(*, deprecated, message: "Use verifyPurchase")
     public func validateReceiptIOS(_ props: VerifyPurchaseProps) async throws -> VerifyPurchaseResultIOS {
         try await performVerifyPurchaseIOS(props)
@@ -675,17 +748,23 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         )
     }
 
+    /// Deprecated. Use verifyPurchase instead — same input/output shape.
+    /// See: https://www.openiap.dev/docs/apis/validate-receipt
     @available(*, deprecated, message: "Use verifyPurchase")
     public func validateReceipt(_ props: VerifyPurchaseProps) async throws -> VerifyPurchaseResult {
         try await verifyPurchase(props)
     }
 
+    /// Verify a purchase against your own backend (returns isValid + raw store metadata).
+    /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
     public func verifyPurchase(_ props: VerifyPurchaseProps) async throws -> VerifyPurchaseResult {
         try await ensureConnection()
         let iosResult = try await performVerifyPurchaseIOS(props)
         return .verifyPurchaseResultIos(iosResult)
     }
 
+    /// Verify via a managed provider (IAPKit, Apple, Google, Horizon).
+    /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
     public func verifyPurchaseWithProvider(_ props: VerifyPurchaseWithProviderProps) async throws -> VerifyPurchaseWithProviderResult {
         try await ensureConnection()
         guard props.provider == .iapkit else {
@@ -853,6 +932,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     // MARK: - Store Information
 
+    /// Deprecated. Use cross-platform `getStorefront` instead.
+    /// See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
     public func getStorefrontIOS() async throws -> String {
         try await ensureConnection()
         guard let storefront = await Storefront.current else {
@@ -866,6 +947,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
     /// Get the app transaction that represents the user's purchase of the app
     /// - Note: Available on iOS 16.0+, macOS 14.0+, tvOS 16.0+, watchOS 9.0+
     /// - SeeAlso: https://developer.apple.com/documentation/storekit/apptransaction
+    ///
+    /// See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
     @available(iOS 16.0, macOS 14.0, tvOS 16.0, watchOS 9.0, *)
     public func getAppTransactionIOS() async throws -> AppTransaction? {
         try await ensureConnection()
@@ -880,6 +963,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     // MARK: - Subscription Management
 
+    /// Get details of all currently active subscriptions.
+    /// See: https://www.openiap.dev/docs/apis/get-active-subscriptions
     public func getActiveSubscriptions(_ subscriptionIds: [String]?) async throws -> [ActiveSubscription] {
         try await ensureConnection()
         var allSubscriptions: [ActiveSubscription] = []
@@ -940,6 +1025,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         return allSubscriptions
     }
 
+    /// Check whether the user has any active subscription.
+    /// See: https://www.openiap.dev/docs/apis/has-active-subscriptions
     public func hasActiveSubscriptions(_ subscriptionIds: [String]?) async throws -> Bool {
         let subscriptions = try await getActiveSubscriptions(subscriptionIds)
         return subscriptions.contains { $0.isActive }
@@ -948,6 +1035,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
     /// Show the subscription management interface
     /// - Note: Available on iOS 15.0+, iPadOS 15.0+, Mac Catalyst 15.0+, macOS 14.0+, visionOS 1.0+. Not available on tvOS (subscriptions are managed in Settings > Accounts) or watchOS.
     /// - SeeAlso: https://developer.apple.com/documentation/storekit/appstore/showmanagesubscriptions(in:)
+    ///
+    /// See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
     public func deepLinkToSubscriptions(_ options: DeepLinkOptions?) async throws -> Void {
         try await ensureConnection()
         // tvOS: AppStore.showManageSubscriptions not available on tvOS (subscriptions managed in Settings > Accounts)
@@ -971,6 +1060,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         #endif // !os(tvOS) && !os(watchOS)
     }
 
+    /// Get subscription status objects from StoreKit 2.
+    /// See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
     public func subscriptionStatusIOS(sku: String) async throws -> [SubscriptionStatusIOS] {
         try await ensureConnection()
         let product = try await storeProduct(for: sku)
@@ -1007,6 +1098,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         }
     }
 
+    /// Get the user's current entitlement for a product.
+    /// See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
     public func currentEntitlementIOS(sku: String) async throws -> PurchaseIOS? {
         try await ensureConnection()
         let product = try await storeProduct(for: sku)
@@ -1021,6 +1114,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         }
     }
 
+    /// Get the latest verified transaction for a product.
+    /// See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
     public func latestTransactionIOS(sku: String) async throws -> PurchaseIOS? {
         try await ensureConnection()
         let product = try await storeProduct(for: sku)
@@ -1040,6 +1135,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
     /// Begin a refund request for a transaction
     /// - Note: Available on iOS 15.0+, iPadOS 15.0+, Mac Catalyst 15.0+, macOS 12.0+, visionOS 1.0+. Not available on tvOS or watchOS.
     /// - SeeAlso: https://developer.apple.com/documentation/storekit/transaction/3803220-beginrefundrequest
+    ///
+    /// See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
     public func beginRefundRequestIOS(sku: String) async throws -> String? {
         try await ensureConnection()
         // tvOS: Transaction.beginRefundRequest not available on tvOS
@@ -1086,6 +1183,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     /// Check if the user is eligible for an introductory offer for a subscription group
     /// - SeeAlso: https://developer.apple.com/documentation/storekit/product/subscriptioninfo/iseligibleforintrooffer(for:)
+    ///
+    /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
     public func isEligibleForIntroOfferIOS(groupID: String) async throws -> Bool {
         try await ensureConnection()
         return await StoreKit.Product.SubscriptionInfo.isEligibleForIntroOffer(for: groupID)
@@ -1093,6 +1192,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     /// Sync the user's in-app purchases with the App Store
     /// - SeeAlso: https://developer.apple.com/documentation/storekit/appstore/sync()
+    ///
+    /// See: https://www.openiap.dev/docs/apis/ios/sync-ios
     public func syncIOS() async throws -> Bool {
         try await ensureConnection()
         do {
@@ -1106,6 +1207,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
     /// Present a sheet for redeeming subscription offer codes
     /// - Note: Only available on iOS 14.0+ and Mac Catalyst. Not available on tvOS, macOS, or watchOS
     /// - SeeAlso: https://developer.apple.com/documentation/storekit/skpaymentqueue/3566726-presentcoderedemptionsheet
+    ///
+    /// See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
     public func presentCodeRedemptionSheetIOS() async throws -> Bool {
         try await ensureConnection()
         // presentCodeRedemptionSheet is only available on iOS, not tvOS/watchOS/macOS
@@ -1119,6 +1222,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         #endif // os(iOS)
     }
 
+    /// Present the manage-subscriptions sheet.
+    /// See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
     public func showManageSubscriptionsIOS() async throws -> [PurchaseIOS] {
         try await deepLinkToSubscriptions(nil)
         return []
@@ -1126,6 +1231,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     // MARK: - External Purchase (iOS 17.4+, macOS 14.4+, tvOS 17.4+, visionOS 1.1+)
 
+    /// Check eligibility for the external purchase notice sheet (iOS 17.4+).
+    /// See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
     public func canPresentExternalPurchaseNoticeIOS() async throws -> Bool {
         try await ensureConnection()
         // iOS 17.4+, macOS 14.4+, tvOS 17.4+, watchOS 10.4+, visionOS 1.1+: ExternalPurchase.canPresent
@@ -1137,6 +1244,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         }
     }
 
+    /// Present the external purchase notice sheet (iOS 17.4+).
+    /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
     public func presentExternalPurchaseNoticeSheetIOS() async throws -> ExternalPurchaseNoticeResultIOS {
         try await ensureConnection()
         // iOS 17.4+, macOS 14.4+, tvOS 17.4+, watchOS 10.4+, visionOS 1.1+: ExternalPurchase.presentNoticeSheet
@@ -1199,6 +1308,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         }
     }
 
+    /// Present an external purchase link, StoreKit External (iOS 16+).
+    /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
     public func presentExternalPurchaseLinkIOS(_ url: String) async throws -> ExternalPurchaseLinkResultIOS {
         try await ensureConnection()
         // UIApplication.open is available on iOS/tvOS/visionOS but not watchOS/macOS
@@ -1231,6 +1342,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     // MARK: - ExternalPurchaseCustomLink (iOS 18.1+)
 
+    /// Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
+    /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
     public func isEligibleForExternalPurchaseCustomLinkIOS() async throws -> Bool {
         try await ensureConnection()
         // iOS 18.1+: ExternalPurchaseCustomLink.isEligible
@@ -1242,6 +1355,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         }
     }
 
+    /// Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+    /// See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
     public func getExternalPurchaseCustomLinkTokenIOS(
         _ tokenType: ExternalPurchaseCustomLinkTokenTypeIOS
     ) async throws -> ExternalPurchaseCustomLinkTokenResultIOS {
@@ -1282,6 +1397,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         }
     }
 
+    /// Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
+    /// See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
     public func showExternalPurchaseCustomLinkNoticeIOS(
         _ noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS
     ) async throws -> ExternalPurchaseCustomLinkNoticeResultIOS {

--- a/packages/apple/Sources/OpenIapModule.swift
+++ b/packages/apple/Sources/OpenIapModule.swift
@@ -103,8 +103,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
     /// Retrieve products or subscriptions from the App Store by SKU.
     ///
     /// - Parameter params: `ProductRequest` with `skus` (the product identifiers) and an
-    ///   optional `type` (`.inApp`, `.subs`, or `.all`; defaults to `.all` when omitted —
-    ///   the implementation falls back to `params.type ?? .all`).
+    ///   optional `type` (`.inApp`, `.subs`, or `.all`; defaults to `.inApp` when omitted —
+    ///   matches the cross-platform Flutter / expo-iap / react-native-iap / godot SDKs).
     /// - Returns: A `FetchProductsResult` variant — `Product[]` for `.inApp`,
     ///   `ProductSubscription[]` for `.subs`, or a mixed list for `.all`.
     /// - Throws: When the store rejects the request (unknown SKU, network failure, not connected).
@@ -153,7 +153,7 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
             }
         }
 
-        switch params.type ?? .all {
+        switch params.type ?? .inApp {
         case .subs:
             // Return products that are subscriptions (both auto-renewable and non-renewing)
             // Auto-renewable subscriptions have product.subscription != nil and use subscriptionEntries

--- a/packages/apple/Sources/OpenIapModule.swift
+++ b/packages/apple/Sources/OpenIapModule.swift
@@ -103,7 +103,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
     /// Retrieve products or subscriptions from the App Store by SKU.
     ///
     /// - Parameter params: `ProductRequest` with `skus` (the product identifiers) and an
-    ///   optional `type` (`.inApp`, `.subs`, or `.all`; defaults to `.inApp`).
+    ///   optional `type` (`.inApp`, `.subs`, or `.all`; defaults to `.all` when omitted —
+    ///   the implementation falls back to `params.type ?? .all`).
     /// - Returns: A `FetchProductsResult` variant — `Product[]` for `.inApp`,
     ///   `ProductSubscription[]` for `.subs`, or a mixed list for `.all`.
     /// - Throws: When the store rejects the request (unknown SKU, network failure, not connected).
@@ -512,12 +513,15 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         _ = try await syncIOS()
     }
 
-    /// List the user's unfinished purchases. Use this to restore non-consumables / active
-    /// subscriptions, or to pick up transactions that weren't finished previously.
+    /// List the user's purchases held by StoreKit. By default reads `Transaction.all` (the
+    /// full history including refunded / revoked entries). Pass
+    /// `onlyIncludeActiveItemsIOS = true` to switch to `Transaction.currentEntitlements`,
+    /// which narrows the result to active non-consumables and live subscriptions.
     ///
-    /// - Parameter options: Optional iOS-specific flags
-    ///   (`alsoPublishToEventListenerIOS`, `onlyIncludeActiveItemsIOS`).
-    /// - Returns: An array of `Purchase` values currently held by StoreKit.
+    /// - Parameter options: Optional iOS-specific flags. `onlyIncludeActiveItemsIOS`
+    ///   toggles between `Transaction.all` (default) and `Transaction.currentEntitlements`.
+    ///   `alsoPublishToEventListenerIOS` re-emits each purchase on the update listener.
+    /// - Returns: An array of `Purchase` values matching the selected scope.
     /// - Throws: When the StoreKit query fails.
     ///
     /// See: https://www.openiap.dev/docs/apis/get-available-purchases
@@ -763,7 +767,7 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         return .verifyPurchaseResultIos(iosResult)
     }
 
-    /// Verify via a managed provider (IAPKit, Apple, Google, Horizon).
+    /// Verify via a managed provider (currently IAPKit; the PurchaseVerificationProvider enum exposes only Iapkit today).
     /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
     public func verifyPurchaseWithProvider(_ props: VerifyPurchaseWithProviderProps) async throws -> VerifyPurchaseWithProviderResult {
         try await ensureConnection()

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -36,6 +36,7 @@
     "@typescript-eslint/parser": "^8.39.1",
     "@vitejs/plugin-react": "^4.3.1",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
+    "baseline-browser-mapping": "^2.10.22",
     "eslint": "^9.21.0",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.7",

--- a/packages/docs/src/components/CodeBlock.tsx
+++ b/packages/docs/src/components/CodeBlock.tsx
@@ -113,6 +113,25 @@ function linkifyType(name: string): string {
   return `<span class="token class-name">${name}</span>`;
 }
 
+// Split an already-marked-up HTML string on `<...>` tag boundaries and
+// run the capitalized-identifier linkify pass ONLY on the text segments
+// in between. This avoids regex lookbehind (Safari < 16.4 doesn't
+// support it under Vite's default `target: 'modules'`) and stops
+// keywords already wrapped by upstream passes — Dart `Future`,
+// GDScript `String`, etc. — from being re-wrapped as class-name and
+// clobbering their original token color.
+function linkifyTypesInTextSegments(html: string): string {
+  return html
+    .split(/(<[^>]+>)/)
+    .map((segment) => {
+      if (segment.startsWith('<')) return segment;
+      return segment.replace(/\b([A-Z][a-zA-Z0-9_]*)\b/g, (_, name: string) =>
+        linkifyType(name)
+      );
+    })
+    .join('');
+}
+
 function CodeBlock({ children, language = 'graphql' }: CodeBlockProps) {
   const codeRef = useRef<HTMLElement>(null);
   const [copied, setCopied] = useState(false);
@@ -272,16 +291,7 @@ function highlightCode(element: HTMLElement, language: string) {
           // Capitalized identifiers → linkify known OpenIAP types (so e.g.
           // `ProductRequest`, `Purchase[]`, `Promise<FetchProductsResult>` in
           // a TS signature jump to /docs/types/...).
-          // The negative lookbehind `(?<![">])` skips capitals that sit
-          // immediately after an HTML attribute quote or a closing `>` —
-          // i.e. text already wrapped by the keyword / function passes
-          // above. Without it we'd nest tags (e.g. wrap `Future` inside
-          // `<span class="token keyword">Future</span>`) and clobber the
-          // upstream token color.
-          processed = processed.replace(
-            /(?<![">])\b([A-Z][a-zA-Z0-9_]*)\b/g,
-            (_, name: string) => linkifyType(name)
-          );
+          processed = linkifyTypesInTextSegments(processed);
 
           result += processed;
         }
@@ -385,15 +395,7 @@ function highlightCode(element: HTMLElement, language: string) {
           // Types (capitalized words). Known OpenIAP type names render as
           // anchors to /docs/types/...; unknown ones stay as plain class-name
           // spans so styling is identical.
-          // Negative lookbehind `(?<![">])` skips capitals already inside
-          // tags emitted by the keyword/function/decorator passes above —
-          // languages like Dart treat `Future`/`Function` and GDScript treats
-          // `String`/`Array` as keywords, so the bare `\b[A-Z]...\b` pattern
-          // would re-wrap them and override the upstream token color.
-          processed = processed.replace(
-            /(?<![">])\b([A-Z][a-zA-Z0-9_]*)\b/g,
-            (_, name: string) => linkifyType(name)
-          );
+          processed = linkifyTypesInTextSegments(processed);
 
           // Annotations/Attributes
           processed = processed.replace(

--- a/packages/docs/src/components/CodeBlock.tsx
+++ b/packages/docs/src/components/CodeBlock.tsx
@@ -272,8 +272,14 @@ function highlightCode(element: HTMLElement, language: string) {
           // Capitalized identifiers → linkify known OpenIAP types (so e.g.
           // `ProductRequest`, `Purchase[]`, `Promise<FetchProductsResult>` in
           // a TS signature jump to /docs/types/...).
+          // The negative lookbehind `(?<![">])` skips capitals that sit
+          // immediately after an HTML attribute quote or a closing `>` —
+          // i.e. text already wrapped by the keyword / function passes
+          // above. Without it we'd nest tags (e.g. wrap `Future` inside
+          // `<span class="token keyword">Future</span>`) and clobber the
+          // upstream token color.
           processed = processed.replace(
-            /\b([A-Z][a-zA-Z0-9_]*)\b/g,
+            /(?<![">])\b([A-Z][a-zA-Z0-9_]*)\b/g,
             (_, name: string) => linkifyType(name)
           );
 
@@ -379,8 +385,13 @@ function highlightCode(element: HTMLElement, language: string) {
           // Types (capitalized words). Known OpenIAP type names render as
           // anchors to /docs/types/...; unknown ones stay as plain class-name
           // spans so styling is identical.
+          // Negative lookbehind `(?<![">])` skips capitals already inside
+          // tags emitted by the keyword/function/decorator passes above —
+          // languages like Dart treat `Future`/`Function` and GDScript treats
+          // `String`/`Array` as keywords, so the bare `\b[A-Z]...\b` pattern
+          // would re-wrap them and override the upstream token color.
           processed = processed.replace(
-            /\b([A-Z][a-zA-Z0-9_]*)\b/g,
+            /(?<![">])\b([A-Z][a-zA-Z0-9_]*)\b/g,
             (_, name: string) => linkifyType(name)
           );
 

--- a/packages/docs/src/components/CodeBlock.tsx
+++ b/packages/docs/src/components/CodeBlock.tsx
@@ -20,6 +20,99 @@ interface CodeBlockProps {
     | 'properties';
 }
 
+// Identifier → Type doc page slug. Used by `linkifyType` so capitalized
+// identifiers (Swift/Kotlin/Dart/GDScript class-name tokens, TypeScript
+// type references) render as clickable anchors that jump to the matching
+// `/docs/types/...` page. Add new entries here when a new type page ships.
+const TYPE_LINKS: Record<string, string> = {
+  // Cross-platform
+  ActiveSubscription: '/docs/types/active-subscription',
+  AlternativeBillingModeAndroid: '/docs/types/alternative-billing-types',
+  AlternativeBillingTypes: '/docs/types/alternative-billing-types',
+  BillingProgramAndroid: '/docs/types/billing-programs',
+  BillingProgramAvailabilityResultAndroid: '/docs/types/billing-programs',
+  BillingProgramReportingDetailsAndroid: '/docs/types/billing-programs',
+  DeepLinkOptions: '/docs/types#common',
+  DiscountOffer: '/docs/types/discount-offer',
+  ExternalPurchaseLinkResultIOS: '/docs/types/external-purchase-link',
+  ExternalPurchaseNoticeResultIOS: '/docs/types/external-purchase-link',
+  ExternalPurchaseCustomLinkNoticeResultIOS:
+    '/docs/types/external-purchase-link',
+  ExternalPurchaseCustomLinkTokenResultIOS:
+    '/docs/types/external-purchase-link',
+  ExternalPurchaseCustomLinkNoticeTypeIOS: '/docs/types/external-purchase-link',
+  ExternalPurchaseCustomLinkTokenTypeIOS: '/docs/types/external-purchase-link',
+  FetchProductsResult: '/docs/types/product-request',
+  InitConnectionConfig:
+    '/docs/types/alternative-billing-types#init-connection-config',
+  LaunchExternalLinkParamsAndroid: '/docs/types/billing-programs',
+  Product: '/docs/types/product',
+  ProductAndroid: '/docs/types/product',
+  ProductIOS: '/docs/types/product',
+  ProductOrSubscription: '/docs/types/product',
+  ProductQueryType: '/docs/types/product-request',
+  ProductRequest: '/docs/types/product-request',
+  ProductSubscription: '/docs/types/subscription-product',
+  ProductSubscriptionAndroid: '/docs/types/subscription-product',
+  ProductSubscriptionIOS: '/docs/types/subscription-product',
+  Purchase: '/docs/types/purchase',
+  PurchaseAndroid: '/docs/types/purchase',
+  PurchaseIOS: '/docs/types/purchase',
+  PurchaseInput: '/docs/types/purchase',
+  PurchaseOptions: '/docs/types/purchase',
+  PurchaseVerificationProvider:
+    '/docs/types/verify-purchase-with-provider-props',
+  RequestPurchaseAndroidProps: '/docs/types/request-purchase-props',
+  RequestPurchaseIosProps: '/docs/types/request-purchase-props',
+  RequestPurchaseProps: '/docs/types/request-purchase-props',
+  RequestPurchasePropsByPlatforms: '/docs/types/request-purchase-props',
+  RequestPurchaseResult: '/docs/types/request-purchase-props',
+  RequestSubscriptionPropsByPlatforms: '/docs/types/request-purchase-props',
+  Storefront: '/docs/types/storefront',
+  SubscriptionOffer: '/docs/types/subscription-offer',
+  SubscriptionProduct: '/docs/types/subscription-product',
+  VerifyPurchase: '/docs/types/verify-purchase',
+  VerifyPurchaseProps: '/docs/types/verify-purchase',
+  VerifyPurchaseResult: '/docs/types/verify-purchase',
+  VerifyPurchaseResultAndroid: '/docs/types/verify-purchase',
+  VerifyPurchaseResultHorizon: '/docs/types/verify-purchase',
+  VerifyPurchaseResultIOS: '/docs/types/verify-purchase',
+  VerifyPurchaseWithProviderProps:
+    '/docs/types/verify-purchase-with-provider-props',
+  VerifyPurchaseWithProviderResult:
+    '/docs/types/verify-purchase-with-provider-result',
+  VoidResult: '/docs/types#common',
+  // iOS-only
+  AppTransaction: '/docs/types/ios/app-transaction-ios',
+  AppTransactionIOS: '/docs/types/ios/app-transaction-ios',
+  Discount: '/docs/types/ios/discount-ios',
+  DiscountIOS: '/docs/types/ios/discount-ios',
+  DiscountOfferIOS: '/docs/types/ios/discount-offer-ios',
+  PaymentMode: '/docs/types/ios/payment-mode-ios',
+  PaymentModeIOS: '/docs/types/ios/payment-mode-ios',
+  RenewalInfo: '/docs/types/ios/renewal-info-ios',
+  RenewalInfoIOS: '/docs/types/ios/renewal-info-ios',
+  SubscriptionPeriod: '/docs/types/ios/subscription-period-ios',
+  SubscriptionPeriodIOS: '/docs/types/ios/subscription-period-ios',
+  SubscriptionStatus: '/docs/types/ios/subscription-status-ios',
+  SubscriptionStatusIOS: '/docs/types/ios/subscription-status-ios',
+  // Android-only
+  OneTimePurchaseOfferDetailAndroid:
+    '/docs/types/android/one-time-purchase-offer-detail-android',
+  PricingPhaseAndroid: '/docs/types/android/pricing-phase-android',
+  SubscriptionOfferAndroid: '/docs/types/android/subscription-offer-android',
+};
+
+// Wraps a class-name token in an anchor when it matches a known type.
+// Caller is responsible for HTML-escaping the input.
+function linkifyType(name: string): string {
+  const href = TYPE_LINKS[name];
+  if (href) {
+    return `<a class="token class-name type-ref" href="${href}">${name}</a>`;
+  }
+  return `<span class="token class-name">${name}</span>`;
+}
+
 function CodeBlock({ children, language = 'graphql' }: CodeBlockProps) {
   const codeRef = useRef<HTMLElement>(null);
   const [copied, setCopied] = useState(false);
@@ -176,6 +269,14 @@ function highlightCode(element: HTMLElement, language: string) {
             '<span class="token function">$1</span>'
           );
 
+          // Capitalized identifiers → linkify known OpenIAP types (so e.g.
+          // `ProductRequest`, `Purchase[]`, `Promise<FetchProductsResult>` in
+          // a TS signature jump to /docs/types/...).
+          processed = processed.replace(
+            /\b([A-Z][a-zA-Z0-9_]*)\b/g,
+            (_, name: string) => linkifyType(name)
+          );
+
           result += processed;
         }
       });
@@ -275,10 +376,12 @@ function highlightCode(element: HTMLElement, language: string) {
             '<span class="token function">$1</span>'
           );
 
-          // Types (capitalized words not after a dot)
+          // Types (capitalized words). Known OpenIAP type names render as
+          // anchors to /docs/types/...; unknown ones stay as plain class-name
+          // spans so styling is identical.
           processed = processed.replace(
             /\b([A-Z][a-zA-Z0-9_]*)\b/g,
-            '<span class="token class-name">$1</span>'
+            (_, name: string) => linkifyType(name)
           );
 
           // Annotations/Attributes

--- a/packages/docs/src/components/CodeBlock.tsx
+++ b/packages/docs/src/components/CodeBlock.tsx
@@ -114,17 +114,27 @@ function linkifyType(name: string): string {
 }
 
 // Split an already-marked-up HTML string on `<...>` tag boundaries and
-// run the capitalized-identifier linkify pass ONLY on the text segments
-// in between. This avoids regex lookbehind (Safari < 16.4 doesn't
-// support it under Vite's default `target: 'modules'`) and stops
-// keywords already wrapped by upstream passes — Dart `Future`,
-// GDScript `String`, etc. — from being re-wrapped as class-name and
-// clobbering their original token color.
+// run the capitalized-identifier linkify pass ONLY on text segments
+// that sit OUTSIDE every existing tag. Tracks a tag-depth counter so
+// text content INSIDE a `<span class="token …">…</span>` emitted by an
+// upstream pass (Dart `Future`/`Function`, GDScript `String`/`Array`,
+// already-wrapped function names, …) is skipped — without the depth
+// check we'd nest a class-name span inside the keyword span and clobber
+// its color. Avoids regex lookbehind (Safari < 16.4 doesn't support it
+// under Vite's default `target: 'modules'`).
 function linkifyTypesInTextSegments(html: string): string {
+  let depth = 0;
   return html
     .split(/(<[^>]+>)/)
     .map((segment) => {
-      if (segment.startsWith('<')) return segment;
+      if (segment.startsWith('<')) {
+        // Self-closing `<br/>` etc. don't change depth.
+        if (segment.endsWith('/>')) return segment;
+        if (segment.startsWith('</')) depth = Math.max(0, depth - 1);
+        else depth += 1;
+        return segment;
+      }
+      if (depth > 0) return segment;
       return segment.replace(/\b([A-Z][a-zA-Z0-9_]*)\b/g, (_, name: string) =>
         linkifyType(name)
       );

--- a/packages/docs/src/components/Navigation.tsx
+++ b/packages/docs/src/components/Navigation.tsx
@@ -9,24 +9,22 @@ import { IAPKIT_URL, LOGO_PATH, trackIapKitClick } from '../lib/config';
 function Navigation() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const location = useLocation();
-  // Docs pages have their own sticky "Menu" toggle for the docs sidebar.
-  // The top nav's mobile hamburger ☰ sits in the same vertical area on
-  // mobile and was visually-and-tap competing with that toggle — users
-  // reported tapping the docs Menu button but having the top nav menu
-  // open instead. Hide the top hamburger on docs routes so the docs
-  // sidebar toggle is the only "open menu" affordance there.
-  const isDocsRoute = location.pathname.startsWith('/docs');
 
   const closeMobileMenu = () => {
     setIsMobileMenuOpen(false);
   };
 
-  // Force-close the top nav menu whenever the user navigates onto a
-  // docs route (covers the "I had the top menu open, then tapped a
-  // docs link" path).
+  // Auto-close the top nav menu on route change so a stale dropdown doesn't
+  // sit open over the new page (especially relevant when crossing into /docs
+  // where the docs sidebar takes over as the primary navigation surface).
+  // The top-nav hamburger stays mounted on every route — Introduction /
+  // Languages / Tutorials / Sponsors must remain reachable on mobile from
+  // /docs too, and the closed docs sidebar already uses
+  // `pointer-events: none` + `translateX(-100%)` so the two menus don't
+  // compete for taps.
   useEffect(() => {
-    if (isDocsRoute) setIsMobileMenuOpen(false);
-  }, [isDocsRoute]);
+    setIsMobileMenuOpen(false);
+  }, [location.pathname]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -133,90 +131,85 @@ function Navigation() {
             <FaGithub size={20} />
           </a>
 
-          {/* Mobile Menu Button — hidden on /docs routes so it can't
-              compete with the docs sidebar's own Menu toggle. */}
-          {!isDocsRoute && (
-            <button
-              className="mobile-menu-button"
-              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              aria-label="Toggle mobile menu"
-            >
-              {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
-            </button>
-          )}
+          {/* Mobile Menu Button — visible on every route. Top-level pages
+              (Introduction / Languages / Tutorials / Sponsors) must remain
+              reachable on mobile, including from /docs. */}
+          <button
+            className="mobile-menu-button"
+            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+            aria-label="Toggle mobile menu"
+          >
+            {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+          </button>
         </div>
 
-        {/* Mobile Menu Dropdown — also hidden on /docs to remove its
-            invisible-but-present 0-height absolute box from the DOM. */}
-        {!isDocsRoute && (
-          <div className={`mobile-menu ${isMobileMenuOpen ? 'open' : ''}`}>
-            <ul className="mobile-nav-list">
-              <li>
-                <NavLink
-                  to="/introduction"
-                  className={({ isActive }) => (isActive ? 'active' : '')}
-                  onClick={closeMobileMenu}
-                >
-                  Introduction
-                </NavLink>
-              </li>
+        <div className={`mobile-menu ${isMobileMenuOpen ? 'open' : ''}`}>
+          <ul className="mobile-nav-list">
+            <li>
+              <NavLink
+                to="/introduction"
+                className={({ isActive }) => (isActive ? 'active' : '')}
+                onClick={closeMobileMenu}
+              >
+                Introduction
+              </NavLink>
+            </li>
 
-              <li>
-                <NavLink
-                  to="/docs"
-                  className={({ isActive }) => (isActive ? 'active' : '')}
-                  onClick={closeMobileMenu}
-                >
-                  Docs
-                </NavLink>
-              </li>
+            <li>
+              <NavLink
+                to="/docs"
+                className={({ isActive }) => (isActive ? 'active' : '')}
+                onClick={closeMobileMenu}
+              >
+                Docs
+              </NavLink>
+            </li>
 
-              <li>
-                <NavLink
-                  to="/languages"
-                  className={({ isActive }) => (isActive ? 'active' : '')}
-                  onClick={closeMobileMenu}
-                >
-                  Languages
-                </NavLink>
-              </li>
+            <li>
+              <NavLink
+                to="/languages"
+                className={({ isActive }) => (isActive ? 'active' : '')}
+                onClick={closeMobileMenu}
+              >
+                Languages
+              </NavLink>
+            </li>
 
-              <li>
-                <NavLink
-                  to="/tutorials"
-                  className={({ isActive }) => (isActive ? 'active' : '')}
-                  onClick={closeMobileMenu}
-                >
-                  Tutorials
-                </NavLink>
-              </li>
+            <li>
+              <NavLink
+                to="/tutorials"
+                className={({ isActive }) => (isActive ? 'active' : '')}
+                onClick={closeMobileMenu}
+              >
+                Tutorials
+              </NavLink>
+            </li>
 
-              <li>
-                <NavLink
-                  to="/sponsors"
-                  className={({ isActive }) => (isActive ? 'active' : '')}
-                  onClick={closeMobileMenu}
-                >
-                  Sponsors
-                </NavLink>
-              </li>
+            <li>
+              <NavLink
+                to="/sponsors"
+                className={({ isActive }) => (isActive ? 'active' : '')}
+                onClick={closeMobileMenu}
+              >
+                Sponsors
+              </NavLink>
+            </li>
 
-              <li>
-                <a
-                  href={IAPKIT_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={() => {
-                    trackIapKitClick();
-                    closeMobileMenu();
-                  }}
-                >
-                  IAPKit
-                </a>
-              </li>
-            </ul>
-          </div>
-        )}
+            <li>
+              <a
+                href={IAPKIT_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => {
+                  trackIapKitClick();
+                  closeMobileMenu();
+                }}
+              >
+                IAPKit
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </nav>
   );

--- a/packages/docs/src/components/Navigation.tsx
+++ b/packages/docs/src/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink } from 'react-router-dom';
+import { Link, NavLink, useLocation } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { DarkModeToggle } from './DarkModeToggle';
 import { Menu, X } from 'lucide-react';
@@ -8,10 +8,25 @@ import { IAPKIT_URL, LOGO_PATH, trackIapKitClick } from '../lib/config';
 
 function Navigation() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const location = useLocation();
+  // Docs pages have their own sticky "Menu" toggle for the docs sidebar.
+  // The top nav's mobile hamburger ☰ sits in the same vertical area on
+  // mobile and was visually-and-tap competing with that toggle — users
+  // reported tapping the docs Menu button but having the top nav menu
+  // open instead. Hide the top hamburger on docs routes so the docs
+  // sidebar toggle is the only "open menu" affordance there.
+  const isDocsRoute = location.pathname.startsWith('/docs');
 
   const closeMobileMenu = () => {
     setIsMobileMenuOpen(false);
   };
+
+  // Force-close the top nav menu whenever the user navigates onto a
+  // docs route (covers the "I had the top menu open, then tapped a
+  // docs link" path).
+  useEffect(() => {
+    if (isDocsRoute) setIsMobileMenuOpen(false);
+  }, [isDocsRoute]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -118,84 +133,90 @@ function Navigation() {
             <FaGithub size={20} />
           </a>
 
-          {/* Mobile Menu Button */}
-          <button
-            className="mobile-menu-button"
-            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-            aria-label="Toggle mobile menu"
-          >
-            {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
-          </button>
+          {/* Mobile Menu Button — hidden on /docs routes so it can't
+              compete with the docs sidebar's own Menu toggle. */}
+          {!isDocsRoute && (
+            <button
+              className="mobile-menu-button"
+              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+              aria-label="Toggle mobile menu"
+            >
+              {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+            </button>
+          )}
         </div>
 
-        {/* Mobile Menu Dropdown */}
-        <div className={`mobile-menu ${isMobileMenuOpen ? 'open' : ''}`}>
-          <ul className="mobile-nav-list">
-            <li>
-              <NavLink
-                to="/introduction"
-                className={({ isActive }) => (isActive ? 'active' : '')}
-                onClick={closeMobileMenu}
-              >
-                Introduction
-              </NavLink>
-            </li>
+        {/* Mobile Menu Dropdown — also hidden on /docs to remove its
+            invisible-but-present 0-height absolute box from the DOM. */}
+        {!isDocsRoute && (
+          <div className={`mobile-menu ${isMobileMenuOpen ? 'open' : ''}`}>
+            <ul className="mobile-nav-list">
+              <li>
+                <NavLink
+                  to="/introduction"
+                  className={({ isActive }) => (isActive ? 'active' : '')}
+                  onClick={closeMobileMenu}
+                >
+                  Introduction
+                </NavLink>
+              </li>
 
-            <li>
-              <NavLink
-                to="/docs"
-                className={({ isActive }) => (isActive ? 'active' : '')}
-                onClick={closeMobileMenu}
-              >
-                Docs
-              </NavLink>
-            </li>
+              <li>
+                <NavLink
+                  to="/docs"
+                  className={({ isActive }) => (isActive ? 'active' : '')}
+                  onClick={closeMobileMenu}
+                >
+                  Docs
+                </NavLink>
+              </li>
 
-            <li>
-              <NavLink
-                to="/languages"
-                className={({ isActive }) => (isActive ? 'active' : '')}
-                onClick={closeMobileMenu}
-              >
-                Languages
-              </NavLink>
-            </li>
+              <li>
+                <NavLink
+                  to="/languages"
+                  className={({ isActive }) => (isActive ? 'active' : '')}
+                  onClick={closeMobileMenu}
+                >
+                  Languages
+                </NavLink>
+              </li>
 
-            <li>
-              <NavLink
-                to="/tutorials"
-                className={({ isActive }) => (isActive ? 'active' : '')}
-                onClick={closeMobileMenu}
-              >
-                Tutorials
-              </NavLink>
-            </li>
+              <li>
+                <NavLink
+                  to="/tutorials"
+                  className={({ isActive }) => (isActive ? 'active' : '')}
+                  onClick={closeMobileMenu}
+                >
+                  Tutorials
+                </NavLink>
+              </li>
 
-            <li>
-              <NavLink
-                to="/sponsors"
-                className={({ isActive }) => (isActive ? 'active' : '')}
-                onClick={closeMobileMenu}
-              >
-                Sponsors
-              </NavLink>
-            </li>
+              <li>
+                <NavLink
+                  to="/sponsors"
+                  className={({ isActive }) => (isActive ? 'active' : '')}
+                  onClick={closeMobileMenu}
+                >
+                  Sponsors
+                </NavLink>
+              </li>
 
-            <li>
-              <a
-                href={IAPKIT_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => {
-                  trackIapKitClick();
-                  closeMobileMenu();
-                }}
-              >
-                IAPKit
-              </a>
-            </li>
-          </ul>
-        </div>
+              <li>
+                <a
+                  href={IAPKIT_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => {
+                    trackIapKitClick();
+                    closeMobileMenu();
+                  }}
+                >
+                  IAPKit
+                </a>
+              </li>
+            </ul>
+          </div>
+        )}
       </div>
     </nav>
   );

--- a/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
@@ -23,6 +23,19 @@ function AcknowledgePurchaseAndroid() {
         Acknowledge a non-consumable purchase or subscription. Required within 3
         days or the purchase will be refunded.
       </p>
+      <p>
+        Wraps <code>BillingClient.acknowledgePurchase(AcknowledgePurchaseParams)</code>{' '}
+        — required for non-consumables and subscriptions within 3 days, otherwise
+        Google auto-refunds. See the{' '}
+        <a
+          href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#acknowledgePurchase(com.android.billingclient.api.AcknowledgePurchaseParams,com.android.billingclient.api.AcknowledgePurchaseResponseListener)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Play Billing reference
+        </a>
+        .
+      </p>
 
       <div className="alert-card alert-card--warning">
         <p>

--- a/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -38,6 +39,40 @@ function AcknowledgePurchaseAndroid() {
           Google Play Billing reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>purchaseToken</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Yes</td>
+            <td>Purchase token from the Play Billing transaction.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the
+        purchase has been acknowledged.
       </p>
 
       <div className="alert-card alert-card--warning">

--- a/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
@@ -44,28 +44,15 @@ function AcknowledgePurchaseAndroid() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>purchaseToken</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Yes</td>
-            <td>Purchase token from the Play Billing transaction.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>purchaseToken</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Purchase token from the Play Billing transaction.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
@@ -91,20 +91,52 @@ function AcknowledgePurchaseAndroid() {
       <h2>Signature</h2>
       <LanguageTabs>
         {{
-          typescript: (
-            <CodeBlock language="typescript">{`acknowledgePurchaseAndroid(purchaseToken: string): Promise<boolean>`}</CodeBlock>
-          ),
           kotlin: (
             <CodeBlock language="kotlin">{`suspend fun acknowledgePurchase(purchaseToken: String): Boolean`}</CodeBlock>
           ),
           kmp: (
             <CodeBlock language="kotlin">{`suspend fun acknowledgePurchaseAndroid(purchaseToken: String): Boolean`}</CodeBlock>
           ),
+          typescript: (
+            <CodeBlock language="typescript">{`acknowledgePurchaseAndroid(purchaseToken: string): Promise<boolean>`}</CodeBlock>
+          ),
           dart: (
             <CodeBlock language="dart">{`Future<bool> acknowledgePurchaseAndroid(String purchaseToken);`}</CodeBlock>
           ),
           gdscript: (
             <CodeBlock language="gdscript">{`func acknowledge_purchase_android(purchase_token: String) -> bool`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`openIapStore.acknowledgePurchase(purchase.purchaseToken)`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`// kmp-iap (Android targets only — no-op on iOS)
+kmpIAP.acknowledgePurchaseAndroid(purchase.purchaseToken)`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { acknowledgePurchaseAndroid } from 'expo-iap';
+
+if (Platform.OS === 'android') {
+  await acknowledgePurchaseAndroid(purchase.purchaseToken);
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isAndroid) {
+  await FlutterInappPurchase.instance.acknowledgePurchaseAndroid(
+    purchase.purchaseToken,
+  );
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
+    await iap.acknowledge_purchase_android(purchase.purchase_token)`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
@@ -24,9 +24,12 @@ function AcknowledgePurchaseAndroid() {
         days or the purchase will be refunded.
       </p>
       <p>
-        Wraps <code>BillingClient.acknowledgePurchase(AcknowledgePurchaseParams)</code>{' '}
-        — required for non-consumables and subscriptions within 3 days, otherwise
-        Google auto-refunds. See the{' '}
+        Wraps{' '}
+        <code>
+          BillingClient.acknowledgePurchase(AcknowledgePurchaseParams)
+        </code>{' '}
+        — required for non-consumables and subscriptions within 3 days,
+        otherwise Google auto-refunds. See the{' '}
         <a
           href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#acknowledgePurchase(com.android.billingclient.api.AcknowledgePurchaseParams,com.android.billingclient.api.AcknowledgePurchaseResponseListener)"
           target="_blank"

--- a/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
@@ -41,27 +41,6 @@ function AcknowledgePurchaseAndroid() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <ul className="api-params">
-        <li>
-          <code>purchaseToken</code>{' '}
-          <em>
-            (required, <code>string</code>)
-          </em>{' '}
-          — Purchase token from the Play Billing transaction.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the
-        purchase has been acknowledged.
-      </p>
-
       <div className="alert-card alert-card--warning">
         <p>
           ⚠️ <strong>Deprecated in Google Play Billing Library 8.2.0+.</strong>{' '}
@@ -95,6 +74,27 @@ function AcknowledgePurchaseAndroid() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <ul className="api-params">
+        <li>
+          <code>purchaseToken</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Purchase token from the Play Billing transaction.
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the
+        purchase has been acknowledged.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
@@ -23,8 +23,9 @@ function CheckAlternativeBillingAvailabilityAndroid() {
         available for this user/device.
       </p>
       <p>
-        Wraps <code>BillingClient.isAlternativeBillingOnlyAvailableAsync()</code>{' '}
-        — step 1 of the alternative billing flow. Returns whether the user/device
+        Wraps{' '}
+        <code>BillingClient.isAlternativeBillingOnlyAvailableAsync()</code> —
+        step 1 of the alternative billing flow. Returns whether the user/device
         is eligible. See the{' '}
         <a
           href="https://developer.android.com/google/play/billing/alternative"

--- a/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
@@ -38,14 +38,6 @@ function CheckAlternativeBillingAvailabilityAndroid() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — Whether alternative billing is
-        available for this user/device (step 1 of 3).
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -68,6 +60,14 @@ suspend fun checkAlternativeBillingAvailability(): Boolean`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — Whether alternative billing is
+        available for this user/device (step 1 of 3).
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
@@ -59,6 +59,49 @@ function CheckAlternativeBillingAvailabilityAndroid() {
 // Throws OpenIapError.NotPrepared if billing client not ready
 suspend fun checkAlternativeBillingAvailability(): Boolean`}</CodeBlock>
           ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun checkAlternativeBillingAvailabilityAndroid(): Boolean`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`checkAlternativeBillingAvailabilityAndroid(): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> checkAlternativeBillingAvailabilityAndroid();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func check_alternative_billing_availability_android() -> bool`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`val ok = openIapStore.checkAlternativeBillingAvailability()`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`// kmp-iap (Android targets only — no-op on iOS)
+val ok = kmpIAP.checkAlternativeBillingAvailabilityAndroid()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { checkAlternativeBillingAvailabilityAndroid } from 'expo-iap';
+
+if (Platform.OS === 'android') {
+  const ok = await checkAlternativeBillingAvailabilityAndroid();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isAndroid) {
+  final ok = await FlutterInappPurchase.instance
+      .checkAlternativeBillingAvailabilityAndroid();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
+    var ok: bool = await iap.check_alternative_billing_availability_android()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -35,6 +36,19 @@ function CheckAlternativeBillingAvailabilityAndroid() {
           Google Play Billing reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — Whether alternative billing is
+        available for this user/device (step 1 of 3).
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
@@ -22,6 +22,19 @@ function CheckAlternativeBillingAvailabilityAndroid() {
         Step 1 of alternative billing flow. Check if alternative billing is
         available for this user/device.
       </p>
+      <p>
+        Wraps <code>BillingClient.isAlternativeBillingOnlyAvailableAsync()</code>{' '}
+        — step 1 of the alternative billing flow. Returns whether the user/device
+        is eligible. See the{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/alternative"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Play Billing reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/check-alternative-billing-availability-android.tsx
@@ -38,11 +38,6 @@ function CheckAlternativeBillingAvailabilityAndroid() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -35,6 +36,40 @@ function ConsumePurchaseAndroid() {
           Google Play Billing reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>purchaseToken</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Yes</td>
+            <td>Purchase token from the Play Billing transaction.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the
+        purchase has been consumed.
       </p>
 
       <div className="alert-card alert-card--warning">

--- a/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
@@ -23,6 +23,19 @@ function ConsumePurchaseAndroid() {
         Consume a consumable purchase, allowing repurchase. Automatically
         acknowledges the purchase.
       </p>
+      <p>
+        Wraps <code>BillingClient.consumeAsync(ConsumeParams)</code> — for
+        consumables (re-buyable like coins). Same 3-day deadline as acknowledge.
+        See the{' '}
+        <a
+          href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#consumeAsync(com.android.billingclient.api.ConsumeParams,com.android.billingclient.api.ConsumeResponseListener)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Play Billing reference
+        </a>
+        .
+      </p>
 
       <div className="alert-card alert-card--warning">
         <p>

--- a/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
@@ -91,6 +91,50 @@ function ConsumePurchaseAndroid() {
           kotlin: (
             <CodeBlock language="kotlin">{`suspend fun consumePurchase(purchaseToken: String): Boolean`}</CodeBlock>
           ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun consumePurchaseAndroid(purchaseToken: String): Boolean`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`consumePurchaseAndroid(purchaseToken: string): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> consumePurchaseAndroid(String purchaseToken);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func consume_purchase_android(purchase_token: String) -> bool`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`openIapStore.consumePurchase(purchase.purchaseToken)`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`// kmp-iap (Android targets only — no-op on iOS)
+kmpIAP.consumePurchaseAndroid(purchase.purchaseToken)`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { consumePurchaseAndroid } from 'expo-iap';
+
+if (Platform.OS === 'android') {
+  await consumePurchaseAndroid(purchase.purchaseToken);
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isAndroid) {
+  await FlutterInappPurchase.instance.consumePurchaseAndroid(
+    purchase.purchaseToken,
+  );
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
+    await iap.consume_purchase_android(purchase.purchase_token)`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
 

--- a/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
@@ -41,28 +41,15 @@ function ConsumePurchaseAndroid() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>purchaseToken</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Yes</td>
-            <td>Purchase token from the Play Billing transaction.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>purchaseToken</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Purchase token from the Play Billing transaction.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
@@ -38,27 +38,6 @@ function ConsumePurchaseAndroid() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <ul className="api-params">
-        <li>
-          <code>purchaseToken</code>{' '}
-          <em>
-            (required, <code>string</code>)
-          </em>{' '}
-          — Purchase token from the Play Billing transaction.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the
-        purchase has been consumed.
-      </p>
-
       <div className="alert-card alert-card--warning">
         <p>
           ⚠️ <strong>Deprecated in Google Play Billing Library 8.2.0+.</strong>{' '}
@@ -92,6 +71,27 @@ function ConsumePurchaseAndroid() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <ul className="api-params">
+        <li>
+          <code>purchaseToken</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Purchase token from the Play Billing transaction.
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the
+        purchase has been consumed.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/create-alternative-billing-token-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-alternative-billing-token-android.tsx
@@ -40,15 +40,6 @@ function CreateAlternativeBillingTokenAndroid() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;string | null&gt;</code> — Reporting token to send to
-        Google within 24h, or <code>null</code> if creation failed (step 3 of
-        3).
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -71,6 +62,15 @@ suspend fun createAlternativeBillingToken(): String?`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string | null&gt;</code> — Reporting token to send to
+        Google within 24h, or <code>null</code> if creation failed (step 3 of
+        3).
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/create-alternative-billing-token-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-alternative-billing-token-android.tsx
@@ -40,11 +40,6 @@ function CreateAlternativeBillingTokenAndroid() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/android/create-alternative-billing-token-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-alternative-billing-token-android.tsx
@@ -22,6 +22,22 @@ function CreateAlternativeBillingTokenAndroid() {
         Step 3 of alternative billing flow. Create external transaction token
         for Google Play reporting.
       </p>
+      <p>
+        Wraps{' '}
+        <code>
+          BillingClient.createAlternativeBillingOnlyReportingDetailsAsync()
+        </code>{' '}
+        — step 3. Token must be reported to Google within 24h of payment. See
+        the{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/alternative"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Play Billing reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/create-alternative-billing-token-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-alternative-billing-token-android.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -37,6 +38,20 @@ function CreateAlternativeBillingTokenAndroid() {
           Google Play Billing reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string | null&gt;</code> — Reporting token to send to
+        Google within 24h, or <code>null</code> if creation failed (step 3 of
+        3).
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/android/create-alternative-billing-token-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-alternative-billing-token-android.tsx
@@ -62,6 +62,49 @@ function CreateAlternativeBillingTokenAndroid() {
 // Returns token string, or null if creation failed
 suspend fun createAlternativeBillingToken(): String?`}</CodeBlock>
           ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun createAlternativeBillingTokenAndroid(): String?`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`createAlternativeBillingTokenAndroid(): Promise<string | null>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<String?> createAlternativeBillingTokenAndroid();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func create_alternative_billing_token_android() -> String`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`val token = openIapStore.createAlternativeBillingToken()`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`// kmp-iap (Android targets only — no-op on iOS)
+val token = kmpIAP.createAlternativeBillingTokenAndroid()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { createAlternativeBillingTokenAndroid } from 'expo-iap';
+
+if (Platform.OS === 'android') {
+  const token = await createAlternativeBillingTokenAndroid();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isAndroid) {
+  final token = await FlutterInappPurchase.instance
+      .createAlternativeBillingTokenAndroid();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
+    var token: String = await iap.create_alternative_billing_token_android()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
@@ -44,30 +44,19 @@ function CreateBillingProgramReportingDetailsAndroid() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>program</code>
-            </td>
-            <td>
-              <Link to="/docs/types/billing-programs#billing-program-android">
-                <code>BillingProgramAndroid</code>
-              </Link>
-            </td>
-            <td>Yes</td>
-            <td>Billing program identifier.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>program</code>{' '}
+          <em>
+            (required,{' '}
+            <Link to="/docs/types/billing-programs#billing-program-android">
+              <code>BillingProgramAndroid</code>
+            </Link>
+            )
+          </em>{' '}
+          — Billing program identifier.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns
@@ -78,46 +67,29 @@ function CreateBillingProgramReportingDetailsAndroid() {
         </Link>{' '}
         — payload to report a Developer-Provided Billing transaction:
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>externalTransactionToken</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>
-              Token to send to Google's reporting API. Required for compliance.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>responseCode</code>
-            </td>
-            <td>
-              <code>number?</code>
-            </td>
-            <td>Raw Play Billing response code (when Play returned one).</td>
-          </tr>
-          <tr>
-            <td>
-              <code>debugMessage</code>
-            </td>
-            <td>
-              <code>string?</code>
-            </td>
-            <td>Optional debug message from Play.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>externalTransactionToken</code>{' '}
+          <em>
+            (<code>string</code>)
+          </em>{' '}
+          — Token to send to Google's reporting API. Required for compliance.
+        </li>
+        <li>
+          <code>responseCode</code>{' '}
+          <em>
+            (<code>number?</code>)
+          </em>{' '}
+          — Raw Play Billing response code (when Play returned one).
+        </li>
+        <li>
+          <code>debugMessage</code>{' '}
+          <em>
+            (<code>string?</code>)
+          </em>{' '}
+          — Optional debug message from Play.
+        </li>
+      </ul>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
@@ -22,6 +22,22 @@ function CreateBillingProgramReportingDetailsAndroid() {
         Step 3 of Billing Programs API. Create reporting details with external
         transaction token after successful payment.
       </p>
+      <p>
+        Wraps{' '}
+        <code>
+          BillingClient.createBillingProgramReportingDetailsAsync(BillingProgram)
+        </code>{' '}
+        — returns the external transaction token to report a Developer-Provided
+        Billing transaction. Play Billing 8.3.0+. See the{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/billing-programs"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Play Billing reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
@@ -73,13 +73,51 @@ function CreateBillingProgramReportingDetailsAndroid() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;BillingProgramReportingDetailsAndroid&gt;</code> —
-        External transaction token + metadata for reporting. See{' '}
         <Link to="/docs/types/billing-programs#billing-program-reporting-details-android">
-          <code>BillingProgramReportingDetailsAndroid</code>
-        </Link>
-        .
+          <code>Promise&lt;BillingProgramReportingDetailsAndroid&gt;</code>
+        </Link>{' '}
+        — payload to report a Developer-Provided Billing transaction:
       </p>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>externalTransactionToken</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>
+              Token to send to Google's reporting API. Required for compliance.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>responseCode</code>
+            </td>
+            <td>
+              <code>number?</code>
+            </td>
+            <td>Raw Play Billing response code (when Play returned one).</td>
+          </tr>
+          <tr>
+            <td>
+              <code>debugMessage</code>
+            </td>
+            <td>
+              <code>string?</code>
+            </td>
+            <td>Optional debug message from Play.</td>
+          </tr>
+        </tbody>
+      </table>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
@@ -41,6 +41,41 @@ function CreateBillingProgramReportingDetailsAndroid() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`// Returns BillingProgramReportingDetailsAndroid with externalTransactionToken
+// Token must be reported to Google Play backend within 24 hours
+// Throws OpenIapError.NotPrepared if billing client not ready
+suspend fun createBillingProgramReportingDetails(
+    program: BillingProgramAndroid
+): BillingProgramReportingDetailsAndroid`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun createBillingProgramReportingDetailsAndroid(
+    program: BillingProgramAndroid
+): BillingProgramReportingDetailsAndroid`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`createBillingProgramReportingDetailsAndroid(
+  program: BillingProgramAndroid
+): Promise<BillingProgramReportingDetailsAndroid>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<BillingProgramReportingDetailsAndroid>
+    createBillingProgramReportingDetailsAndroid(
+  BillingProgramAndroid program,
+);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func create_billing_program_reporting_details_android(
+    program: int
+) -> BillingProgramReportingDetailsAndroid`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -90,41 +125,6 @@ function CreateBillingProgramReportingDetailsAndroid() {
           — Optional debug message from Play.
         </li>
       </ul>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          kotlin: (
-            <CodeBlock language="kotlin">{`// Returns BillingProgramReportingDetailsAndroid with externalTransactionToken
-// Token must be reported to Google Play backend within 24 hours
-// Throws OpenIapError.NotPrepared if billing client not ready
-suspend fun createBillingProgramReportingDetails(
-    program: BillingProgramAndroid
-): BillingProgramReportingDetailsAndroid`}</CodeBlock>
-          ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun createBillingProgramReportingDetailsAndroid(
-    program: BillingProgramAndroid
-): BillingProgramReportingDetailsAndroid`}</CodeBlock>
-          ),
-          typescript: (
-            <CodeBlock language="typescript">{`createBillingProgramReportingDetailsAndroid(
-  program: BillingProgramAndroid
-): Promise<BillingProgramReportingDetailsAndroid>`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<BillingProgramReportingDetailsAndroid>
-    createBillingProgramReportingDetailsAndroid(
-  BillingProgramAndroid program,
-);`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func create_billing_program_reporting_details_android(
-    program: int
-) -> BillingProgramReportingDetailsAndroid`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
@@ -130,6 +130,68 @@ suspend fun createBillingProgramReportingDetails(
     program: BillingProgramAndroid
 ): BillingProgramReportingDetailsAndroid`}</CodeBlock>
           ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun createBillingProgramReportingDetailsAndroid(
+    program: BillingProgramAndroid
+): BillingProgramReportingDetailsAndroid`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`createBillingProgramReportingDetailsAndroid(
+  program: BillingProgramAndroid
+): Promise<BillingProgramReportingDetailsAndroid>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<BillingProgramReportingDetailsAndroid>
+    createBillingProgramReportingDetailsAndroid(
+  BillingProgramAndroid program,
+);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func create_billing_program_reporting_details_android(
+    program: int
+) -> BillingProgramReportingDetailsAndroid`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`val details = openIapStore.createBillingProgramReportingDetails(
+    BillingProgramAndroid.ExternalOffer
+)`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`// kmp-iap (Android targets only — no-op on iOS)
+val details = kmpIAP.createBillingProgramReportingDetailsAndroid(
+    BillingProgramAndroid.ExternalOffer
+)`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { createBillingProgramReportingDetailsAndroid } from 'expo-iap';
+
+if (Platform.OS === 'android') {
+  const details = await createBillingProgramReportingDetailsAndroid(
+    'external-offer',
+  );
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isAndroid) {
+  final details = await FlutterInappPurchase.instance
+      .createBillingProgramReportingDetailsAndroid(
+    BillingProgramAndroid.externalOffer,
+  );
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
+    var details = await iap.create_billing_program_reporting_details_android(
+        BillingProgramAndroid.EXTERNAL_OFFER
+    )`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -36,6 +38,46 @@ function CreateBillingProgramReportingDetailsAndroid() {
         >
           Google Play Billing reference
         </a>
+        .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>program</code>
+            </td>
+            <td>
+              <Link to="/docs/types/billing-programs#billing-program-android">
+                <code>BillingProgramAndroid</code>
+              </Link>
+            </td>
+            <td>Yes</td>
+            <td>Billing program identifier.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;BillingProgramReportingDetailsAndroid&gt;</code> —
+        External transaction token + metadata for reporting. See{' '}
+        <Link to="/docs/types/billing-programs#billing-program-reporting-details-android">
+          <code>BillingProgramReportingDetailsAndroid</code>
+        </Link>
         .
       </p>
 

--- a/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
@@ -86,29 +86,27 @@ func init_connection(config: InitConnectionConfig) -> bool`}</CodeBlock>
         }}
       </LanguageTabs>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <ul className="api-params">
-        <li>
-          <code>billingProgramAndroid</code>{' '}
-          <em>
-            (required,{' '}
-            <Link to="/docs/types/billing-programs#billing-program-android">
-              <code>BillingProgramAndroid</code>
-            </Link>
-            )
-          </em>{' '}
-          — Note: this is a config field of <code>InitConnectionConfig</code>{' '}
-          passed to <code>initConnection()</code>, not a standalone mutation.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
+      <AnchorLink id="config-field" level="h2">
+        Config field
       </AnchorLink>
       <p>
-        <code>Promise&lt;void&gt;</code> — Resolves once the program is enabled.
+        <code>enableBillingProgramAndroid</code> on{' '}
+        <Link to="/docs/types/alternative-billing-types#init-connection-config">
+          <code>InitConnectionConfig</code>
+        </Link>
+        : optional{' '}
+        <Link to="/docs/types/billing-programs#billing-program-android">
+          <code>BillingProgramAndroid</code>
+        </Link>
+        . Pass the program identifier you want to enable (e.g.{' '}
+        <code>'external-offer'</code>) as part of the config you hand to{' '}
+        <Link to="/docs/apis/init-connection">
+          <code>initConnection()</code>
+        </Link>
+        ; the connection succeeds with the program enabled, and{' '}
+        <code>initConnection()</code>'s own <code>Promise&lt;boolean&gt;</code>{' '}
+        return value indicates the overall connection result. There is no
+        separate <code>enableBillingProgramAndroid()</code> call.
       </p>
 
       <h2>Example</h2>

--- a/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
@@ -51,34 +51,20 @@ function EnableBillingProgramAndroid() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>billingProgramAndroid</code>
-            </td>
-            <td>
-              <Link to="/docs/types/billing-programs#billing-program-android">
-                <code>BillingProgramAndroid</code>
-              </Link>
-            </td>
-            <td>Yes</td>
-            <td>
-              Note: this is a config field of <code>InitConnectionConfig</code>{' '}
-              passed to <code>initConnection()</code>, not a standalone
-              mutation.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>billingProgramAndroid</code>{' '}
+          <em>
+            (required,{' '}
+            <Link to="/docs/types/billing-programs#billing-program-android">
+              <code>BillingProgramAndroid</code>
+            </Link>
+            )
+          </em>{' '}
+          — Note: this is a config field of <code>InitConnectionConfig</code>{' '}
+          passed to <code>initConnection()</code>, not a standalone mutation.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
@@ -32,6 +32,20 @@ function EnableBillingProgramAndroid() {
         when calling <code>initConnection()</code> — there is no separate
         top-level call.
       </p>
+      <p>
+        Sets <code>enableBillingProgramAndroid</code> on{' '}
+        <code>InitConnectionConfig</code>; under the hood it configures{' '}
+        <code>BillingClient.Builder.enableBillingPrograms(...)</code> (Play
+        Billing 8.2.0+). See the{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/billing-programs"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Play Billing reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
@@ -48,31 +48,6 @@ function EnableBillingProgramAndroid() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <ul className="api-params">
-        <li>
-          <code>billingProgramAndroid</code>{' '}
-          <em>
-            (required,{' '}
-            <Link to="/docs/types/billing-programs#billing-program-android">
-              <code>BillingProgramAndroid</code>
-            </Link>
-            )
-          </em>{' '}
-          — Note: this is a config field of <code>InitConnectionConfig</code>{' '}
-          passed to <code>initConnection()</code>, not a standalone mutation.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;void&gt;</code> — Resolves once the program is enabled.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -110,6 +85,31 @@ func init_connection(config: InitConnectionConfig) -> bool`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <ul className="api-params">
+        <li>
+          <code>billingProgramAndroid</code>{' '}
+          <em>
+            (required,{' '}
+            <Link to="/docs/types/billing-programs#billing-program-android">
+              <code>BillingProgramAndroid</code>
+            </Link>
+            )
+          </em>{' '}
+          — Note: this is a config field of <code>InitConnectionConfig</code>{' '}
+          passed to <code>initConnection()</code>, not a standalone mutation.
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;void&gt;</code> — Resolves once the program is enabled.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -45,6 +46,45 @@ function EnableBillingProgramAndroid() {
           Google Play Billing reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>billingProgramAndroid</code>
+            </td>
+            <td>
+              <Link to="/docs/types/billing-programs#billing-program-android">
+                <code>BillingProgramAndroid</code>
+              </Link>
+            </td>
+            <td>Yes</td>
+            <td>
+              Note: this is a config field of <code>InitConnectionConfig</code>{' '}
+              passed to <code>initConnection()</code>, not a standalone
+              mutation.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;void&gt;</code> — Resolves once the program is enabled.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
@@ -90,11 +90,62 @@ function EnableBillingProgramAndroid() {
       <h2>Signature</h2>
       <LanguageTabs>
         {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`// Config field on InitConnectionConfig — wired via initConnection()
+data class InitConnectionConfig(
+    val enableBillingProgramAndroid: BillingProgramAndroid? = null,
+    // ...other fields
+)`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`// Config field on InitConnectionConfig (kmp-iap)
+data class InitConnectionConfig(
+    val enableBillingProgramAndroid: BillingProgramAndroid? = null,
+    // ...other fields
+)`}</CodeBlock>
+          ),
           typescript: (
-            <CodeBlock language="typescript">{`// expo-iap
+            <CodeBlock language="typescript">{`initConnection(config?: {
+  enableBillingProgramAndroid?: BillingProgramAndroid;
+  // ...other fields
+}): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> initConnection({InitConnectionConfig? config});
+
+class InitConnectionConfig {
+  final BillingProgramAndroid? enableBillingProgramAndroid;
+  // ...other fields
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`# InitConnectionConfig.enable_billing_program_android: BillingProgramAndroid
+func init_connection(config: InitConnectionConfig) -> bool`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`openIapStore.initConnection(
+    InitConnectionConfig(
+        enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
+    )
+)`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`// kmp-iap (Android targets only)
+kmpIAP.initConnection(
+    InitConnectionConfig(
+        enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
+    )
+)`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
 import { initConnection } from 'expo-iap';
-// Same API in react-native-iap:
-// import { initConnection } from 'react-native-iap';
 
 await initConnection({
   enableBillingProgramAndroid: 'external-offer',
@@ -113,24 +164,20 @@ function App() {
   return <Root />;
 }`}</CodeBlock>
           ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`openIapStore.initConnection(
-    InitConnectionConfig(
-        enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
-    )
-)`}</CodeBlock>
-          ),
           dart: (
-            <CodeBlock language="dart">{`await FlutterInappPurchase.instance.initConnection(
-  config: InitConnectionConfig(
-    enableBillingProgramAndroid: BillingProgramAndroid.externalOffer,
-  ),
-);`}</CodeBlock>
+            <CodeBlock language="dart">{`if (Platform.isAndroid) {
+  await FlutterInappPurchase.instance.initConnection(
+    config: InitConnectionConfig(
+      enableBillingProgramAndroid: BillingProgramAndroid.externalOffer,
+    ),
+  );
+}`}</CodeBlock>
           ),
           gdscript: (
-            <CodeBlock language="gdscript">{`var config = InitConnectionConfig.new()
-config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_OFFER
-await iap.init_connection(config)`}</CodeBlock>
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
+    var config = InitConnectionConfig.new()
+    config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_OFFER
+    await iap.init_connection(config)`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -36,6 +38,46 @@ function IsBillingProgramAvailableAndroid() {
         >
           Google Play Billing reference
         </a>
+        .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>program</code>
+            </td>
+            <td>
+              <Link to="/docs/types/billing-programs#billing-program-android">
+                <code>BillingProgramAndroid</code>
+              </Link>
+            </td>
+            <td>Yes</td>
+            <td>Billing program identifier.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;BillingProgramAvailabilityResultAndroid&gt;</code> —
+        Availability result with <code>isAvailable</code> flag. See{' '}
+        <Link to="/docs/types/billing-programs#billing-program-availability-result-android">
+          <code>BillingProgramAvailabilityResultAndroid</code>
+        </Link>
         .
       </p>
 

--- a/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
@@ -44,30 +44,19 @@ function IsBillingProgramAvailableAndroid() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>program</code>
-            </td>
-            <td>
-              <Link to="/docs/types/billing-programs#billing-program-android">
-                <code>BillingProgramAndroid</code>
-              </Link>
-            </td>
-            <td>Yes</td>
-            <td>Billing program identifier.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>program</code>{' '}
+          <em>
+            (required,{' '}
+            <Link to="/docs/types/billing-programs#billing-program-android">
+              <code>BillingProgramAndroid</code>
+            </Link>
+            )
+          </em>{' '}
+          — Billing program identifier.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns
@@ -78,46 +67,29 @@ function IsBillingProgramAvailableAndroid() {
         </Link>{' '}
         — carries:
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>isAvailable</code>
-            </td>
-            <td>
-              <code>boolean</code>
-            </td>
-            <td>
-              Whether the billing program is available for this user/device.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>responseCode</code>
-            </td>
-            <td>
-              <code>number?</code>
-            </td>
-            <td>Raw Play Billing response code (when Play returned one).</td>
-          </tr>
-          <tr>
-            <td>
-              <code>debugMessage</code>
-            </td>
-            <td>
-              <code>string?</code>
-            </td>
-            <td>Optional debug message from Play.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>isAvailable</code>{' '}
+          <em>
+            (<code>boolean</code>)
+          </em>{' '}
+          — Whether the billing program is available for this user/device.
+        </li>
+        <li>
+          <code>responseCode</code>{' '}
+          <em>
+            (<code>number?</code>)
+          </em>{' '}
+          — Raw Play Billing response code (when Play returned one).
+        </li>
+        <li>
+          <code>debugMessage</code>{' '}
+          <em>
+            (<code>string?</code>)
+          </em>{' '}
+          — Optional debug message from Play.
+        </li>
+      </ul>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
@@ -73,13 +73,51 @@ function IsBillingProgramAvailableAndroid() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;BillingProgramAvailabilityResultAndroid&gt;</code> —
-        Availability result with <code>isAvailable</code> flag. See{' '}
         <Link to="/docs/types/billing-programs#billing-program-availability-result-android">
-          <code>BillingProgramAvailabilityResultAndroid</code>
-        </Link>
-        .
+          <code>Promise&lt;BillingProgramAvailabilityResultAndroid&gt;</code>
+        </Link>{' '}
+        — carries:
       </p>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>isAvailable</code>
+            </td>
+            <td>
+              <code>boolean</code>
+            </td>
+            <td>
+              Whether the billing program is available for this user/device.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>responseCode</code>
+            </td>
+            <td>
+              <code>number?</code>
+            </td>
+            <td>Raw Play Billing response code (when Play returned one).</td>
+          </tr>
+          <tr>
+            <td>
+              <code>debugMessage</code>
+            </td>
+            <td>
+              <code>string?</code>
+            </td>
+            <td>Optional debug message from Play.</td>
+          </tr>
+        </tbody>
+      </table>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
@@ -101,25 +101,22 @@ suspend fun isBillingProgramAvailable(
       </p>
       <ul className="api-params">
         <li>
+          <code>billingProgram</code>{' '}
+          <em>
+            (
+            <Link to="/docs/types/billing-programs#billing-program-android">
+              <code>BillingProgramAndroid</code>
+            </Link>
+            )
+          </em>{' '}
+          — Echoes back the program that was checked.
+        </li>
+        <li>
           <code>isAvailable</code>{' '}
           <em>
             (<code>boolean</code>)
           </em>{' '}
           — Whether the billing program is available for this user/device.
-        </li>
-        <li>
-          <code>responseCode</code>{' '}
-          <em>
-            (<code>number?</code>)
-          </em>{' '}
-          — Raw Play Billing response code (when Play returned one).
-        </li>
-        <li>
-          <code>debugMessage</code>{' '}
-          <em>
-            (<code>string?</code>)
-          </em>{' '}
-          — Optional debug message from Play.
         </li>
       </ul>
 

--- a/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
@@ -129,6 +129,62 @@ suspend fun isBillingProgramAvailable(
     program: BillingProgramAndroid
 ): BillingProgramAvailabilityResultAndroid`}</CodeBlock>
           ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun isBillingProgramAvailableAndroid(
+    program: BillingProgramAndroid
+): BillingProgramAvailabilityResultAndroid`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`isBillingProgramAvailableAndroid(
+  program: BillingProgramAndroid
+): Promise<BillingProgramAvailabilityResultAndroid>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<BillingProgramAvailabilityResultAndroid>
+    isBillingProgramAvailableAndroid(BillingProgramAndroid program);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func is_billing_program_available_android(
+    program: int
+) -> BillingProgramAvailabilityResultAndroid`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`val result = openIapStore.isBillingProgramAvailable(
+    BillingProgramAndroid.ExternalOffer
+)`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`// kmp-iap (Android targets only — no-op on iOS)
+val result = kmpIAP.isBillingProgramAvailableAndroid(
+    BillingProgramAndroid.ExternalOffer
+)`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { isBillingProgramAvailableAndroid } from 'expo-iap';
+
+if (Platform.OS === 'android') {
+  const result = await isBillingProgramAvailableAndroid('external-offer');
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isAndroid) {
+  final result = await FlutterInappPurchase.instance
+      .isBillingProgramAvailableAndroid(BillingProgramAndroid.externalOffer);
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
+    var result = await iap.is_billing_program_available_android(
+        BillingProgramAndroid.EXTERNAL_OFFER
+    )`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
@@ -23,7 +23,10 @@ function IsBillingProgramAvailableAndroid() {
         for the current user.
       </p>
       <p>
-        Wraps <code>BillingClient.isBillingProgramAvailableAsync(BillingProgram)</code>{' '}
+        Wraps{' '}
+        <code>
+          BillingClient.isBillingProgramAvailableAsync(BillingProgram)
+        </code>{' '}
         — replaces <code>isExternalOfferAvailableAsync</code>. Play Billing
         8.2.0+. See the{' '}
         <a

--- a/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
@@ -22,6 +22,19 @@ function IsBillingProgramAvailableAndroid() {
         Step 1 of Billing Programs API. Check if a billing program is available
         for the current user.
       </p>
+      <p>
+        Wraps <code>BillingClient.isBillingProgramAvailableAsync(BillingProgram)</code>{' '}
+        — replaces <code>isExternalOfferAvailableAsync</code>. Play Billing
+        8.2.0+. See the{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/billing-programs"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Play Billing reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
@@ -41,6 +41,38 @@ function IsBillingProgramAvailableAndroid() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`// Returns BillingProgramAvailabilityResultAndroid with isAvailable flag
+// Throws OpenIapError.NotPrepared if billing client not ready
+suspend fun isBillingProgramAvailable(
+    program: BillingProgramAndroid
+): BillingProgramAvailabilityResultAndroid`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun isBillingProgramAvailableAndroid(
+    program: BillingProgramAndroid
+): BillingProgramAvailabilityResultAndroid`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`isBillingProgramAvailableAndroid(
+  program: BillingProgramAndroid
+): Promise<BillingProgramAvailabilityResultAndroid>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<BillingProgramAvailabilityResultAndroid>
+    isBillingProgramAvailableAndroid(BillingProgramAndroid program);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func is_billing_program_available_android(
+    program: int
+) -> BillingProgramAvailabilityResultAndroid`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -90,38 +122,6 @@ function IsBillingProgramAvailableAndroid() {
           — Optional debug message from Play.
         </li>
       </ul>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          kotlin: (
-            <CodeBlock language="kotlin">{`// Returns BillingProgramAvailabilityResultAndroid with isAvailable flag
-// Throws OpenIapError.NotPrepared if billing client not ready
-suspend fun isBillingProgramAvailable(
-    program: BillingProgramAndroid
-): BillingProgramAvailabilityResultAndroid`}</CodeBlock>
-          ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun isBillingProgramAvailableAndroid(
-    program: BillingProgramAndroid
-): BillingProgramAvailabilityResultAndroid`}</CodeBlock>
-          ),
-          typescript: (
-            <CodeBlock language="typescript">{`isBillingProgramAvailableAndroid(
-  program: BillingProgramAndroid
-): Promise<BillingProgramAvailabilityResultAndroid>`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<BillingProgramAvailabilityResultAndroid>
-    isBillingProgramAvailableAndroid(BillingProgramAndroid program);`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func is_billing_program_available_android(
-    program: int
-) -> BillingProgramAvailabilityResultAndroid`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
@@ -52,45 +52,27 @@ function LaunchExternalLinkAndroid() {
         </Link>
         :
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>program</code>
-            </td>
-            <td>
-              <Link to="/docs/types/billing-programs#billing-program-android">
-                <code>BillingProgramAndroid</code>
-              </Link>
-            </td>
-            <td>Yes</td>
-            <td>
-              Billing program the link belongs to (e.g.{' '}
-              <code>EXTERNAL_OFFER</code>).
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>url</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Yes</td>
-            <td>
-              External URL to launch after the Play disclosure dialog dismisses.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>program</code>{' '}
+          <em>
+            (required,{' '}
+            <Link to="/docs/types/billing-programs#billing-program-android">
+              <code>BillingProgramAndroid</code>
+            </Link>
+            )
+          </em>{' '}
+          — Billing program the link belongs to (e.g.{' '}
+          <code>EXTERNAL_OFFER</code>).
+        </li>
+        <li>
+          <code>url</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — External URL to launch after the Play disclosure dialog dismisses.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
@@ -42,46 +42,6 @@ function LaunchExternalLinkAndroid() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>
-        Pass a single{' '}
-        <Link to="/docs/types/billing-programs#launch-external-link-params-android">
-          <code>LaunchExternalLinkParamsAndroid</code>
-        </Link>
-        :
-      </p>
-      <ul className="api-params">
-        <li>
-          <code>program</code>{' '}
-          <em>
-            (required,{' '}
-            <Link to="/docs/types/billing-programs#billing-program-android">
-              <code>BillingProgramAndroid</code>
-            </Link>
-            )
-          </em>{' '}
-          — Billing program the link belongs to (e.g.{' '}
-          <code>EXTERNAL_OFFER</code>).
-        </li>
-        <li>
-          <code>url</code>{' '}
-          <em>
-            (required, <code>string</code>)
-          </em>{' '}
-          — External URL to launch after the Play disclosure dialog dismisses.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the Play
-        disclosure dialog finished and (optionally) the URL was opened.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -121,6 +81,46 @@ suspend fun launchExternalLink(
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>
+        Pass a single{' '}
+        <Link to="/docs/types/billing-programs#launch-external-link-params-android">
+          <code>LaunchExternalLinkParamsAndroid</code>
+        </Link>
+        :
+      </p>
+      <ul className="api-params">
+        <li>
+          <code>program</code>{' '}
+          <em>
+            (required,{' '}
+            <Link to="/docs/types/billing-programs#billing-program-android">
+              <code>BillingProgramAndroid</code>
+            </Link>
+            )
+          </em>{' '}
+          — Billing program the link belongs to (e.g.{' '}
+          <code>EXTERNAL_OFFER</code>).
+        </li>
+        <li>
+          <code>url</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — External URL to launch after the Play disclosure dialog dismisses.
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the Play
+        disclosure dialog finished and (optionally) the URL was opened.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
@@ -144,8 +144,8 @@ suspend fun launchExternalLink(
     activity,
     LaunchExternalLinkParamsAndroid(
         billingProgram = BillingProgramAndroid.ExternalOffer,
-        launchMode = ExternalLinkLaunchModeAndroid.IN_APP_BROWSER,
-        linkType = ExternalLinkTypeAndroid.OFFER,
+        launchMode = ExternalLinkLaunchModeAndroid.LaunchInExternalBrowserOrApp,
+        linkType = ExternalLinkTypeAndroid.LinkToDigitalContentOffer,
         linkUri = "https://example.com/offer"
     )
 )`}</CodeBlock>
@@ -155,8 +155,8 @@ suspend fun launchExternalLink(
 kmpIAP.launchExternalLinkAndroid(
     LaunchExternalLinkParamsAndroid(
         billingProgram = BillingProgramAndroid.ExternalOffer,
-        launchMode = ExternalLinkLaunchModeAndroid.IN_APP_BROWSER,
-        linkType = ExternalLinkTypeAndroid.OFFER,
+        launchMode = ExternalLinkLaunchModeAndroid.LaunchInExternalBrowserOrApp,
+        linkType = ExternalLinkTypeAndroid.LinkToDigitalContentOffer,
         linkUri = "https://example.com/offer"
     )
 )`}</CodeBlock>
@@ -168,8 +168,8 @@ import { launchExternalLinkAndroid } from 'expo-iap';
 if (Platform.OS === 'android') {
   await launchExternalLinkAndroid({
     billingProgram: 'external-offer',
-    launchMode: 'in-app-browser',
-    linkType: 'offer',
+    launchMode: 'launch-in-external-browser-or-app',
+    linkType: 'link-to-digital-content-offer',
     linkUri: 'https://example.com/offer',
   });
 }`}</CodeBlock>
@@ -179,8 +179,8 @@ if (Platform.OS === 'android') {
   await FlutterInappPurchase.instance.launchExternalLinkAndroid(
     LaunchExternalLinkParamsAndroid(
       billingProgram: BillingProgramAndroid.externalOffer,
-      launchMode: ExternalLinkLaunchModeAndroid.inAppBrowser,
-      linkType: ExternalLinkTypeAndroid.offer,
+      launchMode: ExternalLinkLaunchModeAndroid.LaunchInExternalBrowserOrApp,
+      linkType: ExternalLinkTypeAndroid.LinkToDigitalContentOffer,
       linkUri: 'https://example.com/offer',
     ),
   );
@@ -190,8 +190,8 @@ if (Platform.OS === 'android') {
             <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
     var params = LaunchExternalLinkParamsAndroid.new()
     params.billing_program = BillingProgramAndroid.EXTERNAL_OFFER
-    params.launch_mode = ExternalLinkLaunchModeAndroid.IN_APP_BROWSER
-    params.link_type = ExternalLinkTypeAndroid.OFFER
+    params.launch_mode = ExternalLinkLaunchModeAndroid.LAUNCH_IN_EXTERNAL_BROWSER_OR_APP
+    params.link_type = ExternalLinkTypeAndroid.LINK_TO_DIGITAL_CONTENT_OFFER
     params.link_uri = "https://example.com/offer"
     await iap.launch_external_link_android(params)`}</CodeBlock>
           ),

--- a/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
@@ -23,9 +23,10 @@ function LaunchExternalLinkAndroid() {
         Store dialog and optionally launches external URL.
       </p>
       <p>
-        Wraps <code>BillingClient.launchExternalLinkFlow(activity, params)</code>{' '}
-        — replaces <code>showExternalOfferInformationDialog</code>. Shows the
-        Play disclosure dialog and (optionally) launches the URL. Play Billing
+        Wraps{' '}
+        <code>BillingClient.launchExternalLinkFlow(activity, params)</code> —
+        replaces <code>showExternalOfferInformationDialog</code>. Shows the Play
+        disclosure dialog and (optionally) launches the URL. Play Billing
         8.2.0+. See the{' '}
         <a
           href="https://developer.android.com/google/play/billing/billing-programs"

--- a/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
@@ -24,9 +24,11 @@ function LaunchExternalLinkAndroid() {
       </p>
       <p>
         Wraps{' '}
-        <code>BillingClient.launchExternalLinkFlow(activity, params)</code> —
-        replaces <code>showExternalOfferInformationDialog</code>. Shows the Play
-        disclosure dialog and (optionally) launches the URL. Play Billing
+        <code>
+          BillingClient.launchExternalLink(activity, params, listener)
+        </code>{' '}
+        — replaces <code>showExternalOfferInformationDialog</code>. Shows the
+        Play disclosure dialog and (optionally) launches the URL. Play Billing
         8.2.0+. See the{' '}
         <a
           href="https://developer.android.com/google/play/billing/billing-programs"

--- a/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
@@ -22,6 +22,20 @@ function LaunchExternalLinkAndroid() {
         Step 2 of Billing Programs API. Launch external link flow — shows Play
         Store dialog and optionally launches external URL.
       </p>
+      <p>
+        Wraps <code>BillingClient.launchExternalLinkFlow(activity, params)</code>{' '}
+        — replaces <code>showExternalOfferInformationDialog</code>. Shows the
+        Play disclosure dialog and (optionally) launches the URL. Play Billing
+        8.2.0+. See the{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/billing-programs"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Play Billing reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -38,6 +40,42 @@ function LaunchExternalLinkAndroid() {
           Google Play Billing reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>params</code>
+            </td>
+            <td>
+              <Link to="/docs/types/billing-programs#launch-external-link-params-android">
+                <code>LaunchExternalLinkParamsAndroid</code>
+              </Link>
+            </td>
+            <td>Yes</td>
+            <td>Includes the external URL plus per-program options.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the Play
+        disclosure dialog finished and (optionally) the URL was opened.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
@@ -94,7 +94,7 @@ suspend fun launchExternalLink(
       </p>
       <ul className="api-params">
         <li>
-          <code>program</code>{' '}
+          <code>billingProgram</code>{' '}
           <em>
             (required,{' '}
             <Link to="/docs/types/billing-programs#billing-program-android">
@@ -103,14 +103,28 @@ suspend fun launchExternalLink(
             )
           </em>{' '}
           — Billing program the link belongs to (e.g.{' '}
-          <code>EXTERNAL_OFFER</code>).
+          <code>EXTERNAL_CONTENT_LINK</code> or <code>EXTERNAL_OFFER</code>).
         </li>
         <li>
-          <code>url</code>{' '}
+          <code>launchMode</code>{' '}
+          <em>
+            (required, <code>ExternalLinkLaunchModeAndroid</code>)
+          </em>{' '}
+          — How the link is presented (in-app browser, system browser, etc.).
+        </li>
+        <li>
+          <code>linkType</code>{' '}
+          <em>
+            (required, <code>ExternalLinkTypeAndroid</code>)
+          </em>{' '}
+          — Type of the external link (e.g. offer page).
+        </li>
+        <li>
+          <code>linkUri</code>{' '}
           <em>
             (required, <code>string</code>)
           </em>{' '}
-          — External URL to launch after the Play disclosure dialog dismisses.
+          — External URI to launch after the Play disclosure dialog dismisses.
         </li>
       </ul>
 
@@ -153,8 +167,10 @@ import { launchExternalLinkAndroid } from 'expo-iap';
 
 if (Platform.OS === 'android') {
   await launchExternalLinkAndroid({
-    program: 'external-offer',
-    url: 'https://example.com/offer',
+    billingProgram: 'external-offer',
+    launchMode: 'in-app-browser',
+    linkType: 'offer',
+    linkUri: 'https://example.com/offer',
   });
 }`}</CodeBlock>
           ),
@@ -162,8 +178,10 @@ if (Platform.OS === 'android') {
             <CodeBlock language="dart">{`if (Platform.isAndroid) {
   await FlutterInappPurchase.instance.launchExternalLinkAndroid(
     LaunchExternalLinkParamsAndroid(
-      program: BillingProgramAndroid.externalOffer,
-      url: 'https://example.com/offer',
+      billingProgram: BillingProgramAndroid.externalOffer,
+      launchMode: ExternalLinkLaunchModeAndroid.inAppBrowser,
+      linkType: ExternalLinkTypeAndroid.offer,
+      linkUri: 'https://example.com/offer',
     ),
   );
 }`}</CodeBlock>
@@ -171,8 +189,10 @@ if (Platform.OS === 'android') {
           gdscript: (
             <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
     var params = LaunchExternalLinkParamsAndroid.new()
-    params.program = BillingProgramAndroid.EXTERNAL_OFFER
-    params.url = "https://example.com/offer"
+    params.billing_program = BillingProgramAndroid.EXTERNAL_OFFER
+    params.launch_mode = ExternalLinkLaunchModeAndroid.IN_APP_BROWSER
+    params.link_type = ExternalLinkTypeAndroid.OFFER
+    params.link_uri = "https://example.com/offer"
     await iap.launch_external_link_android(params)`}</CodeBlock>
           ),
         }}

--- a/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
@@ -117,6 +117,82 @@ suspend fun launchExternalLink(
 // - linkType: ExternalLinkTypeAndroid
 // - linkUri: String`}</CodeBlock>
           ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun launchExternalLinkAndroid(
+    params: LaunchExternalLinkParamsAndroid
+): Boolean`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`launchExternalLinkAndroid(
+  params: LaunchExternalLinkParamsAndroid
+): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> launchExternalLinkAndroid(
+  LaunchExternalLinkParamsAndroid params,
+);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func launch_external_link_android(
+    params: LaunchExternalLinkParamsAndroid
+) -> bool`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`openIapStore.launchExternalLink(
+    activity,
+    LaunchExternalLinkParamsAndroid(
+        billingProgram = BillingProgramAndroid.ExternalOffer,
+        launchMode = ExternalLinkLaunchModeAndroid.IN_APP_BROWSER,
+        linkType = ExternalLinkTypeAndroid.OFFER,
+        linkUri = "https://example.com/offer"
+    )
+)`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`// kmp-iap (Android targets only — no-op on iOS)
+kmpIAP.launchExternalLinkAndroid(
+    LaunchExternalLinkParamsAndroid(
+        billingProgram = BillingProgramAndroid.ExternalOffer,
+        launchMode = ExternalLinkLaunchModeAndroid.IN_APP_BROWSER,
+        linkType = ExternalLinkTypeAndroid.OFFER,
+        linkUri = "https://example.com/offer"
+    )
+)`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { launchExternalLinkAndroid } from 'expo-iap';
+
+if (Platform.OS === 'android') {
+  await launchExternalLinkAndroid({
+    program: 'external-offer',
+    url: 'https://example.com/offer',
+  });
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isAndroid) {
+  await FlutterInappPurchase.instance.launchExternalLinkAndroid(
+    LaunchExternalLinkParamsAndroid(
+      program: BillingProgramAndroid.externalOffer,
+      url: 'https://example.com/offer',
+    ),
+  );
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
+    var params = LaunchExternalLinkParamsAndroid.new()
+    params.program = BillingProgramAndroid.EXTERNAL_OFFER
+    params.url = "https://example.com/offer"
+    await iap.launch_external_link_android(params)`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
@@ -45,10 +45,17 @@ function LaunchExternalLinkAndroid() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
+      <p>
+        Pass a single{' '}
+        <Link to="/docs/types/billing-programs#launch-external-link-params-android">
+          <code>LaunchExternalLinkParamsAndroid</code>
+        </Link>
+        :
+      </p>
       <table className="doc-table">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Field</th>
             <th>Type</th>
             <th>Required</th>
             <th>Description</th>
@@ -57,15 +64,30 @@ function LaunchExternalLinkAndroid() {
         <tbody>
           <tr>
             <td>
-              <code>params</code>
+              <code>program</code>
             </td>
             <td>
-              <Link to="/docs/types/billing-programs#launch-external-link-params-android">
-                <code>LaunchExternalLinkParamsAndroid</code>
+              <Link to="/docs/types/billing-programs#billing-program-android">
+                <code>BillingProgramAndroid</code>
               </Link>
             </td>
             <td>Yes</td>
-            <td>Includes the external URL plus per-program options.</td>
+            <td>
+              Billing program the link belongs to (e.g.{' '}
+              <code>EXTERNAL_OFFER</code>).
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>url</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Yes</td>
+            <td>
+              External URL to launch after the Play disclosure dialog dismisses.
+            </td>
           </tr>
         </tbody>
       </table>

--- a/packages/docs/src/pages/docs/apis/android/show-alternative-billing-dialog-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/show-alternative-billing-dialog-android.tsx
@@ -63,6 +63,49 @@ function ShowAlternativeBillingDialogAndroid() {
 // Throws OpenIapError.NotPrepared if billing client not ready
 suspend fun showAlternativeBillingDialog(): Boolean`}</CodeBlock>
           ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun showAlternativeBillingDialogAndroid(): Boolean`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`showAlternativeBillingDialogAndroid(): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> showAlternativeBillingDialogAndroid();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func show_alternative_billing_dialog_android() -> bool`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          kotlin: (
+            <CodeBlock language="kotlin">{`val accepted = openIapStore.showAlternativeBillingDialog()`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`// kmp-iap (Android targets only — no-op on iOS)
+val accepted = kmpIAP.showAlternativeBillingDialogAndroid()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { showAlternativeBillingDialogAndroid } from 'expo-iap';
+
+if (Platform.OS === 'android') {
+  const accepted = await showAlternativeBillingDialogAndroid();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isAndroid) {
+  final accepted = await FlutterInappPurchase.instance
+      .showAlternativeBillingDialogAndroid();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
+    var accepted: bool = await iap.show_alternative_billing_dialog_android()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/android/show-alternative-billing-dialog-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/show-alternative-billing-dialog-android.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -38,6 +39,20 @@ function ShowAlternativeBillingDialogAndroid() {
           Google Play Billing reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the user
+        accepts the disclosure dialog, <code>false</code> if they cancel (step 2
+        of 3).
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/android/show-alternative-billing-dialog-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/show-alternative-billing-dialog-android.tsx
@@ -22,6 +22,23 @@ function ShowAlternativeBillingDialogAndroid() {
         Step 2 of alternative billing flow. Show alternative billing information
         dialog before processing payment.
       </p>
+      <p>
+        Wraps{' '}
+        <code>
+          BillingClient.showAlternativeBillingOnlyInformationDialog(activity,
+          listener)
+        </code>{' '}
+        — step 2. Required disclosure sheet before charging via your own payment
+        system. See the{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/alternative"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Play Billing reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/show-alternative-billing-dialog-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/show-alternative-billing-dialog-android.tsx
@@ -41,15 +41,6 @@ function ShowAlternativeBillingDialogAndroid() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the user
-        accepts the disclosure dialog, <code>false</code> if they cancel (step 2
-        of 3).
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -72,6 +63,15 @@ suspend fun showAlternativeBillingDialog(): Boolean`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the user
+        accepts the disclosure dialog, <code>false</code> if they cancel (step 2
+        of 3).
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/show-alternative-billing-dialog-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/show-alternative-billing-dialog-android.tsx
@@ -41,11 +41,6 @@ function ShowAlternativeBillingDialogAndroid() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
@@ -20,6 +20,32 @@ function DeepLinkToSubscriptions() {
         Open the native subscription management interface where users can view
         and manage their subscriptions.
       </p>
+      <p>
+        <strong>iOS:</strong> Opens{' '}
+        <code>https://apps.apple.com/account/subscriptions</code> (universal
+        link) so the user can manage subscriptions in the App Store.{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/manage-subscriptions-in-your-app"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        . <strong>Android:</strong> Opens the Play Store subscription
+        management deep link{' '}
+        <code>
+          https://play.google.com/store/account/subscriptions?package=&lt;pkg&gt;&amp;sku=&lt;sku&gt;
+        </code>
+        .{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/subscriptions#deep-link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google docs
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
@@ -21,11 +21,12 @@ function DeepLinkToSubscriptions() {
         and manage their subscriptions.
       </p>
       <p>
-        <strong>iOS:</strong> Opens{' '}
-        <code>https://apps.apple.com/account/subscriptions</code> (universal
-        link) so the user can manage subscriptions in the App Store.{' '}
+        <strong>iOS:</strong> Calls{' '}
+        <code>AppStore.showManageSubscriptions(in:)</code> with the active{' '}
+        <code>UIWindowScene</code>; throws if no window scene is available. Not
+        supported on tvOS / watchOS / macOS in the current implementation.{' '}
         <a
-          href="https://developer.apple.com/documentation/storekit/manage-subscriptions-in-your-app"
+          href="https://developer.apple.com/documentation/storekit/appstore/showmanagesubscriptions(in:)"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
@@ -59,44 +59,24 @@ function DeepLinkToSubscriptions() {
         </Link>
         :
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>skuAndroid</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>No</td>
-            <td>
-              <strong>Android.</strong> Subscription SKU to deep-link to.
-              Without it the user lands on the generic Play subscriptions page.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>packageNameAndroid</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>No</td>
-            <td>
-              <strong>Android.</strong> Defaults to the host app's package;
-              override only when proxying for another app.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>skuAndroid</code>{' '}
+          <em>
+            (optional, <code>string</code>)
+          </em>{' '}
+          — <strong>Android.</strong> Subscription SKU to deep-link to. Without
+          it the user lands on the generic Play subscriptions page.
+        </li>
+        <li>
+          <code>packageNameAndroid</code>{' '}
+          <em>
+            (optional, <code>string</code>)
+          </em>{' '}
+          — <strong>Android.</strong> Defaults to the host app's package;
+          override only when proxying for another app.
+        </li>
+      </ul>
       <p>
         iOS ignores all fields — the wrapper calls{' '}
         <code>AppStore.showManageSubscriptions(in:)</code> with the active{' '}

--- a/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
@@ -31,8 +31,8 @@ function DeepLinkToSubscriptions() {
         >
           Apple docs
         </a>
-        . <strong>Android:</strong> Opens the Play Store subscription
-        management deep link{' '}
+        . <strong>Android:</strong> Opens the Play Store subscription management
+        deep link{' '}
         <code>
           https://play.google.com/store/account/subscriptions?package=&lt;pkg&gt;&amp;sku=&lt;sku&gt;
         </code>

--- a/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
@@ -52,10 +52,17 @@ function DeepLinkToSubscriptions() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
+      <p>
+        Pass an optional{' '}
+        <Link to="/docs/types#common">
+          <code>DeepLinkOptions</code>
+        </Link>
+        :
+      </p>
       <table className="doc-table">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Field</th>
             <th>Type</th>
             <th>Required</th>
             <th>Description</th>
@@ -64,22 +71,37 @@ function DeepLinkToSubscriptions() {
         <tbody>
           <tr>
             <td>
-              <code>options</code>
+              <code>skuAndroid</code>
             </td>
             <td>
-              <Link to="/docs/types#common">
-                <code>DeepLinkOptions</code>
-              </Link>
+              <code>string</code>
             </td>
             <td>No</td>
             <td>
-              Android needs <code>skuAndroid</code> +{' '}
-              <code>packageNameAndroid</code> to deep-link to a specific
-              subscription; iOS ignores the argument.
+              <strong>Android.</strong> Subscription SKU to deep-link to.
+              Without it the user lands on the generic Play subscriptions page.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>packageNameAndroid</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>No</td>
+            <td>
+              <strong>Android.</strong> Defaults to the host app's package;
+              override only when proxying for another app.
             </td>
           </tr>
         </tbody>
       </table>
+      <p>
+        iOS ignores all fields — the wrapper calls{' '}
+        <code>AppStore.showManageSubscriptions(in:)</code> with the active{' '}
+        <code>UIWindowScene</code>.
+      </p>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -46,6 +47,53 @@ function DeepLinkToSubscriptions() {
           Google docs
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>options</code>
+            </td>
+            <td>
+              <Link to="/docs/types#common">
+                <code>DeepLinkOptions</code>
+              </Link>
+            </td>
+            <td>No</td>
+            <td>
+              Android needs <code>skuAndroid</code> +{' '}
+              <code>packageNameAndroid</code> to deep-link to a specific
+              subscription; iOS ignores the argument.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;void&gt;</code> — Resolves when the system surface is
+        presented (or the deep link is opened on Android).
+      </p>
+
+      <AnchorLink id="throws" level="h2">
+        Throws
+      </AnchorLink>
+      <p>
+        <strong>iOS:</strong> When no <code>UIWindowScene</code> is available.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/deep-link-to-subscriptions.tsx
@@ -49,6 +49,35 @@ function DeepLinkToSubscriptions() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          typescript: (
+            <CodeBlock language="typescript">{`deepLinkToSubscriptions(options?: DeepLinkOptions): Promise<void>
+
+interface DeepLinkOptions {
+  skuAndroid?: string;
+  packageNameAndroid?: string;
+}`}</CodeBlock>
+          ),
+          swift: (
+            <CodeBlock language="swift">{`func deepLinkToSubscriptions() async throws`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun deepLinkToSubscriptions(options: DeepLinkOptions? = null)`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun deepLinkToSubscriptions(options: DeepLinkOptions? = null)`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<void> deepLinkToSubscriptions({String? skuAndroid, String? packageNameAndroid});`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func deep_link_to_subscriptions(options: DeepLinkOptions) -> void`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -97,35 +126,6 @@ function DeepLinkToSubscriptions() {
       <p>
         <strong>iOS:</strong> When no <code>UIWindowScene</code> is available.
       </p>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          typescript: (
-            <CodeBlock language="typescript">{`deepLinkToSubscriptions(options?: DeepLinkOptions): Promise<void>
-
-interface DeepLinkOptions {
-  skuAndroid?: string;
-  packageNameAndroid?: string;
-}`}</CodeBlock>
-          ),
-          swift: (
-            <CodeBlock language="swift">{`func deepLinkToSubscriptions() async throws`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`suspend fun deepLinkToSubscriptions(options: DeepLinkOptions? = null)`}</CodeBlock>
-          ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun deepLinkToSubscriptions(options: DeepLinkOptions? = null)`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<void> deepLinkToSubscriptions({String? skuAndroid, String? packageNameAndroid});`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func deep_link_to_subscriptions(options: DeepLinkOptions) -> void`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/end-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/end-connection.tsx
@@ -43,14 +43,6 @@ function EndConnection() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> when the
-        connection was closed cleanly.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -74,6 +66,14 @@ function EndConnection() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> when the
+        connection was closed cleanly.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/end-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/end-connection.tsx
@@ -43,11 +43,6 @@ function EndConnection() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/end-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/end-connection.tsx
@@ -19,6 +19,28 @@ function EndConnection() {
         End connection to the store service. Call this when your app closes or
         the IAP component unmounts to clean up resources.
       </p>
+      <p>
+        <strong>iOS:</strong> Cancels the StoreKit{' '}
+        <code>Transaction.updates</code> task and clears in-memory caches.{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/updates"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        . <strong>Android:</strong> Calls{' '}
+        <code>BillingClient.endConnection()</code>; the client cannot be reused
+        after this — call <code>initConnection</code> again to reconnect.{' '}
+        <a
+          href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#endConnection()"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google docs
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/end-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/end-connection.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -40,6 +41,19 @@ function EndConnection() {
           Google docs
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> when the
+        connection was closed cleanly.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/fetch-products.tsx
+++ b/packages/docs/src/pages/docs/apis/fetch-products.tsx
@@ -252,12 +252,25 @@ function ProductList() {
           ),
           kmp: (
             <CodeBlock language="kotlin">{`import io.github.hyochan.kmpiap.KmpIAP
+import io.github.hyochan.kmpiap.fetchProducts // DSL extension
 
 val kmpIAP = KmpIAP()
 
-val products = kmpIAP.fetchProducts(
-    ProductRequest(skus = listOf("com.app.premium"), type = ProductQueryType.InApp)
-)`}</CodeBlock>
+// 1) Builder pattern — pass a ProductRequest data class directly.
+//    Returns the sealed FetchProductsResult union; unwrap by variant.
+val result = kmpIAP.fetchProducts(
+    ProductRequest(
+        skus = listOf("com.app.premium"),
+        type = ProductQueryType.InApp,
+    )
+)
+
+// 2) DSL pattern — trailing-lambda builder.
+//    Returns List<Product> directly (already unwrapped).
+val products = kmpIAP.fetchProducts {
+    skus = listOf("com.app.premium")
+    type = ProductQueryType.InApp
+}`}</CodeBlock>
           ),
           dart: (
             <CodeBlock language="dart">{`final FetchProductsResult result = await FlutterInappPurchase.instance.fetchProducts(

--- a/packages/docs/src/pages/docs/apis/fetch-products.tsx
+++ b/packages/docs/src/pages/docs/apis/fetch-products.tsx
@@ -43,75 +43,6 @@ function FetchProducts() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>
-        Pass a single{' '}
-        <Link to="/docs/types/product-request">
-          <code>ProductRequest</code>
-        </Link>{' '}
-        object:
-      </p>
-      <ul className="api-params">
-        <li>
-          <code>skus</code>{' '}
-          <em>
-            (required, <code>string[]</code>)
-          </em>{' '}
-          — Product identifiers to fetch.
-        </li>
-        <li>
-          <code>type</code>{' '}
-          <em>
-            (optional, <code>'in-app' | 'subs' | 'all'</code>, default{' '}
-            <code>'in-app'</code>)
-          </em>{' '}
-          — Filter by product kind. Use <code>'all'</code> to query both in one
-          call.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;FetchProductsResult&gt;</code> — sealed union,
-        discriminated by the request <code>type</code>:
-      </p>
-      <ul className="api-params">
-        <li>
-          <Link to="/docs/types/product">
-            <code>Product[]</code>
-          </Link>{' '}
-          <em>
-            (for <code>type: 'in-app'</code>)
-          </em>{' '}
-          — Array of one-time products. Empty array if none of the SKUs exist.
-        </li>
-        <li>
-          <Link to="/docs/types/subscription-product">
-            <code>ProductSubscription[]</code>
-          </Link>{' '}
-          <em>
-            (for <code>type: 'subs'</code>)
-          </em>{' '}
-          — Array of subscription products with offer details.
-        </li>
-        <li>
-          <code>(Product | ProductSubscription)[]</code>{' '}
-          <em>
-            (for <code>type: 'all'</code>)
-          </em>{' '}
-          — Mixed array; use each entry's <code>type</code> field to
-          disambiguate.
-        </li>
-        <li>
-          <code>null</code> <em>(legacy)</em> — Older schema branch retained for
-          backwards compatibility.
-        </li>
-      </ul>
-
       <AnchorLink id="request-apis" level="h2">
         Note about <code>request*</code> APIs
       </AnchorLink>
@@ -194,6 +125,75 @@ func fetch_products(request: ProductRequest) -> Array`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>
+        Pass a single{' '}
+        <Link to="/docs/types/product-request">
+          <code>ProductRequest</code>
+        </Link>{' '}
+        object:
+      </p>
+      <ul className="api-params">
+        <li>
+          <code>skus</code>{' '}
+          <em>
+            (required, <code>string[]</code>)
+          </em>{' '}
+          — Product identifiers to fetch.
+        </li>
+        <li>
+          <code>type</code>{' '}
+          <em>
+            (optional, <code>'in-app' | 'subs' | 'all'</code>, default{' '}
+            <code>'in-app'</code>)
+          </em>{' '}
+          — Filter by product kind. Use <code>'all'</code> to query both in one
+          call.
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;FetchProductsResult&gt;</code> — sealed union,
+        discriminated by the request <code>type</code>:
+      </p>
+      <ul className="api-params">
+        <li>
+          <Link to="/docs/types/product">
+            <code>Product[]</code>
+          </Link>{' '}
+          <em>
+            (for <code>type: 'in-app'</code>)
+          </em>{' '}
+          — Array of one-time products. Empty array if none of the SKUs exist.
+        </li>
+        <li>
+          <Link to="/docs/types/subscription-product">
+            <code>ProductSubscription[]</code>
+          </Link>{' '}
+          <em>
+            (for <code>type: 'subs'</code>)
+          </em>{' '}
+          — Array of subscription products with offer details.
+        </li>
+        <li>
+          <code>(Product | ProductSubscription)[]</code>{' '}
+          <em>
+            (for <code>type: 'all'</code>)
+          </em>{' '}
+          — Mixed array; use each entry's <code>type</code> field to
+          disambiguate.
+        </li>
+        <li>
+          <code>null</code> <em>(legacy)</em> — Older schema branch retained for
+          backwards compatibility.
+        </li>
+      </ul>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/fetch-products.tsx
+++ b/packages/docs/src/pages/docs/apis/fetch-products.tsx
@@ -43,6 +43,48 @@ function FetchProducts() {
         .
       </p>
 
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>params</code>
+            </td>
+            <td>
+              <Link to="/docs/types/product-request">
+                <code>ProductRequest</code>
+              </Link>
+            </td>
+            <td>Yes</td>
+            <td>
+              Object with <code>skus: string[]</code> and optional{' '}
+              <code>type: 'in-app' | 'subs' | 'all'</code> (defaults to{' '}
+              <code>'in-app'</code>).
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;FetchProductsResult&gt;</code> — Sealed union;{' '}
+        <code>Product[]</code> for <code>'in-app'</code>,{' '}
+        <code>ProductSubscription[]</code> for <code>'subs'</code>, mixed for{' '}
+        <code>'all'</code>, or <code>null</code> (legacy schema branch).
+      </p>
+
       <AnchorLink id="request-apis" level="h2">
         Note about <code>request*</code> APIs
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/fetch-products.tsx
+++ b/packages/docs/src/pages/docs/apis/fetch-products.tsx
@@ -53,43 +53,24 @@ function FetchProducts() {
         </Link>{' '}
         object:
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>skus</code>
-            </td>
-            <td>
-              <code>string[]</code>
-            </td>
-            <td>Yes</td>
-            <td>Product identifiers to fetch.</td>
-          </tr>
-          <tr>
-            <td>
-              <code>type</code>
-            </td>
-            <td>
-              <code>'in-app' | 'subs' | 'all'</code>
-            </td>
-            <td>
-              No (default <code>'in-app'</code>)
-            </td>
-            <td>
-              Filter by product kind. Use <code>'all'</code> to query both in
-              one call.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>skus</code>{' '}
+          <em>
+            (required, <code>string[]</code>)
+          </em>{' '}
+          — Product identifiers to fetch.
+        </li>
+        <li>
+          <code>type</code>{' '}
+          <em>
+            (optional, <code>'in-app' | 'subs' | 'all'</code>, default{' '}
+            <code>'in-app'</code>)
+          </em>{' '}
+          — Filter by product kind. Use <code>'all'</code> to query both in one
+          call.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns
@@ -98,60 +79,38 @@ function FetchProducts() {
         <code>Promise&lt;FetchProductsResult&gt;</code> — sealed union,
         discriminated by the request <code>type</code>:
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Variant</th>
-            <th>Returned for</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <Link to="/docs/types/product">
-                <code>Product[]</code>
-              </Link>
-            </td>
-            <td>
-              <code>type: 'in-app'</code>
-            </td>
-            <td>
-              Array of one-time products. Empty array if none of the SKUs exist.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <Link to="/docs/types/subscription-product">
-                <code>ProductSubscription[]</code>
-              </Link>
-            </td>
-            <td>
-              <code>type: 'subs'</code>
-            </td>
-            <td>Array of subscription products with offer details.</td>
-          </tr>
-          <tr>
-            <td>
-              <code>(Product | ProductSubscription)[]</code>
-            </td>
-            <td>
-              <code>type: 'all'</code>
-            </td>
-            <td>
-              Mixed array — use each entry's <code>type</code> field to
-              disambiguate.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>null</code>
-            </td>
-            <td>(legacy)</td>
-            <td>Older schema branch retained for backwards compatibility.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <Link to="/docs/types/product">
+            <code>Product[]</code>
+          </Link>{' '}
+          <em>
+            (for <code>type: 'in-app'</code>)
+          </em>{' '}
+          — Array of one-time products. Empty array if none of the SKUs exist.
+        </li>
+        <li>
+          <Link to="/docs/types/subscription-product">
+            <code>ProductSubscription[]</code>
+          </Link>{' '}
+          <em>
+            (for <code>type: 'subs'</code>)
+          </em>{' '}
+          — Array of subscription products with offer details.
+        </li>
+        <li>
+          <code>(Product | ProductSubscription)[]</code>{' '}
+          <em>
+            (for <code>type: 'all'</code>)
+          </em>{' '}
+          — Mixed array; use each entry's <code>type</code> field to
+          disambiguate.
+        </li>
+        <li>
+          <code>null</code> <em>(legacy)</em> — Older schema branch retained for
+          backwards compatibility.
+        </li>
+      </ul>
 
       <AnchorLink id="request-apis" level="h2">
         Note about <code>request*</code> APIs

--- a/packages/docs/src/pages/docs/apis/fetch-products.tsx
+++ b/packages/docs/src/pages/docs/apis/fetch-products.tsx
@@ -20,8 +20,9 @@ function FetchProducts() {
       <p>Retrieve products or subscriptions from the store by SKU.</p>
       <p>
         <strong>iOS:</strong> Wraps <code>Product.products(for:)</code>{' '}
-        (StoreKit 2). Fetches the localized price/title for each SKU; throws if
-        any SKU is invalid.{' '}
+        (StoreKit 2). Fetches the localized price/title for each SKU. Unknown
+        SKUs are simply omitted from the returned array — only transport
+        failures (network, store unavailable, etc.) throw.{' '}
         <a
           href="https://developer.apple.com/documentation/storekit/product/products(for:)"
           target="_blank"

--- a/packages/docs/src/pages/docs/apis/fetch-products.tsx
+++ b/packages/docs/src/pages/docs/apis/fetch-products.tsx
@@ -18,6 +18,30 @@ function FetchProducts() {
       />
       <h1>fetchProducts</h1>
       <p>Retrieve products or subscriptions from the store by SKU.</p>
+      <p>
+        <strong>iOS:</strong> Wraps <code>Product.products(for:)</code>{' '}
+        (StoreKit 2). Fetches the localized price/title for each SKU; throws if
+        any SKU is invalid.{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/product/products(for:)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        . <strong>Android:</strong> Calls{' '}
+        <code>BillingClient.queryProductDetailsAsync</code> with the right{' '}
+        <code>ProductType</code> (INAPP/SUBS) per request. Unknown SKUs return
+        an empty list, not an error.{' '}
+        <a
+          href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryProductDetailsAsync(com.android.billingclient.api.QueryProductDetailsParams,com.android.billingclient.api.ProductDetailsResponseListener)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google docs
+        </a>
+        .
+      </p>
 
       <AnchorLink id="request-apis" level="h2">
         Note about <code>request*</code> APIs

--- a/packages/docs/src/pages/docs/apis/fetch-products.tsx
+++ b/packages/docs/src/pages/docs/apis/fetch-products.tsx
@@ -46,10 +46,17 @@ function FetchProducts() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
+      <p>
+        Pass a single{' '}
+        <Link to="/docs/types/product-request">
+          <code>ProductRequest</code>
+        </Link>{' '}
+        object:
+      </p>
       <table className="doc-table">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Field</th>
             <th>Type</th>
             <th>Required</th>
             <th>Description</th>
@@ -58,18 +65,27 @@ function FetchProducts() {
         <tbody>
           <tr>
             <td>
-              <code>params</code>
+              <code>skus</code>
             </td>
             <td>
-              <Link to="/docs/types/product-request">
-                <code>ProductRequest</code>
-              </Link>
+              <code>string[]</code>
             </td>
             <td>Yes</td>
+            <td>Product identifiers to fetch.</td>
+          </tr>
+          <tr>
             <td>
-              Object with <code>skus: string[]</code> and optional{' '}
-              <code>type: 'in-app' | 'subs' | 'all'</code> (defaults to{' '}
-              <code>'in-app'</code>).
+              <code>type</code>
+            </td>
+            <td>
+              <code>'in-app' | 'subs' | 'all'</code>
+            </td>
+            <td>
+              No (default <code>'in-app'</code>)
+            </td>
+            <td>
+              Filter by product kind. Use <code>'all'</code> to query both in
+              one call.
             </td>
           </tr>
         </tbody>
@@ -79,11 +95,63 @@ function FetchProducts() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;FetchProductsResult&gt;</code> — Sealed union;{' '}
-        <code>Product[]</code> for <code>'in-app'</code>,{' '}
-        <code>ProductSubscription[]</code> for <code>'subs'</code>, mixed for{' '}
-        <code>'all'</code>, or <code>null</code> (legacy schema branch).
+        <code>Promise&lt;FetchProductsResult&gt;</code> — sealed union,
+        discriminated by the request <code>type</code>:
       </p>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Variant</th>
+            <th>Returned for</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <Link to="/docs/types/product">
+                <code>Product[]</code>
+              </Link>
+            </td>
+            <td>
+              <code>type: 'in-app'</code>
+            </td>
+            <td>
+              Array of one-time products. Empty array if none of the SKUs exist.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <Link to="/docs/types/subscription-product">
+                <code>ProductSubscription[]</code>
+              </Link>
+            </td>
+            <td>
+              <code>type: 'subs'</code>
+            </td>
+            <td>Array of subscription products with offer details.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>(Product | ProductSubscription)[]</code>
+            </td>
+            <td>
+              <code>type: 'all'</code>
+            </td>
+            <td>
+              Mixed array — use each entry's <code>type</code> field to
+              disambiguate.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>null</code>
+            </td>
+            <td>(legacy)</td>
+            <td>Older schema branch retained for backwards compatibility.</td>
+          </tr>
+        </tbody>
+      </table>
 
       <AnchorLink id="request-apis" level="h2">
         Note about <code>request*</code> APIs

--- a/packages/docs/src/pages/docs/apis/finish-transaction.tsx
+++ b/packages/docs/src/pages/docs/apis/finish-transaction.tsx
@@ -50,51 +50,30 @@ function FinishTransaction() {
         Parameters
       </AnchorLink>
       <p>The transaction to close, plus an optional consumable flag:</p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>purchase</code>
-            </td>
-            <td>
-              <Link to="/docs/types/purchase">
-                <code>Purchase</code>
-              </Link>
-            </td>
-            <td>Yes</td>
-            <td>
-              The purchase / transaction to finalize. Must come from{' '}
-              <code>requestPurchase</code> or <code>getAvailablePurchases</code>
-              .
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>isConsumable</code>
-            </td>
-            <td>
-              <code>boolean</code>
-            </td>
-            <td>
-              No (default <code>false</code>)
-            </td>
-            <td>
-              <strong>Android.</strong> <code>true</code> consumes the token
-              (re-buyable like coins); <code>false</code> just acknowledges
-              (non-consumables, subscriptions). iOS always calls{' '}
-              <code>Transaction.finish()</code> regardless.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>purchase</code>{' '}
+          <em>
+            (required,{' '}
+            <Link to="/docs/types/purchase">
+              <code>Purchase</code>
+            </Link>
+            )
+          </em>{' '}
+          — The purchase / transaction to finalize. Must come from{' '}
+          <code>requestPurchase</code> or <code>getAvailablePurchases</code>.
+        </li>
+        <li>
+          <code>isConsumable</code>{' '}
+          <em>
+            (optional, <code>boolean</code>, default <code>false</code>)
+          </em>{' '}
+          — <strong>Android.</strong> <code>true</code> consumes the token
+          (re-buyable like coins); <code>false</code> just acknowledges
+          (non-consumables, subscriptions). iOS always calls{' '}
+          <code>Transaction.finish()</code> regardless.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/finish-transaction.tsx
+++ b/packages/docs/src/pages/docs/apis/finish-transaction.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -43,6 +45,61 @@ function FinishTransaction() {
         </a>
         .
       </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>purchase</code>
+            </td>
+            <td>
+              <Link to="/docs/types/purchase">
+                <code>Purchase</code>
+              </Link>
+            </td>
+            <td>Yes</td>
+            <td>The purchase to finalize.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>isConsumable</code>
+            </td>
+            <td>
+              <code>boolean</code>
+            </td>
+            <td>No</td>
+            <td>
+              Defaults to <code>false</code>. Pass <code>true</code> for
+              consumables (re-buyable like coins) so Android consumes the token;
+              non-consumables and subscriptions just get acknowledged.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;void&gt;</code> — Resolves once the platform finalizes
+        the transaction.
+      </p>
+
+      <AnchorLink id="throws" level="h2">
+        Throws
+      </AnchorLink>
+      <p>When the platform finalize call fails.</p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/finish-transaction.tsx
+++ b/packages/docs/src/pages/docs/apis/finish-transaction.tsx
@@ -20,8 +20,8 @@ function FinishTransaction() {
         purchase to remove it from the queue.
       </p>
       <p>
-        <strong>iOS:</strong> Calls <code>Transaction.finish()</code>. Until
-        you do, the same transaction replays through{' '}
+        <strong>iOS:</strong> Calls <code>Transaction.finish()</code>. Until you
+        do, the same transaction replays through{' '}
         <code>Transaction.updates</code> on every app launch.{' '}
         <a
           href="https://developer.apple.com/documentation/storekit/transaction/finish()"

--- a/packages/docs/src/pages/docs/apis/finish-transaction.tsx
+++ b/packages/docs/src/pages/docs/apis/finish-transaction.tsx
@@ -49,10 +49,11 @@ function FinishTransaction() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
+      <p>The transaction to close, plus an optional consumable flag:</p>
       <table className="doc-table">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Field</th>
             <th>Type</th>
             <th>Required</th>
             <th>Description</th>
@@ -69,7 +70,11 @@ function FinishTransaction() {
               </Link>
             </td>
             <td>Yes</td>
-            <td>The purchase to finalize.</td>
+            <td>
+              The purchase / transaction to finalize. Must come from{' '}
+              <code>requestPurchase</code> or <code>getAvailablePurchases</code>
+              .
+            </td>
           </tr>
           <tr>
             <td>
@@ -78,11 +83,14 @@ function FinishTransaction() {
             <td>
               <code>boolean</code>
             </td>
-            <td>No</td>
             <td>
-              Defaults to <code>false</code>. Pass <code>true</code> for
-              consumables (re-buyable like coins) so Android consumes the token;
-              non-consumables and subscriptions just get acknowledged.
+              No (default <code>false</code>)
+            </td>
+            <td>
+              <strong>Android.</strong> <code>true</code> consumes the token
+              (re-buyable like coins); <code>false</code> just acknowledges
+              (non-consumables, subscriptions). iOS always calls{' '}
+              <code>Transaction.finish()</code> regardless.
             </td>
           </tr>
         </tbody>

--- a/packages/docs/src/pages/docs/apis/finish-transaction.tsx
+++ b/packages/docs/src/pages/docs/apis/finish-transaction.tsx
@@ -19,6 +19,30 @@ function FinishTransaction() {
         Complete a purchase transaction. Must be called after verifying the
         purchase to remove it from the queue.
       </p>
+      <p>
+        <strong>iOS:</strong> Calls <code>Transaction.finish()</code>. Until
+        you do, the same transaction replays through{' '}
+        <code>Transaction.updates</code> on every app launch.{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/finish()"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        . <strong>Android:</strong> Acknowledges (
+        <code>acknowledgePurchase</code>) for non-consumables/subscriptions or
+        consumes (<code>consumeAsync</code>) for consumables. Google
+        auto-refunds within 3 days if neither runs.{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/integrate#process"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google docs
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/finish-transaction.tsx
+++ b/packages/docs/src/pages/docs/apis/finish-transaction.tsx
@@ -46,6 +46,35 @@ function FinishTransaction() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          typescript: (
+            <CodeBlock language="typescript">{`finishTransaction(args: MutationFinishTransactionArgs): Promise<void>
+
+interface MutationFinishTransactionArgs {
+  purchase: Purchase;
+  isConsumable?: boolean | null;
+}`}</CodeBlock>
+          ),
+          swift: (
+            <CodeBlock language="swift">{`func finishTransaction(_ purchase: Purchase, isConsumable: Bool = false) async throws`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun finishTransaction(purchase: Purchase, isConsumable: Boolean = false)`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun finishTransaction(purchase: Purchase, isConsumable: Boolean = false)`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<void> finishTransaction(Purchase purchase, {bool isConsumable = false});`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func finish_transaction(purchase: Purchase, is_consumable: bool = false) -> void`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -87,35 +116,6 @@ function FinishTransaction() {
         Throws
       </AnchorLink>
       <p>When the platform finalize call fails.</p>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          typescript: (
-            <CodeBlock language="typescript">{`finishTransaction(args: MutationFinishTransactionArgs): Promise<void>
-
-interface MutationFinishTransactionArgs {
-  purchase: Purchase;
-  isConsumable?: boolean | null;
-}`}</CodeBlock>
-          ),
-          swift: (
-            <CodeBlock language="swift">{`func finishTransaction(_ purchase: Purchase, isConsumable: Bool = false) async throws`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`suspend fun finishTransaction(purchase: Purchase, isConsumable: Boolean = false)`}</CodeBlock>
-          ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun finishTransaction(purchase: Purchase, isConsumable: Boolean = false)`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<void> finishTransaction(Purchase purchase, {bool isConsumable = false});`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func finish_transaction(purchase: Purchase, is_consumable: bool = false) -> void`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
@@ -49,32 +49,17 @@ function GetActiveSubscriptions() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>subscriptionIds</code>
-            </td>
-            <td>
-              <code>string[]</code>
-            </td>
-            <td>No</td>
-            <td>
-              If provided, the result is filtered to these SKUs. Omit / pass{' '}
-              <code>null</code> to return every active subscription the store
-              knows about.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>subscriptionIds</code>{' '}
+          <em>
+            (optional, <code>string[]</code>)
+          </em>{' '}
+          — If provided, the result is filtered to these SKUs. Omit / pass{' '}
+          <code>null</code> to return every active subscription the store knows
+          about.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns
@@ -85,93 +70,60 @@ function GetActiveSubscriptions() {
         </Link>{' '}
         — one entry per active subscription. Each row carries:
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>productId</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Subscription product identifier.</td>
-          </tr>
-          <tr>
-            <td>
-              <code>basePlanId</code>
-            </td>
-            <td>
-              <code>string?</code>
-            </td>
-            <td>
-              <strong>Android.</strong> Base plan identifier when applicable.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>isActive</code>
-            </td>
-            <td>
-              <code>boolean</code>
-            </td>
-            <td>
-              <code>true</code> while the subscription is in a paying or grace
-              state.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>willExpireSoon</code>
-            </td>
-            <td>
-              <code>boolean?</code>
-            </td>
-            <td>Hint that renewal is imminent (cancelled or grace period).</td>
-          </tr>
-          <tr>
-            <td>
-              <code>expirationDateIOS</code>
-            </td>
-            <td>
-              <code>number?</code>
-            </td>
-            <td>
-              <strong>iOS.</strong> Epoch ms expiration timestamp.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>environmentIOS</code>
-            </td>
-            <td>
-              <code>string?</code>
-            </td>
-            <td>
-              <strong>iOS.</strong> <code>"Sandbox"</code> or{' '}
-              <code>"Production"</code>.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>autoRenewingAndroid</code>
-            </td>
-            <td>
-              <code>boolean?</code>
-            </td>
-            <td>
-              <strong>Android.</strong> Whether Play will auto-renew at the next
-              cycle.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>productId</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Subscription product identifier.
+        </li>
+        <li>
+          <code>basePlanId</code>{' '}
+          <em>
+            (optional, <code>string</code>)
+          </em>{' '}
+          — <strong>Android.</strong> Base plan identifier when applicable.
+        </li>
+        <li>
+          <code>isActive</code>{' '}
+          <em>
+            (required, <code>boolean</code>)
+          </em>{' '}
+          — <code>true</code> while the subscription is in a paying or grace
+          state.
+        </li>
+        <li>
+          <code>willExpireSoon</code>{' '}
+          <em>
+            (optional, <code>boolean</code>)
+          </em>{' '}
+          — Hint that renewal is imminent (cancelled or grace period).
+        </li>
+        <li>
+          <code>expirationDateIOS</code>{' '}
+          <em>
+            (optional, <code>number</code>)
+          </em>{' '}
+          — <strong>iOS.</strong> Epoch ms expiration timestamp.
+        </li>
+        <li>
+          <code>environmentIOS</code>{' '}
+          <em>
+            (optional, <code>string</code>)
+          </em>{' '}
+          — <strong>iOS.</strong> <code>"Sandbox"</code> or{' '}
+          <code>"Production"</code>.
+        </li>
+        <li>
+          <code>autoRenewingAndroid</code>{' '}
+          <em>
+            (optional, <code>boolean</code>)
+          </em>{' '}
+          — <strong>Android.</strong> Whether Play will auto-renew at the next
+          cycle.
+        </li>
+      </ul>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
@@ -67,7 +67,11 @@ function GetActiveSubscriptions() {
               <code>string[]</code>
             </td>
             <td>No</td>
-            <td>When provided, narrows the result to these SKUs only.</td>
+            <td>
+              If provided, the result is filtered to these SKUs. Omit / pass{' '}
+              <code>null</code> to return every active subscription the store
+              knows about.
+            </td>
           </tr>
         </tbody>
       </table>
@@ -79,9 +83,95 @@ function GetActiveSubscriptions() {
         <Link to="/docs/types/active-subscription">
           <code>Promise&lt;ActiveSubscription[]&gt;</code>
         </Link>{' '}
-        — Active subscription details (see <code>ActiveSubscription</code>{' '}
-        type).
+        — one entry per active subscription. Each row carries:
       </p>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>productId</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Subscription product identifier.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>basePlanId</code>
+            </td>
+            <td>
+              <code>string?</code>
+            </td>
+            <td>
+              <strong>Android.</strong> Base plan identifier when applicable.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>isActive</code>
+            </td>
+            <td>
+              <code>boolean</code>
+            </td>
+            <td>
+              <code>true</code> while the subscription is in a paying or grace
+              state.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>willExpireSoon</code>
+            </td>
+            <td>
+              <code>boolean?</code>
+            </td>
+            <td>Hint that renewal is imminent (cancelled or grace period).</td>
+          </tr>
+          <tr>
+            <td>
+              <code>expirationDateIOS</code>
+            </td>
+            <td>
+              <code>number?</code>
+            </td>
+            <td>
+              <strong>iOS.</strong> Epoch ms expiration timestamp.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>environmentIOS</code>
+            </td>
+            <td>
+              <code>string?</code>
+            </td>
+            <td>
+              <strong>iOS.</strong> <code>"Sandbox"</code> or{' '}
+              <code>"Production"</code>.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>autoRenewingAndroid</code>
+            </td>
+            <td>
+              <code>boolean?</code>
+            </td>
+            <td>
+              <strong>Android.</strong> Whether Play will auto-renew at the next
+              cycle.
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
@@ -32,8 +32,9 @@ function GetActiveSubscriptions() {
           Apple docs
         </a>
         . <strong>Android:</strong> Calls <code>queryPurchasesAsync(SUBS)</code>{' '}
-        and treats <code>purchaseState == PURCHASED &amp;&amp; autoRenewing</code>{' '}
-        as active.{' '}
+        and treats{' '}
+        <code>purchaseState == PURCHASED &amp;&amp; autoRenewing</code> as
+        active.{' '}
         <a
           href="https://developer.android.com/google/play/billing/subscriptions#lifecycle"
           target="_blank"

--- a/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -43,6 +44,43 @@ function GetActiveSubscriptions() {
           Google docs
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>subscriptionIds</code>
+            </td>
+            <td>
+              <code>string[]</code>
+            </td>
+            <td>No</td>
+            <td>When provided, narrows the result to these SKUs only.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <Link to="/docs/types/active-subscription">
+          <code>Promise&lt;ActiveSubscription[]&gt;</code>
+        </Link>{' '}
+        — Active subscription details (see <code>ActiveSubscription</code>{' '}
+        type).
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
@@ -46,6 +46,30 @@ function GetActiveSubscriptions() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          typescript: (
+            <CodeBlock language="typescript">{`getActiveSubscriptions(subscriptionIds?: string[]): Promise<ActiveSubscription[]>`}</CodeBlock>
+          ),
+          swift: (
+            <CodeBlock language="swift">{`func getActiveSubscriptions(subscriptionIds: [String]? = nil) async throws -> [ActiveSubscription]`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun getActiveSubscriptions(subscriptionIds: List<String>? = null): List<ActiveSubscription>`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun getActiveSubscriptions(subscriptionIds: List<String>? = null): List<ActiveSubscription>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<List<ActiveSubscription>> getActiveSubscriptions({List<String>? subscriptionIds});`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func get_active_subscriptions(subscription_ids: Array[String] = []) -> Array[ActiveSubscription]`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -124,30 +148,6 @@ function GetActiveSubscriptions() {
           cycle.
         </li>
       </ul>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          typescript: (
-            <CodeBlock language="typescript">{`getActiveSubscriptions(subscriptionIds?: string[]): Promise<ActiveSubscription[]>`}</CodeBlock>
-          ),
-          swift: (
-            <CodeBlock language="swift">{`func getActiveSubscriptions(subscriptionIds: [String]? = nil) async throws -> [ActiveSubscription]`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`suspend fun getActiveSubscriptions(subscriptionIds: List<String>? = null): List<ActiveSubscription>`}</CodeBlock>
-          ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun getActiveSubscriptions(subscriptionIds: List<String>? = null): List<ActiveSubscription>`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<List<ActiveSubscription>> getActiveSubscriptions({List<String>? subscriptionIds});`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func get_active_subscriptions(subscription_ids: Array[String] = []) -> Array[ActiveSubscription]`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
@@ -19,6 +19,30 @@ function GetActiveSubscriptions() {
       <p>
         Get all active subscriptions with detailed renewal status information.
       </p>
+      <p>
+        <strong>iOS:</strong> Iterates{' '}
+        <code>Transaction.currentEntitlements</code> and filters to subscription
+        product types; checks <code>expirationDate</code> and{' '}
+        <code>revocationDate</code>.{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/product/subscriptioninfo"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        . <strong>Android:</strong> Calls <code>queryPurchasesAsync(SUBS)</code>{' '}
+        and treats <code>purchaseState == PURCHASED &amp;&amp; autoRenewing</code>{' '}
+        as active.{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/subscriptions#lifecycle"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google docs
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -58,64 +58,33 @@ function GetAvailablePurchases() {
         </Link>
         :
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>alsoPublishToEventListenerIOS</code>
-            </td>
-            <td>
-              <code>boolean</code>
-            </td>
-            <td>
-              No (default <code>false</code>)
-            </td>
-            <td>
-              <strong>iOS.</strong> Re-emit results on{' '}
-              <code>purchaseUpdatedListener</code>.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>onlyIncludeActiveItemsIOS</code>
-            </td>
-            <td>
-              <code>boolean</code>
-            </td>
-            <td>
-              No (default <code>false</code>)
-            </td>
-            <td>
-              <strong>iOS.</strong> Switch from <code>Transaction.all</code>{' '}
-              (full history) to <code>Transaction.currentEntitlements</code>{' '}
-              (active only).
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>includeSuspendedAndroid</code>
-            </td>
-            <td>
-              <code>boolean</code>
-            </td>
-            <td>
-              No (default <code>false</code>)
-            </td>
-            <td>
-              <strong>Android.</strong> Include subscriptions in a paused/grace
-              state.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>alsoPublishToEventListenerIOS</code>{' '}
+          <em>
+            (optional, <code>boolean</code>, default <code>false</code>)
+          </em>{' '}
+          — <strong>iOS.</strong> Re-emit results on{' '}
+          <code>purchaseUpdatedListener</code>.
+        </li>
+        <li>
+          <code>onlyIncludeActiveItemsIOS</code>{' '}
+          <em>
+            (optional, <code>boolean</code>, default <code>false</code>)
+          </em>{' '}
+          — <strong>iOS.</strong> Switch from <code>Transaction.all</code> (full
+          history) to <code>Transaction.currentEntitlements</code> (active
+          only).
+        </li>
+        <li>
+          <code>includeSuspendedAndroid</code>{' '}
+          <em>
+            (optional, <code>boolean</code>, default <code>false</code>)
+          </em>{' '}
+          — <strong>Android.</strong> Include subscriptions in a paused/grace
+          state.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -45,6 +46,47 @@ function GetAvailablePurchases() {
           Google docs
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>options</code>
+            </td>
+            <td>
+              <Link to="/docs/types/purchase#purchase-options">
+                <code>PurchaseOptions</code>
+              </Link>
+            </td>
+            <td>No</td>
+            <td>
+              Platform-specific filters (
+              <code>alsoPublishToEventListenerIOS</code>,{' '}
+              <code>onlyIncludeActiveItemsIOS</code>,{' '}
+              <code>includeSuspendedAndroid</code>).
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;Purchase[]&gt;</code> — Owned/available purchases held
+        by the store.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -17,15 +17,17 @@ function GetAvailablePurchases() {
       />
       <h1>getAvailablePurchases</h1>
       <p>
-        Get all available (unfinished) purchases for the current user. Use this
-        to restore purchases or check for pending transactions.
+        Get the user's purchases held by the store — owned non-consumables,
+        active subscriptions, and any pending transactions not yet finished.
       </p>
       <p>
-        <strong>iOS:</strong> Iterates{' '}
-        <code>Transaction.currentEntitlements</code> (StoreKit 2). Excludes
-        revoked / refunded transactions by default.{' '}
+        <strong>iOS:</strong> By default iterates <code>Transaction.all</code>{' '}
+        (the full StoreKit 2 history, including refunded / revoked entries).
+        Pass <code>onlyIncludeActiveItemsIOS = true</code> to switch to{' '}
+        <code>Transaction.currentEntitlements</code>, which narrows the result
+        to active non-consumables and live subscriptions.{' '}
         <a
-          href="https://developer.apple.com/documentation/storekit/transaction/currententitlements"
+          href="https://developer.apple.com/documentation/storekit/transaction/all"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -48,6 +48,35 @@ function GetAvailablePurchases() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          typescript: (
+            <CodeBlock language="typescript">{`getAvailablePurchases(options?: PurchaseOptions): Promise<Purchase[]>
+
+interface PurchaseOptions {
+  alsoPublishToEventListenerIOS?: boolean;
+  onlyIncludeActiveItemsIOS?: boolean;
+}`}</CodeBlock>
+          ),
+          swift: (
+            <CodeBlock language="swift">{`func getAvailablePurchases(options: PurchaseOptions? = nil) async throws -> [Purchase]`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun getAvailablePurchases(): List<Purchase>`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun getAvailablePurchases(): List<Purchase>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<List<Purchase>> getAvailablePurchases({PurchaseOptions? options});`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func get_available_purchases(options: PurchaseOptions = null) -> Array[Purchase]`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -95,35 +124,6 @@ function GetAvailablePurchases() {
         </Link>{' '}
         — owned/available purchases held by the store.
       </p>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          typescript: (
-            <CodeBlock language="typescript">{`getAvailablePurchases(options?: PurchaseOptions): Promise<Purchase[]>
-
-interface PurchaseOptions {
-  alsoPublishToEventListenerIOS?: boolean;
-  onlyIncludeActiveItemsIOS?: boolean;
-}`}</CodeBlock>
-          ),
-          swift: (
-            <CodeBlock language="swift">{`func getAvailablePurchases(options: PurchaseOptions? = nil) async throws -> [Purchase]`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`suspend fun getAvailablePurchases(): List<Purchase>`}</CodeBlock>
-          ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun getAvailablePurchases(): List<Purchase>`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<List<Purchase>> getAvailablePurchases({PurchaseOptions? options});`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func get_available_purchases(options: PurchaseOptions = null) -> Array[Purchase]`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -20,6 +20,30 @@ function GetAvailablePurchases() {
         Get all available (unfinished) purchases for the current user. Use this
         to restore purchases or check for pending transactions.
       </p>
+      <p>
+        <strong>iOS:</strong> Iterates{' '}
+        <code>Transaction.currentEntitlements</code> (StoreKit 2). Excludes
+        revoked / refunded transactions by default.{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/currententitlements"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        . <strong>Android:</strong> Calls{' '}
+        <code>BillingClient.queryPurchasesAsync</code> for both{' '}
+        <code>INAPP</code> and <code>SUBS</code> and merges. Only returns
+        purchases still owned by the user.{' '}
+        <a
+          href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryPurchasesAsync(com.android.billingclient.api.QueryPurchasesParams,com.android.billingclient.api.PurchasesResponseListener)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google docs
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -110,8 +110,11 @@ interface PurchaseOptions {
           <em>
             (optional, <code>boolean</code>, default <code>false</code>)
           </em>{' '}
-          — <strong>Android.</strong> Include subscriptions in a paused/grace
-          state.
+          — <strong>Android (Billing 8.1+).</strong> Include suspended
+          subscriptions in the result. Suspended entries (
+          <code>isSuspendedAndroid === true</code>) should NOT grant
+          entitlements — direct the user to the subscription center to resolve
+          payment first.
         </li>
       </ul>
 

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -51,10 +51,17 @@ function GetAvailablePurchases() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
+      <p>
+        Pass an optional{' '}
+        <Link to="/docs/types/purchase#purchase-options">
+          <code>PurchaseOptions</code>
+        </Link>
+        :
+      </p>
       <table className="doc-table">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Field</th>
             <th>Type</th>
             <th>Required</th>
             <th>Description</th>
@@ -63,19 +70,48 @@ function GetAvailablePurchases() {
         <tbody>
           <tr>
             <td>
-              <code>options</code>
+              <code>alsoPublishToEventListenerIOS</code>
             </td>
             <td>
-              <Link to="/docs/types/purchase#purchase-options">
-                <code>PurchaseOptions</code>
-              </Link>
+              <code>boolean</code>
             </td>
-            <td>No</td>
             <td>
-              Platform-specific filters (
-              <code>alsoPublishToEventListenerIOS</code>,{' '}
-              <code>onlyIncludeActiveItemsIOS</code>,{' '}
-              <code>includeSuspendedAndroid</code>).
+              No (default <code>false</code>)
+            </td>
+            <td>
+              <strong>iOS.</strong> Re-emit results on{' '}
+              <code>purchaseUpdatedListener</code>.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>onlyIncludeActiveItemsIOS</code>
+            </td>
+            <td>
+              <code>boolean</code>
+            </td>
+            <td>
+              No (default <code>false</code>)
+            </td>
+            <td>
+              <strong>iOS.</strong> Switch from <code>Transaction.all</code>{' '}
+              (full history) to <code>Transaction.currentEntitlements</code>{' '}
+              (active only).
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>includeSuspendedAndroid</code>
+            </td>
+            <td>
+              <code>boolean</code>
+            </td>
+            <td>
+              No (default <code>false</code>)
+            </td>
+            <td>
+              <strong>Android.</strong> Include subscriptions in a paused/grace
+              state.
             </td>
           </tr>
         </tbody>
@@ -85,8 +121,10 @@ function GetAvailablePurchases() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;Purchase[]&gt;</code> — Owned/available purchases held
-        by the store.
+        <Link to="/docs/types/purchase">
+          <code>Promise&lt;Purchase[]&gt;</code>
+        </Link>{' '}
+        — owned/available purchases held by the store.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/get-storefront.tsx
+++ b/packages/docs/src/pages/docs/apis/get-storefront.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -38,6 +39,19 @@ function GetStorefront() {
           Google docs
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string&gt;</code> — ISO 3166-1 alpha-2 country code of
+        the user's storefront.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/get-storefront.tsx
+++ b/packages/docs/src/pages/docs/apis/get-storefront.tsx
@@ -51,7 +51,9 @@ function GetStorefront() {
       </AnchorLink>
       <p>
         <code>Promise&lt;string&gt;</code> — ISO 3166-1 alpha-2 country code of
-        the user's storefront.
+        the user's storefront (e.g. <code>"US"</code>, <code>"KR"</code>).
+        Returns the App Store / Play Store account region, NOT the device
+        locale.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/get-storefront.tsx
+++ b/packages/docs/src/pages/docs/apis/get-storefront.tsx
@@ -122,7 +122,6 @@ function StorefrontBadge() {
           ),
         }}
       </LanguageTabs>
-
     </div>
   );
 }

--- a/packages/docs/src/pages/docs/apis/get-storefront.tsx
+++ b/packages/docs/src/pages/docs/apis/get-storefront.tsx
@@ -41,11 +41,6 @@ function GetStorefront() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/get-storefront.tsx
+++ b/packages/docs/src/pages/docs/apis/get-storefront.tsx
@@ -41,16 +41,6 @@ function GetStorefront() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;string&gt;</code> — ISO 3166-1 alpha-2 country code of
-        the user's storefront (e.g. <code>"US"</code>, <code>"KR"</code>).
-        Returns the App Store / Play Store account region, NOT the device
-        locale.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -74,6 +64,16 @@ function GetStorefront() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string&gt;</code> — ISO 3166-1 alpha-2 country code of
+        the user's storefront (e.g. <code>"US"</code>, <code>"KR"</code>).
+        Returns the App Store / Play Store account region, NOT the device
+        locale.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/get-storefront.tsx
+++ b/packages/docs/src/pages/docs/apis/get-storefront.tsx
@@ -70,9 +70,9 @@ function GetStorefront() {
       </AnchorLink>
       <p>
         <code>Promise&lt;string&gt;</code> — ISO 3166-1 alpha-2 country code of
-        the user's storefront (e.g. <code>"US"</code>, <code>"KR"</code>).
-        Returns the App Store / Play Store account region, NOT the device
-        locale.
+        the user's storefront (e.g. <code>"US"</code>, <code>"KR"</code>), or an
+        empty string when the storefront can't be determined. Returns the App
+        Store / Play Store account region, NOT the device locale.
       </p>
 
       <h2>Example</h2>
@@ -123,10 +123,6 @@ function StorefrontBadge() {
         }}
       </LanguageTabs>
 
-      <p>
-        Returns the ISO 3166-1 alpha-2 country code. Returns an empty string
-        when the storefront cannot be determined.
-      </p>
     </div>
   );
 }

--- a/packages/docs/src/pages/docs/apis/get-storefront.tsx
+++ b/packages/docs/src/pages/docs/apis/get-storefront.tsx
@@ -16,6 +16,29 @@ function GetStorefront() {
       />
       <h1>getStorefront</h1>
       <p>Get the storefront country code for the active user.</p>
+      <p>
+        <strong>iOS:</strong> Reads <code>Storefront.current?.countryCode</code>{' '}
+        (StoreKit 2). Returns the user's App Store storefront, not the device
+        locale.{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/storefront"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        . <strong>Android:</strong> Reads <code>BillingConfig.countryCode</code>{' '}
+        from <code>BillingClient.getBillingConfigAsync</code>. Reflects the Play
+        Store account region, not the SIM/device locale.{' '}
+        <a
+          href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#getBillingConfigAsync(com.android.billingclient.api.GetBillingConfigParams,com.android.billingclient.api.BillingConfigResponseListener)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google docs
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -38,6 +39,40 @@ function HasActiveSubscriptions() {
           Google docs
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>subscriptionIds</code>
+            </td>
+            <td>
+              <code>string[]</code>
+            </td>
+            <td>No</td>
+            <td>When provided, checks only these SKUs.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if any
+        (matching) subscription is active.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
@@ -62,7 +63,10 @@ function HasActiveSubscriptions() {
               <code>string[]</code>
             </td>
             <td>No</td>
-            <td>When provided, checks only these SKUs.</td>
+            <td>
+              If provided, only these SKUs are checked. Omit to ask "any active
+              subscription at all?".
+            </td>
           </tr>
         </tbody>
       </table>
@@ -71,8 +75,12 @@ function HasActiveSubscriptions() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if any
-        (matching) subscription is active.
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> when at least
+        one (matching) subscription is in an active state. Convenience over{' '}
+        <Link to="/docs/apis/get-active-subscriptions">
+          <code>getActiveSubscriptions</code>
+        </Link>{' '}
+        when you only need a yes/no answer.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -42,6 +42,30 @@ function HasActiveSubscriptions() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          typescript: (
+            <CodeBlock language="typescript">{`hasActiveSubscriptions(subscriptionIds?: string[]): Promise<boolean>`}</CodeBlock>
+          ),
+          swift: (
+            <CodeBlock language="swift">{`func hasActiveSubscriptions(subscriptionIds: [String]? = nil) async throws -> Bool`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun hasActiveSubscriptions(subscriptionIds: List<String>? = null): Boolean`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun hasActiveSubscriptions(subscriptionIds: List<String>? = null): Boolean`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> hasActiveSubscriptions({List<String>? subscriptionIds});`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func has_active_subscriptions(subscription_ids: Array[String] = []) -> bool`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -67,30 +91,6 @@ function HasActiveSubscriptions() {
         </Link>{' '}
         when you only need a yes/no answer.
       </p>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          typescript: (
-            <CodeBlock language="typescript">{`hasActiveSubscriptions(subscriptionIds?: string[]): Promise<boolean>`}</CodeBlock>
-          ),
-          swift: (
-            <CodeBlock language="swift">{`func hasActiveSubscriptions(subscriptionIds: [String]? = nil) async throws -> Bool`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`suspend fun hasActiveSubscriptions(subscriptionIds: List<String>? = null): Boolean`}</CodeBlock>
-          ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun hasActiveSubscriptions(subscriptionIds: List<String>? = null): Boolean`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<bool> hasActiveSubscriptions({List<String>? subscriptionIds});`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func has_active_subscriptions(subscription_ids: Array[String] = []) -> bool`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -45,31 +45,16 @@ function HasActiveSubscriptions() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>subscriptionIds</code>
-            </td>
-            <td>
-              <code>string[]</code>
-            </td>
-            <td>No</td>
-            <td>
-              If provided, only these SKUs are checked. Omit to ask "any active
-              subscription at all?".
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>subscriptionIds</code>{' '}
+          <em>
+            (optional, <code>string[]</code>)
+          </em>{' '}
+          — If provided, only these SKUs are checked. Omit to ask "any active
+          subscription at all?".
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -16,6 +16,29 @@ function HasActiveSubscriptions() {
       />
       <h1>hasActiveSubscriptions</h1>
       <p>Quick check if the user has any active subscriptions.</p>
+      <p>
+        <strong>iOS:</strong> Convenience over{' '}
+        <code>getActiveSubscriptions</code> — returns <code>true</code> if the
+        iterator yields at least one non-expired subscription.{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/currententitlements"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        . <strong>Android:</strong> Convenience over{' '}
+        <code>queryPurchasesAsync(SUBS)</code> — returns <code>true</code> if
+        any subscription is in <code>PURCHASED</code> state.{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/subscriptions#lifecycle"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google docs
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/index.tsx
+++ b/packages/docs/src/pages/docs/apis/index.tsx
@@ -330,8 +330,9 @@ function APIsIndex() {
                 </Link>
               </td>
               <td>
-                Verify via a managed provider (IAPKit, Apple, Google, Horizon)
-                without standing up your own server.
+                Verify via a managed provider without standing up your own
+                server. The <code>PurchaseVerificationProvider</code> enum
+                currently exposes only IAPKit.
               </td>
             </tr>
             <tr>

--- a/packages/docs/src/pages/docs/apis/init-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/init-connection.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -44,6 +45,50 @@ function InitConnection() {
         </a>
         .
       </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>config</code>
+            </td>
+            <td>
+              <Link to="/docs/types/alternative-billing-types#init-connection-config">
+                <code>InitConnectionConfig</code>
+              </Link>
+            </td>
+            <td>No</td>
+            <td>
+              Connection config (e.g. <code>enableBillingProgramAndroid</code>{' '}
+              for Play Billing 8.2.0+; iOS ignores Android-specific fields).
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the
+        platform billing client is connected.
+      </p>
+
+      <AnchorLink id="throws" level="h2">
+        Throws
+      </AnchorLink>
+      <p>When the platform billing client fails to initialize.</p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/init-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/init-connection.tsx
@@ -21,8 +21,10 @@ function InitConnection() {
         other IAP operations.
       </p>
       <p>
-        <strong>iOS:</strong> Calls <code>AppStore.sync()</code> lazily and
-        verifies StoreKit 2 is available; safe to call repeatedly.{' '}
+        <strong>iOS:</strong> Verifies <code>AppStore.canMakePayments</code>,
+        registers the <code>SKPaymentQueue</code> observer for promoted IAPs,
+        and starts a <code>Transaction.updates</code> listener that drives the
+        purchase event stream. Safe to call repeatedly.{' '}
         <a
           href="https://developer.apple.com/documentation/storekit/transaction/updates"
           target="_blank"

--- a/packages/docs/src/pages/docs/apis/init-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/init-connection.tsx
@@ -46,6 +46,30 @@ function InitConnection() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          typescript: (
+            <CodeBlock language="typescript">{`initConnection(config?: InitConnectionConfig): Promise<boolean>`}</CodeBlock>
+          ),
+          swift: (
+            <CodeBlock language="swift">{`func initConnection() async throws -> Bool`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun initConnection(config: InitConnectionConfig? = null): Boolean`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun initConnection(config: InitConnectionConfig? = null): Boolean`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> initConnection({InitConnectionConfig? config});`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func init_connection(config: InitConnectionConfig = null) -> bool`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -95,30 +119,6 @@ function InitConnection() {
         Throws
       </AnchorLink>
       <p>When the platform billing client fails to initialize.</p>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          typescript: (
-            <CodeBlock language="typescript">{`initConnection(config?: InitConnectionConfig): Promise<boolean>`}</CodeBlock>
-          ),
-          swift: (
-            <CodeBlock language="swift">{`func initConnection() async throws -> Bool`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`suspend fun initConnection(config: InitConnectionConfig? = null): Boolean`}</CodeBlock>
-          ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun initConnection(config: InitConnectionConfig? = null): Boolean`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<bool> initConnection({InitConnectionConfig? config});`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func init_connection(config: InitConnectionConfig = null) -> bool`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/init-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/init-connection.tsx
@@ -53,52 +53,35 @@ function InitConnection() {
         Pass an optional{' '}
         <Link to="/docs/types/alternative-billing-types#init-connection-config">
           <code>InitConnectionConfig</code>
-        </Link>
-        :
+        </Link>{' '}
+        — Android billing program flags. iOS ignores Android-specific fields.
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>alternativeBillingModeAndroid</code>
-            </td>
-            <td>
-              <Link to="/docs/types/alternative-billing-types#alternative-billing-mode-android">
-                <code>AlternativeBillingModeAndroid</code>
-              </Link>
-            </td>
-            <td>No</td>
-            <td>
-              <strong>Android · deprecated.</strong> Opt into Google's
-              user-choice billing flow. Prefer{' '}
-              <code>enableBillingProgramAndroid</code>.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>enableBillingProgramAndroid</code>
-            </td>
-            <td>
-              <Link to="/docs/types/billing-programs#billing-program-android">
-                <code>BillingProgramAndroid</code>
-              </Link>
-            </td>
-            <td>No</td>
-            <td>
-              <strong>Android.</strong> Enable a Play Billing 8.2.0+ program
-              (External Payments etc.) at connection time.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>alternativeBillingModeAndroid</code>{' '}
+          <em>
+            (optional,{' '}
+            <Link to="/docs/types/alternative-billing-types#alternative-billing-mode-android">
+              <code>AlternativeBillingModeAndroid</code>
+            </Link>
+            )
+          </em>{' '}
+          — <strong>Android · deprecated.</strong> Opt into Google's user-choice
+          billing flow. Prefer <code>enableBillingProgramAndroid</code>.
+        </li>
+        <li>
+          <code>enableBillingProgramAndroid</code>{' '}
+          <em>
+            (optional,{' '}
+            <Link to="/docs/types/billing-programs#billing-program-android">
+              <code>BillingProgramAndroid</code>
+            </Link>
+            )
+          </em>{' '}
+          — <strong>Android.</strong> Enable a Play Billing 8.2.0+ program
+          (External Payments etc.) at connection time.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/init-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/init-connection.tsx
@@ -20,6 +20,28 @@ function InitConnection() {
         Initialize connection to the store service. Must be called before any
         other IAP operations.
       </p>
+      <p>
+        <strong>iOS:</strong> Calls <code>AppStore.sync()</code> lazily and
+        verifies StoreKit 2 is available; safe to call repeatedly.{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/updates"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        . <strong>Android:</strong> Starts <code>BillingClient</code> and waits
+        for <code>onBillingSetupFinished</code>. Required before any other Play
+        Billing call.{' '}
+        <a
+          href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#startConnection(com.android.billingclient.api.BillingClientStateListener)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google docs
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/init-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/init-connection.tsx
@@ -49,10 +49,17 @@ function InitConnection() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
+      <p>
+        Pass an optional{' '}
+        <Link to="/docs/types/alternative-billing-types#init-connection-config">
+          <code>InitConnectionConfig</code>
+        </Link>
+        :
+      </p>
       <table className="doc-table">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Field</th>
             <th>Type</th>
             <th>Required</th>
             <th>Description</th>
@@ -61,17 +68,33 @@ function InitConnection() {
         <tbody>
           <tr>
             <td>
-              <code>config</code>
+              <code>alternativeBillingModeAndroid</code>
             </td>
             <td>
-              <Link to="/docs/types/alternative-billing-types#init-connection-config">
-                <code>InitConnectionConfig</code>
+              <Link to="/docs/types/alternative-billing-types#alternative-billing-mode-android">
+                <code>AlternativeBillingModeAndroid</code>
               </Link>
             </td>
             <td>No</td>
             <td>
-              Connection config (e.g. <code>enableBillingProgramAndroid</code>{' '}
-              for Play Billing 8.2.0+; iOS ignores Android-specific fields).
+              <strong>Android · deprecated.</strong> Opt into Google's
+              user-choice billing flow. Prefer{' '}
+              <code>enableBillingProgramAndroid</code>.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>enableBillingProgramAndroid</code>
+            </td>
+            <td>
+              <Link to="/docs/types/billing-programs#billing-program-android">
+                <code>BillingProgramAndroid</code>
+              </Link>
+            </td>
+            <td>No</td>
+            <td>
+              <strong>Android.</strong> Enable a Play Billing 8.2.0+ program
+              (External Payments etc.) at connection time.
             </td>
           </tr>
         </tbody>

--- a/packages/docs/src/pages/docs/apis/init-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/init-connection.tsx
@@ -102,8 +102,10 @@ function InitConnection() {
             </Link>
             )
           </em>{' '}
-          — <strong>Android.</strong> Enable a Play Billing 8.2.0+ program
-          (External Payments etc.) at connection time.
+          — <strong>Android.</strong> Enable a Play Billing 8.2.0+ program (
+          <code>EXTERNAL_CONTENT_LINK</code> / <code>EXTERNAL_OFFER</code>) at
+          connection time. <code>EXTERNAL_PAYMENTS</code> is gated to Billing
+          8.3.0+ (Japan only).
         </li>
       </ul>
 

--- a/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
@@ -53,7 +53,7 @@ function BeginRefundRequestIOS() {
             <CodeBlock language="dart">{`Future<String?> beginRefundRequestIOS(String sku);`}</CodeBlock>
           ),
           gdscript: (
-            <CodeBlock language="gdscript">{`func begin_refund_request_ios(sku: String) -> Variant`}</CodeBlock>
+            <CodeBlock language="gdscript">{`func begin_refund_request_ios(product_id: String) -> Types.RefundResultIOS`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
@@ -91,6 +91,7 @@ val status = kmpIAP.beginRefundRequestIOS(sku = "com.app.premium")`}</CodeBlock>
           ),
           typescript: (
             <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { Platform } from 'react-native';
 import { beginRefundRequestIOS } from 'expo-iap';
 
 if (Platform.OS === 'ios') {
@@ -105,7 +106,8 @@ if (Platform.OS === 'ios') {
           ),
           gdscript: (
             <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
-    var status = await iap.begin_refund_request_ios("com.app.premium")`}</CodeBlock>
+    # Synchronous — no await; returns Types.RefundResultIOS directly.
+    var result = iap.begin_refund_request_ios("com.app.premium")`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
@@ -40,28 +40,15 @@ function BeginRefundRequestIOS() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>sku</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Yes</td>
-            <td>Product identifier to refund.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>sku</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Product identifier to refund.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
@@ -77,6 +77,49 @@ function BeginRefundRequestIOS() {
           swift: (
             <CodeBlock language="swift">{`func beginRefundRequestIOS(sku: String) async throws -> String?`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun beginRefundRequestIOS(sku: String): String?`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`beginRefundRequestIOS(sku: string): Promise<string | null>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<String?> beginRefundRequestIOS(String sku);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func begin_refund_request_ios(sku: String) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let status = try await OpenIapModule.shared.beginRefundRequestIOS(sku: "com.app.premium")`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val status = kmpIAP.beginRefundRequestIOS(sku = "com.app.premium")`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { beginRefundRequestIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const status = await beginRefundRequestIOS('com.app.premium');
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final status = await FlutterInappPurchase.instance
+      .beginRefundRequestIOS('com.app.premium');
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var status = await iap.begin_refund_request_ios("com.app.premium")`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
 

--- a/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
@@ -37,27 +37,6 @@ function BeginRefundRequestIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <ul className="api-params">
-        <li>
-          <code>sku</code>{' '}
-          <em>
-            (required, <code>string</code>)
-          </em>{' '}
-          — Product identifier to refund.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;string | null&gt;</code> — Refund request status
-        string, or <code>null</code> if the user dismissed the sheet.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -78,6 +57,27 @@ function BeginRefundRequestIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <ul className="api-params">
+        <li>
+          <code>sku</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Product identifier to refund.
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string | null&gt;</code> — Refund request status
+        string, or <code>null</code> if the user dismissed the sheet.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
@@ -23,6 +23,18 @@ function BeginRefundRequestIOS() {
         Initiate a refund request for a product (iOS 15+). Presents the StoreKit
         refund sheet.
       </p>
+      <p>
+        Wraps <code>Transaction.beginRefundRequest(in:)</code> — presents the
+        refund-request sheet. iOS 15+. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/beginrefundrequest(in:)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/begin-refund-request-ios.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -34,6 +35,40 @@ function BeginRefundRequestIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>sku</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Yes</td>
+            <td>Product identifier to refund.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string | null&gt;</code> — Refund request status
+        string, or <code>null</code> if the user dismissed the sheet.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
@@ -35,11 +35,6 @@ function CanPresentExternalPurchaseNoticeIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -32,6 +33,19 @@ function CanPresentExternalPurchaseNoticeIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the
+        external-purchase notice sheet can be presented (iOS 17.4+).
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
@@ -35,14 +35,6 @@ function CanPresentExternalPurchaseNoticeIOS() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the
-        external-purchase notice sheet can be presented (iOS 17.4+).
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -63,6 +55,14 @@ function CanPresentExternalPurchaseNoticeIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the
+        external-purchase notice sheet can be presented (iOS 17.4+).
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
@@ -51,7 +51,7 @@ function CanPresentExternalPurchaseNoticeIOS() {
             <CodeBlock language="dart">{`Future<bool> canPresentExternalPurchaseNoticeIOS();`}</CodeBlock>
           ),
           gdscript: (
-            <CodeBlock language="gdscript">{`func can_present_external_purchase_notice_ios() -> Variant`}</CodeBlock>
+            <CodeBlock language="gdscript">{`func can_present_external_purchase_notice_ios() -> bool`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
@@ -54,6 +54,49 @@ function CanPresentExternalPurchaseNoticeIOS() {
           swift: (
             <CodeBlock language="swift">{`func canPresentExternalPurchaseNoticeIOS() async throws -> Bool`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun canPresentExternalPurchaseNoticeIOS(): Boolean`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`canPresentExternalPurchaseNoticeIOS(): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> canPresentExternalPurchaseNoticeIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func can_present_external_purchase_notice_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let can = try await OpenIapModule.shared.canPresentExternalPurchaseNoticeIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val can = kmpIAP.canPresentExternalPurchaseNoticeIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { canPresentExternalPurchaseNoticeIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const can = await canPresentExternalPurchaseNoticeIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final can = await FlutterInappPurchase.instance
+      .canPresentExternalPurchaseNoticeIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var can = await iap.can_present_external_purchase_notice_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/can-present-external-purchase-notice-ios.tsx
@@ -21,6 +21,18 @@ function CanPresentExternalPurchaseNoticeIOS() {
       <p>
         Check if external purchase notice sheet can be presented (iOS 17.4+).
       </p>
+      <p>
+        Wraps <code>ExternalPurchase.canPresent</code> — gate before calling{' '}
+        <code>presentExternalPurchaseNoticeSheetIOS</code>. iOS 17.4+. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/externalpurchase/canpresent"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/clear-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/clear-transaction-ios.tsx
@@ -19,6 +19,19 @@ function ClearTransactionIOS() {
         clearTransactionIOS
       </h1>
       <p>Clear pending transactions from the StoreKit payment queue.</p>
+      <p>
+        Iterates <code>Transaction.unfinished</code> and calls{' '}
+        <code>.finish()</code> on each — sandbox/dev helper, do NOT ship in
+        production paths. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/unfinished"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/clear-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/clear-transaction-ios.tsx
@@ -53,6 +53,48 @@ function ClearTransactionIOS() {
           swift: (
             <CodeBlock language="swift">{`func clearTransactionIOS() async throws -> Bool`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun clearTransactionIOS(): Boolean`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`clearTransactionIOS(): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> clearTransactionIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func clear_transaction_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`try await OpenIapModule.shared.clearTransactionIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+kmpIAP.clearTransactionIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { clearTransactionIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  await clearTransactionIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  await FlutterInappPurchase.instance.clearTransactionIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var result = await iap.clear_transaction_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/clear-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/clear-transaction-ios.tsx
@@ -34,14 +34,6 @@ function ClearTransactionIOS() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once unfinished
-        transactions in the queue have been cleared.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -62,6 +54,14 @@ function ClearTransactionIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once unfinished
+        transactions in the queue have been cleared.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/clear-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/clear-transaction-ios.tsx
@@ -34,11 +34,6 @@ function ClearTransactionIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/clear-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/clear-transaction-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -31,6 +32,19 @@ function ClearTransactionIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once unfinished
+        transactions in the queue have been cleared.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
@@ -34,6 +34,27 @@ function CurrentEntitlementIOS() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`func currentEntitlementIOS(sku: String) async throws -> Purchase?`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun currentEntitlementIOS(sku: String): PurchaseIOS?`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`currentEntitlementIOS(sku: string): Promise<PurchaseIOS | null>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<PurchaseIOS?> currentEntitlementIOS(String sku);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func current_entitlement_ios(sku: String) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -57,27 +78,6 @@ function CurrentEntitlementIOS() {
         — iOS purchase shape, or <code>null</code> if the SKU has no matching
         transaction.
       </p>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          swift: (
-            <CodeBlock language="swift">{`func currentEntitlementIOS(sku: String) async throws -> Purchase?`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`suspend fun currentEntitlementIOS(sku: String): PurchaseIOS?`}</CodeBlock>
-          ),
-          typescript: (
-            <CodeBlock language="typescript">{`currentEntitlementIOS(sku: string): Promise<PurchaseIOS | null>`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<PurchaseIOS?> currentEntitlementIOS(String sku);`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func current_entitlement_ios(sku: String) -> Variant`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
@@ -37,28 +37,15 @@ function CurrentEntitlementIOS() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>sku</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Yes</td>
-            <td>Product identifier.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>sku</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Product identifier.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -30,6 +31,40 @@ function CurrentEntitlementIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>sku</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Yes</td>
+            <td>Product identifier.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;PurchaseIOS | null&gt;</code> — Current entitlement for
+        the product, or <code>null</code>.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
@@ -19,6 +19,18 @@ function CurrentEntitlementIOS() {
         currentEntitlementIOS
       </h1>
       <p>Get current StoreKit 2 entitlement for a product (iOS 15+).</p>
+      <p>
+        Wraps <code>Transaction.currentEntitlement(for:)</code> — single-product
+        convenience over <code>currentEntitlements</code>. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/currententitlement(for:)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
@@ -63,8 +64,11 @@ function CurrentEntitlementIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;PurchaseIOS | null&gt;</code> — Current entitlement for
-        the product, or <code>null</code>.
+        <Link to="/docs/types/purchase">
+          <code>Promise&lt;PurchaseIOS | null&gt;</code>
+        </Link>{' '}
+        — iOS purchase shape, or <code>null</code> if the SKU has no matching
+        transaction.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/current-entitlement-ios.tsx
@@ -77,6 +77,49 @@ function CurrentEntitlementIOS() {
           swift: (
             <CodeBlock language="swift">{`func currentEntitlementIOS(sku: String) async throws -> Purchase?`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun currentEntitlementIOS(sku: String): PurchaseIOS?`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`currentEntitlementIOS(sku: string): Promise<PurchaseIOS | null>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<PurchaseIOS?> currentEntitlementIOS(String sku);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func current_entitlement_ios(sku: String) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let entitlement = try await OpenIapModule.shared.currentEntitlementIOS(sku: "com.app.premium")`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val entitlement = kmpIAP.currentEntitlementIOS(sku = "com.app.premium")`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { currentEntitlementIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const entitlement = await currentEntitlementIOS('com.app.premium');
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final entitlement = await FlutterInappPurchase.instance
+      .currentEntitlementIOS('com.app.premium');
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var entitlement = await iap.current_entitlement_ios("com.app.premium")`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
@@ -39,20 +39,6 @@ function GetAllTransactionsIOS() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <Link to="/docs/types/purchase">
-          <code>Promise&lt;PurchaseIOS[]&gt;</code>
-        </Link>{' '}
-        — array of StoreKit transactions in the iOS-specific shape. See{' '}
-        <Link to="/docs/types/purchase">
-          <code>Purchase</code>
-        </Link>{' '}
-        for the full field reference.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -73,6 +59,20 @@ function GetAllTransactionsIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <Link to="/docs/types/purchase">
+          <code>Promise&lt;PurchaseIOS[]&gt;</code>
+        </Link>{' '}
+        — array of StoreKit transactions in the iOS-specific shape. See{' '}
+        <Link to="/docs/types/purchase">
+          <code>Purchase</code>
+        </Link>{' '}
+        for the full field reference.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -35,6 +36,19 @@ function GetAllTransactionsIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;PurchaseIOS[]&gt;</code> — Every StoreKit transaction
+        (finished + unfinished).
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
@@ -23,6 +23,19 @@ function GetAllTransactionsIOS() {
         Requires the SK2ConsumableTransactionHistory Info.plist key for finished
         consumables to be included (iOS 18+).
       </p>
+      <p>
+        Iterates <code>Transaction.all</code>. iOS 18+ requires{' '}
+        <code>SK2ConsumableTransactionHistory</code> Info.plist key for finished
+        consumables to appear. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/all"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
@@ -47,8 +48,14 @@ function GetAllTransactionsIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;PurchaseIOS[]&gt;</code> — Every StoreKit transaction
-        (finished + unfinished).
+        <Link to="/docs/types/purchase">
+          <code>Promise&lt;PurchaseIOS[]&gt;</code>
+        </Link>{' '}
+        — array of StoreKit transactions in the iOS-specific shape. See{' '}
+        <Link to="/docs/types/purchase">
+          <code>Purchase</code>
+        </Link>{' '}
+        for the full field reference.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
@@ -39,11 +39,6 @@ function GetAllTransactionsIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-all-transactions-ios.tsx
@@ -64,6 +64,48 @@ function GetAllTransactionsIOS() {
           swift: (
             <CodeBlock language="swift">{`func getAllTransactionsIOS() async throws -> [PurchaseIOS]`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun getAllTransactionsIOS(): List<PurchaseIOS>`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`getAllTransactionsIOS(): Promise<PurchaseIOS[]>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<List<PurchaseIOS>> getAllTransactionsIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func get_all_transactions_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let txs = try await OpenIapModule.shared.getAllTransactionsIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val txs = kmpIAP.getAllTransactionsIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { getAllTransactionsIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const txs = await getAllTransactionsIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final txs = await FlutterInappPurchase.instance.getAllTransactionsIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var txs = await iap.get_all_transactions_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
@@ -56,6 +56,48 @@ function GetAppTransactionIOS() {
           swift: (
             <CodeBlock language="swift">{`func getAppTransactionIOS() async throws -> AppTransactionIOS?`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun getAppTransactionIOS(): AppTransaction?`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`getAppTransactionIOS(): Promise<AppTransaction | null>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<AppTransaction?> getAppTransactionIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func get_app_transaction_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let appTx = try await OpenIapModule.shared.getAppTransactionIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val appTx = kmpIAP.getAppTransactionIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { getAppTransactionIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const appTx = await getAppTransactionIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final appTx = await FlutterInappPurchase.instance.getAppTransactionIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var app_tx = await iap.get_app_transaction_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
 

--- a/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
@@ -34,17 +34,6 @@ function GetAppTransactionIOS() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <Link to="/docs/types/ios/app-transaction-ios">
-          <code>Promise&lt;AppTransaction | null&gt;</code>
-        </Link>{' '}
-        — JWS-verified record of how the app was acquired. Returns{' '}
-        <code>null</code> on iOS &lt; 16 or when no transaction is available.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -65,6 +54,17 @@ function GetAppTransactionIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <Link to="/docs/types/ios/app-transaction-ios">
+          <code>Promise&lt;AppTransaction | null&gt;</code>
+        </Link>{' '}
+        — JWS-verified record of how the app was acquired. Returns{' '}
+        <code>null</code> on iOS &lt; 16 or when no transaction is available.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
@@ -43,8 +43,11 @@ function GetAppTransactionIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;AppTransaction | null&gt;</code> — JWS-verified record
-        of how the app was acquired (iOS 16+).
+        <Link to="/docs/types/ios/app-transaction-ios">
+          <code>Promise&lt;AppTransaction | null&gt;</code>
+        </Link>{' '}
+        — JWS-verified record of how the app was acquired. Returns{' '}
+        <code>null</code> on iOS &lt; 16 or when no transaction is available.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
@@ -34,11 +34,6 @@ function GetAppTransactionIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
@@ -20,6 +20,18 @@ function GetAppTransactionIOS() {
         getAppTransactionIOS
       </h1>
       <p>Fetch the current app transaction (iOS 16+).</p>
+      <p>
+        Wraps <code>AppTransaction.shared</code> — the JWS-verified record of
+        how the app was acquired. iOS 16+. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/apptransaction"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-app-transaction-ios.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -31,6 +32,19 @@ function GetAppTransactionIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;AppTransaction | null&gt;</code> — JWS-verified record
+        of how the app was acquired (iOS 16+).
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
@@ -95,6 +95,62 @@ function GetExternalPurchaseCustomLinkTokenIOS() {
     tokenType: ExternalPurchaseCustomLinkTokenTypeIOS
 ) async throws -> ExternalPurchaseCustomLinkTokenResultIOS`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun getExternalPurchaseCustomLinkTokenIOS(
+    tokenType: ExternalPurchaseCustomLinkTokenTypeIOS
+): ExternalPurchaseCustomLinkTokenResultIOS`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`getExternalPurchaseCustomLinkTokenIOS(
+  tokenType: ExternalPurchaseCustomLinkTokenTypeIOS,
+): Promise<ExternalPurchaseCustomLinkTokenResultIOS>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<ExternalPurchaseCustomLinkTokenResultIOS>
+    getExternalPurchaseCustomLinkTokenIOS(
+  ExternalPurchaseCustomLinkTokenTypeIOS tokenType,
+);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func get_external_purchase_custom_link_token_ios(token_type: String) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let token = try await OpenIapModule.shared.getExternalPurchaseCustomLinkTokenIOS(
+    tokenType: .acquisition
+)`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val token = kmpIAP.getExternalPurchaseCustomLinkTokenIOS(
+    tokenType = ExternalPurchaseCustomLinkTokenTypeIOS.ACQUISITION
+)`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { getExternalPurchaseCustomLinkTokenIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const token = await getExternalPurchaseCustomLinkTokenIOS('acquisition');
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final token = await FlutterInappPurchase.instance
+      .getExternalPurchaseCustomLinkTokenIOS(
+        ExternalPurchaseCustomLinkTokenTypeIOS.acquisition,
+      );
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var token = await iap.get_external_purchase_custom_link_token_ios("acquisition")`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
 

--- a/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
@@ -78,8 +79,12 @@ function GetExternalPurchaseCustomLinkTokenIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;ExternalPurchaseCustomLinkTokenResultIOS&gt;</code> —
-        Token for Apple's External Purchase Server reporting API.
+        <Link to="/docs/types/external-purchase-link">
+          <code>Promise&lt;ExternalPurchaseCustomLinkTokenResultIOS&gt;</code>
+        </Link>{' '}
+        — token plus its acquired/expiry metadata. Send the <code>token</code>{' '}
+        field to Apple's External Purchase Server within the documented validity
+        window.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
@@ -79,7 +79,7 @@ function GetExternalPurchaseCustomLinkTokenIOS() {
         Returns
       </AnchorLink>
       <p>
-        <Link to="/docs/types/external-purchase-link">
+        <Link to="/docs/types/external-purchase-link#external-purchase-custom-link-token-result-ios">
           <code>Promise&lt;ExternalPurchaseCustomLinkTokenResultIOS&gt;</code>
         </Link>{' '}
         — token plus its acquired/expiry metadata. Send the <code>token</code>{' '}

--- a/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
@@ -46,32 +46,6 @@ function GetExternalPurchaseCustomLinkTokenIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <ul className="api-params">
-        <li>
-          <code>tokenType</code>{' '}
-          <em>
-            (required, <code>ExternalPurchaseCustomLinkTokenTypeIOS</code>)
-          </em>{' '}
-          — <code>acquisition</code> (new customers) or <code>services</code>{' '}
-          (existing customers).
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <Link to="/docs/types/external-purchase-link#external-purchase-custom-link-token-result-ios">
-          <code>Promise&lt;ExternalPurchaseCustomLinkTokenResultIOS&gt;</code>
-        </Link>{' '}
-        — token plus its acquired/expiry metadata. Send the <code>token</code>{' '}
-        field to Apple's External Purchase Server within the documented validity
-        window.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -101,6 +75,32 @@ function GetExternalPurchaseCustomLinkTokenIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <ul className="api-params">
+        <li>
+          <code>tokenType</code>{' '}
+          <em>
+            (required, <code>ExternalPurchaseCustomLinkTokenTypeIOS</code>)
+          </em>{' '}
+          — <code>acquisition</code> (new customers) or <code>services</code>{' '}
+          (existing customers).
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <Link to="/docs/types/external-purchase-link#external-purchase-custom-link-token-result-ios">
+          <code>Promise&lt;ExternalPurchaseCustomLinkTokenResultIOS&gt;</code>
+        </Link>{' '}
+        — token plus its acquired/expiry metadata. Send the <code>token</code>{' '}
+        field to Apple's External Purchase Server within the documented validity
+        window.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
@@ -30,6 +30,19 @@ function GetExternalPurchaseCustomLinkTokenIOS() {
         API (iOS 18.1+). Pair the returned token with Apple's External Purchase
         Server API to report acquisition or services transactions.
       </p>
+      <p>
+        Wraps <code>ExternalPurchaseCustomLink.token(for:)</code> — token to
+        report transactions to Apple's External Purchase Server. iOS 18.1+. See
+        the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
@@ -49,31 +49,16 @@ function GetExternalPurchaseCustomLinkTokenIOS() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>tokenType</code>
-            </td>
-            <td>
-              <code>ExternalPurchaseCustomLinkTokenTypeIOS</code>
-            </td>
-            <td>Yes</td>
-            <td>
-              <code>acquisition</code> (new customers) or <code>services</code>{' '}
-              (existing customers).
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>tokenType</code>{' '}
+          <em>
+            (required, <code>ExternalPurchaseCustomLinkTokenTypeIOS</code>)
+          </em>{' '}
+          — <code>acquisition</code> (new customers) or <code>services</code>{' '}
+          (existing customers).
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-external-purchase-custom-link-token-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -42,6 +43,43 @@ function GetExternalPurchaseCustomLinkTokenIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>tokenType</code>
+            </td>
+            <td>
+              <code>ExternalPurchaseCustomLinkTokenTypeIOS</code>
+            </td>
+            <td>Yes</td>
+            <td>
+              <code>acquisition</code> (new customers) or <code>services</code>{' '}
+              (existing customers).
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;ExternalPurchaseCustomLinkTokenResultIOS&gt;</code> —
+        Token for Apple's External Purchase Server reporting API.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
@@ -42,8 +43,14 @@ function GetPendingTransactionsIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;PurchaseIOS[]&gt;</code> — Unfinished StoreKit
-        transactions in the queue.
+        <Link to="/docs/types/purchase">
+          <code>Promise&lt;PurchaseIOS[]&gt;</code>
+        </Link>{' '}
+        — array of StoreKit transactions in the iOS-specific shape. See{' '}
+        <Link to="/docs/types/purchase">
+          <code>Purchase</code>
+        </Link>{' '}
+        for the full field reference.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -30,6 +31,19 @@ function GetPendingTransactionsIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;PurchaseIOS[]&gt;</code> — Unfinished StoreKit
+        transactions in the queue.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
@@ -59,6 +59,48 @@ function GetPendingTransactionsIOS() {
           swift: (
             <CodeBlock language="swift">{`func getPendingTransactionsIOS() async throws -> [Purchase]`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun getPendingTransactionsIOS(): List<PurchaseIOS>`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`getPendingTransactionsIOS(): Promise<PurchaseIOS[]>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<List<PurchaseIOS>> getPendingTransactionsIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func get_pending_transactions_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let txs = try await OpenIapModule.shared.getPendingTransactionsIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val txs = kmpIAP.getPendingTransactionsIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { getPendingTransactionsIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const txs = await getPendingTransactionsIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final txs = await FlutterInappPurchase.instance.getPendingTransactionsIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var txs = await iap.get_pending_transactions_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
@@ -19,6 +19,18 @@ function GetPendingTransactionsIOS() {
         getPendingTransactionsIOS
       </h1>
       <p>Retrieve all pending transactions in the StoreKit queue.</p>
+      <p>
+        Iterates <code>Transaction.unfinished</code> to surface transactions
+        still awaiting <code>finish()</code>. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/unfinished"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
@@ -34,11 +34,6 @@ function GetPendingTransactionsIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-pending-transactions-ios.tsx
@@ -34,20 +34,6 @@ function GetPendingTransactionsIOS() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <Link to="/docs/types/purchase">
-          <code>Promise&lt;PurchaseIOS[]&gt;</code>
-        </Link>{' '}
-        — array of StoreKit transactions in the iOS-specific shape. See{' '}
-        <Link to="/docs/types/purchase">
-          <code>Purchase</code>
-        </Link>{' '}
-        for the full field reference.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -68,6 +54,20 @@ function GetPendingTransactionsIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <Link to="/docs/types/purchase">
+          <code>Promise&lt;PurchaseIOS[]&gt;</code>
+        </Link>{' '}
+        — array of StoreKit transactions in the iOS-specific shape. See{' '}
+        <Link to="/docs/types/purchase">
+          <code>Purchase</code>
+        </Link>{' '}
+        for the full field reference.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -31,6 +32,19 @@ function GetPromotedProductIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;ProductIOS | null&gt;</code> — The currently promoted
+        product, or <code>null</code> if none is queued.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
@@ -43,8 +44,11 @@ function GetPromotedProductIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;ProductIOS | null&gt;</code> — The currently promoted
-        product, or <code>null</code> if none is queued.
+        <Link to="/docs/types/product">
+          <code>Promise&lt;ProductIOS | null&gt;</code>
+        </Link>{' '}
+        — the App Store-promoted product, or <code>null</code> if no campaign is
+        currently queued.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
@@ -35,17 +35,6 @@ function GetPromotedProductIOS() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <Link to="/docs/types/product">
-          <code>Promise&lt;ProductIOS | null&gt;</code>
-        </Link>{' '}
-        — the App Store-promoted product, or <code>null</code> if no campaign is
-        currently queued.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -66,6 +55,17 @@ function GetPromotedProductIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <Link to="/docs/types/product">
+          <code>Promise&lt;ProductIOS | null&gt;</code>
+        </Link>{' '}
+        — the App Store-promoted product, or <code>null</code> if no campaign is
+        currently queued.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
@@ -57,6 +57,48 @@ function GetPromotedProductIOS() {
           swift: (
             <CodeBlock language="swift">{`func getPromotedProductIOS() async throws -> Product?`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun getPromotedProductIOS(): ProductIOS?`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`getPromotedProductIOS(): Promise<ProductIOS | null>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<ProductIOS?> getPromotedProductIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func get_promoted_product_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let product = try await OpenIapModule.shared.getPromotedProductIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val product = kmpIAP.getPromotedProductIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { getPromotedProductIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const product = await getPromotedProductIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final product = await FlutterInappPurchase.instance.getPromotedProductIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var product = await iap.get_promoted_product_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
@@ -35,11 +35,6 @@ function GetPromotedProductIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-promoted-product-ios.tsx
@@ -19,6 +19,19 @@ function GetPromotedProductIOS() {
         getPromotedProductIOS
       </h1>
       <p>Get the currently promoted product from App Store (iOS 11+).</p>
+      <p>
+        Reads the product surfaced via App Store promoted IAP campaigns (
+        <code>SKPaymentTransactionObserver.shouldAddStorePayment</code>). iOS
+        11+. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/in-app-purchase/promoting-in-app-purchases"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -32,6 +33,19 @@ function GetReceiptDataIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string | null&gt;</code> — Base64-encoded receipt data
+        (legacy StoreKit 1 path).
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
@@ -20,6 +20,19 @@ function GetReceiptDataIOS() {
         getReceiptDataIOS
       </h1>
       <p>Get base64-encoded receipt data for legacy validation.</p>
+      <p>
+        Reads <code>Bundle.main.appStoreReceiptURL</code> and base64-encodes the
+        file. Legacy StoreKit 1 flow — prefer JWS / <code>verifyPurchase</code>.
+        See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/original_api_for_in-app_purchase"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
@@ -35,11 +35,6 @@ function GetReceiptDataIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
@@ -35,14 +35,6 @@ function GetReceiptDataIOS() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;string | null&gt;</code> — Base64-encoded receipt data
-        (legacy StoreKit 1 path).
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -63,6 +55,14 @@ function GetReceiptDataIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string | null&gt;</code> — Base64-encoded receipt data
+        (legacy StoreKit 1 path).
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
@@ -51,7 +51,7 @@ function GetReceiptDataIOS() {
             <CodeBlock language="dart">{`Future<String?> getReceiptDataIOS();`}</CodeBlock>
           ),
           gdscript: (
-            <CodeBlock language="gdscript">{`func get_receipt_data_ios() -> Variant`}</CodeBlock>
+            <CodeBlock language="gdscript">{`func get_receipt_data_ios() -> String`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-receipt-data-ios.tsx
@@ -51,20 +51,20 @@ function GetReceiptDataIOS() {
       <h2>Signature</h2>
       <LanguageTabs>
         {{
-          typescript: (
-            <CodeBlock language="typescript">{`getReceiptDataIOS(): Promise<string | null>`}</CodeBlock>
-          ),
           swift: (
             <CodeBlock language="swift">{`func getReceiptDataIOS() async throws -> String?`}</CodeBlock>
           ),
           kotlin: (
             <CodeBlock language="kotlin">{`suspend fun getReceiptDataIOS(): String?`}</CodeBlock>
           ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun getReceiptDataIOS(): String?`}</CodeBlock>
+          typescript: (
+            <CodeBlock language="typescript">{`getReceiptDataIOS(): Promise<string | null>`}</CodeBlock>
           ),
           dart: (
             <CodeBlock language="dart">{`Future<String?> getReceiptDataIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func get_receipt_data_ios() -> Variant`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
@@ -72,49 +72,29 @@ function GetReceiptDataIOS() {
       <h2>Example</h2>
       <LanguageTabs>
         {{
-          typescript: (
-            <CodeBlock language="typescript">{`// expo-iap
-import { getReceiptDataIOS } from 'expo-iap';
-// Same API in react-native-iap:
-// import { getReceiptDataIOS } from 'react-native-iap';
-
-const receipt = await getReceiptDataIOS();
-// Send the base64-encoded receipt to your server for legacy verifyReceipt.
-console.log(receipt?.length ?? 0, 'bytes');
-
-// --- Or alongside the useIAP() hook (also exported from react-native-iap) ---
-// getReceiptDataIOS is a module-level helper; useIAP doesn't expose it on the
-// hook return, so call the module function from inside your component once
-// the hook reports the connection is ready.
-import { useIAP } from 'expo-iap';
-
-function ReceiptUploader() {
-  const { connected } = useIAP();
-
-  const upload = async () => {
-    if (!connected) return;
-    const receipt = await getReceiptDataIOS();
-    if (!receipt) return;
-    await fetch('/api/validate-receipt', {
-      method: 'POST',
-      body: JSON.stringify({ receipt }),
-    });
-  };
-
-  return <Button title="Upload receipt" onPress={upload} />;
-}`}</CodeBlock>
-          ),
           swift: (
-            <CodeBlock language="swift">{`let receipt = try await OpenIapModule.shared.getReceiptDataIOS()`}</CodeBlock>
+            <CodeBlock language="swift">{`let data = try await OpenIapModule.shared.getReceiptDataIOS()`}</CodeBlock>
           ),
           kotlin: (
-            <CodeBlock language="kotlin">{`val receipt = openIapStore.getReceiptDataIOS()`}</CodeBlock>
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val data = kmpIAP.getReceiptDataIOS()`}</CodeBlock>
           ),
-          kmp: (
-            <CodeBlock language="kotlin">{`val receipt = kmpIAP.getReceiptDataIOS()`}</CodeBlock>
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { getReceiptDataIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const data = await getReceiptDataIOS();
+}`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`final receipt = await FlutterInappPurchase.instance.getReceiptDataIOS();`}</CodeBlock>
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final data = await FlutterInappPurchase.instance.getReceiptDataIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var data = await iap.get_receipt_data_ios()`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-storefront-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-storefront-ios.tsx
@@ -41,13 +41,6 @@ function GetStorefrontIOS() {
         </p>
       </div>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>
-        None. <strong>Deprecated</strong> — use <code>getStorefront</code>.
-      </p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/get-storefront-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-storefront-ios.tsx
@@ -63,6 +63,55 @@ function GetStorefrontIOS() {
             <CodeBlock language="swift">{`@available(*, deprecated, message: "Use getStorefront()")
 func getStorefrontIOS() async throws -> String`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`@Deprecated("Use getStorefront()")
+suspend fun getStorefrontIOS(): String`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`getStorefrontIOS(): Promise<string>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`@Deprecated('Use getStorefront()')
+Future<String> getStorefrontIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func get_storefront_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let code = try await OpenIapModule.shared.getStorefrontIOS()
+// Deprecated — prefer OpenIapModule.shared.getStorefront()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+// Deprecated — prefer kmpIAP.getStorefront()
+val code = kmpIAP.getStorefrontIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+// Deprecated — prefer the cross-platform getStorefront().
+import { getStorefrontIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const code = await getStorefrontIOS();
+  console.log(code); // "US", "JP", etc.
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`// Deprecated — prefer FlutterInappPurchase.instance.getStorefront().
+if (Platform.isIOS) {
+  final code = await FlutterInappPurchase.instance.getStorefrontIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var code = await iap.get_storefront_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/get-storefront-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-storefront-ios.tsx
@@ -20,6 +20,18 @@ function GetStorefrontIOS() {
         getStorefrontIOS
       </h1>
       <p>Deprecated. Use getStorefront() (cross-platform) instead.</p>
+      <p>
+        Wraps <code>Storefront.current</code> — deprecated in OpenIAP. Returns
+        the App Store storefront country code. iOS 13+. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/storefront"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <div className="alert-card alert-card--warning">
         <p>

--- a/packages/docs/src/pages/docs/apis/ios/get-storefront-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-storefront-ios.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -39,6 +40,21 @@ function GetStorefrontIOS() {
           <Link to="/docs/apis/get-storefront">getStorefront</Link> instead.
         </p>
       </div>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>
+        None. <strong>Deprecated</strong> — use <code>getStorefront</code>.
+      </p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string&gt;</code> — ISO country code of the App Store
+        storefront.
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-storefront-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-storefront-ios.tsx
@@ -41,14 +41,6 @@ function GetStorefrontIOS() {
         </p>
       </div>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;string&gt;</code> — ISO country code of the App Store
-        storefront.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -72,6 +64,14 @@ Future<String> getStorefrontIOS();`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string&gt;</code> — ISO country code of the App Store
+        storefront.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
@@ -37,28 +37,15 @@ function GetTransactionJwsIOS() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>sku</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Yes</td>
-            <td>Product identifier.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>sku</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Product identifier.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
@@ -20,6 +20,18 @@ function GetTransactionJwsIOS() {
         getTransactionJwsIOS
       </h1>
       <p>Get the transaction JWS for server-side validation (iOS 15+).</p>
+      <p>
+        Returns <code>Transaction.jsonRepresentation</code> (signed JWS) — pass
+        to your backend for cryptographic validation. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/jsonrepresentation"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -31,6 +32,40 @@ function GetTransactionJwsIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>sku</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Yes</td>
+            <td>Product identifier.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string | null&gt;</code> — Signed JWS for the latest
+        transaction, or <code>null</code>.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
@@ -34,27 +34,6 @@ function GetTransactionJwsIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <ul className="api-params">
-        <li>
-          <code>sku</code>{' '}
-          <em>
-            (required, <code>string</code>)
-          </em>{' '}
-          — Product identifier.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;string | null&gt;</code> — Signed JWS for the latest
-        transaction, or <code>null</code>.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -75,6 +54,27 @@ function GetTransactionJwsIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <ul className="api-params">
+        <li>
+          <code>sku</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Product identifier.
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;string | null&gt;</code> — Signed JWS for the latest
+        transaction, or <code>null</code>.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
@@ -71,20 +71,20 @@ function GetTransactionJwsIOS() {
       <h2>Signature</h2>
       <LanguageTabs>
         {{
-          typescript: (
-            <CodeBlock language="typescript">{`getTransactionJwsIOS(sku: string): Promise<string | null>`}</CodeBlock>
-          ),
           swift: (
             <CodeBlock language="swift">{`func getTransactionJwsIOS(sku: String) async throws -> String?`}</CodeBlock>
           ),
           kotlin: (
             <CodeBlock language="kotlin">{`suspend fun getTransactionJwsIOS(sku: String): String?`}</CodeBlock>
           ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun getTransactionJwsIOS(sku: String): String?`}</CodeBlock>
+          typescript: (
+            <CodeBlock language="typescript">{`getTransactionJwsIOS(sku: string): Promise<string | null>`}</CodeBlock>
           ),
           dart: (
             <CodeBlock language="dart">{`Future<String?> getTransactionJwsIOS(String sku);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func get_transaction_jws_ios(sku: String) -> Variant`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
@@ -92,51 +92,30 @@ function GetTransactionJwsIOS() {
       <h2>Example</h2>
       <LanguageTabs>
         {{
-          typescript: (
-            <CodeBlock language="typescript">{`// expo-iap
-import { getTransactionJwsIOS } from 'expo-iap';
-// Same API in react-native-iap:
-// import { getTransactionJwsIOS } from 'react-native-iap';
-
-const jws = await getTransactionJwsIOS('com.example.premium');
-if (jws) {
-  // Send the JWS to your server; verify it with Apple's public keys.
-  await fetch('/api/verify-transaction', {
-    method: 'POST',
-    body: JSON.stringify({ jws }),
-  });
-}
-
-// --- Or alongside the useIAP() hook (also exported from react-native-iap) ---
-// getTransactionJwsIOS is a module-level helper; useIAP doesn't expose it on
-// the hook return, so call the module function from inside your component.
-import { useIAP } from 'expo-iap';
-
-function ServerValidateButton({ sku }: { sku: string }) {
-  const { connected } = useIAP();
-
-  const validate = async () => {
-    if (!connected) return;
-    const jws = await getTransactionJwsIOS(sku);
-    if (!jws) return;
-    await api.verify(jws);
-  };
-
-  return <Button title="Validate on server" onPress={validate} />;
-}`}</CodeBlock>
-          ),
           swift: (
-            <CodeBlock language="swift">{`let jws = try await OpenIapModule.shared.getTransactionJwsIOS(sku: "com.example.premium")`}</CodeBlock>
+            <CodeBlock language="swift">{`let jws = try await OpenIapModule.shared.getTransactionJwsIOS(sku: "com.app.premium")`}</CodeBlock>
           ),
           kotlin: (
-            <CodeBlock language="kotlin">{`val jws = openIapStore.getTransactionJwsIOS(sku = "com.example.premium")`}</CodeBlock>
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val jws = kmpIAP.getTransactionJwsIOS(sku = "com.app.premium")`}</CodeBlock>
           ),
-          kmp: (
-            <CodeBlock language="kotlin">{`val jws = kmpIAP.getTransactionJwsIOS(sku = "com.example.premium")`}</CodeBlock>
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { getTransactionJwsIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const jws = await getTransactionJwsIOS('com.app.premium');
+}`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`final jws = await FlutterInappPurchase.instance
-    .getTransactionJwsIOS('com.example.premium');`}</CodeBlock>
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final jws = await FlutterInappPurchase.instance
+      .getTransactionJwsIOS('com.app.premium');
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var jws = await iap.get_transaction_jws_ios("com.app.premium")`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/get-transaction-jws-ios.tsx
@@ -50,7 +50,7 @@ function GetTransactionJwsIOS() {
             <CodeBlock language="dart">{`Future<String?> getTransactionJwsIOS(String sku);`}</CodeBlock>
           ),
           gdscript: (
-            <CodeBlock language="gdscript">{`func get_transaction_jws_ios(sku: String) -> Variant`}</CodeBlock>
+            <CodeBlock language="gdscript">{`func get_transaction_jws_ios(sku: String) -> String`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios.tsx
@@ -45,11 +45,6 @@ function IsEligibleForExternalPurchaseCustomLinkIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios.tsx
@@ -31,6 +31,18 @@ function IsEligibleForExternalPurchaseCustomLinkIOS() {
         for the corresponding entitlement and music-streaming-app-style flows
         are allowed.
       </p>
+      <p>
+        Wraps <code>ExternalPurchaseCustomLink.isEligible</code> — iOS 18.1+.
+        See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios.tsx
@@ -64,6 +64,49 @@ function IsEligibleForExternalPurchaseCustomLinkIOS() {
           swift: (
             <CodeBlock language="swift">{`func isEligibleForExternalPurchaseCustomLinkIOS() async throws -> Bool`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun isEligibleForExternalPurchaseCustomLinkIOS(): Boolean`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`isEligibleForExternalPurchaseCustomLinkIOS(): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> isEligibleForExternalPurchaseCustomLinkIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func is_eligible_for_external_purchase_custom_link_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let ok = try await OpenIapModule.shared.isEligibleForExternalPurchaseCustomLinkIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val ok = kmpIAP.isEligibleForExternalPurchaseCustomLinkIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { isEligibleForExternalPurchaseCustomLinkIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const ok = await isEligibleForExternalPurchaseCustomLinkIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final ok = await FlutterInappPurchase.instance
+      .isEligibleForExternalPurchaseCustomLinkIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var ok = await iap.is_eligible_for_external_purchase_custom_link_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios.tsx
@@ -45,14 +45,6 @@ function IsEligibleForExternalPurchaseCustomLinkIOS() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — Whether the app can use
-        ExternalPurchaseCustomLink (iOS 18.1+).
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -73,6 +65,14 @@ function IsEligibleForExternalPurchaseCustomLinkIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — Whether the app can use
+        ExternalPurchaseCustomLink (iOS 18.1+).
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -42,6 +43,19 @@ function IsEligibleForExternalPurchaseCustomLinkIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — Whether the app can use
+        ExternalPurchaseCustomLink (iOS 18.1+).
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -34,6 +35,40 @@ function IsEligibleForIntroOfferIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>groupID</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Yes</td>
+            <td>Subscription group identifier.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the user is
+        eligible for the group's introductory offer.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
@@ -23,8 +23,9 @@ function IsEligibleForIntroOfferIOS() {
         12.2+).
       </p>
       <p>
-        Wraps <code>Product.SubscriptionInfo.isEligibleForIntroOffer(for:)</code>{' '}
-        — checks subscription-group level eligibility. See the{' '}
+        Wraps{' '}
+        <code>Product.SubscriptionInfo.isEligibleForIntroOffer(for:)</code> —
+        checks subscription-group level eligibility. See the{' '}
         <a
           href="https://developer.apple.com/documentation/storekit/product/subscriptioninfo/iseligibleforintrooffer(for:)"
           target="_blank"

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
@@ -40,28 +40,15 @@ function IsEligibleForIntroOfferIOS() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>groupID</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Yes</td>
-            <td>Subscription group identifier.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>groupID</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Subscription group identifier.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
@@ -22,6 +22,18 @@ function IsEligibleForIntroOfferIOS() {
         Check introductory offer eligibility for a subscription group (iOS
         12.2+).
       </p>
+      <p>
+        Wraps <code>Product.SubscriptionInfo.isEligibleForIntroOffer(for:)</code>{' '}
+        — checks subscription-group level eligibility. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/product/subscriptioninfo/iseligibleforintrooffer(for:)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
@@ -77,6 +77,49 @@ function IsEligibleForIntroOfferIOS() {
           swift: (
             <CodeBlock language="swift">{`func isEligibleForIntroOfferIOS(groupID: String) async throws -> Bool`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun isEligibleForIntroOfferIOS(groupID: String): Boolean`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`isEligibleForIntroOfferIOS(groupID: string): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> isEligibleForIntroOfferIOS(String groupID);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func is_eligible_for_intro_offer_ios(group_id: String) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let ok = try await OpenIapModule.shared.isEligibleForIntroOfferIOS(groupID: "com.app.subgroup")`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val ok = kmpIAP.isEligibleForIntroOfferIOS(groupID = "com.app.subgroup")`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { isEligibleForIntroOfferIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const ok = await isEligibleForIntroOfferIOS('com.app.subgroup');
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final ok = await FlutterInappPurchase.instance
+      .isEligibleForIntroOfferIOS('com.app.subgroup');
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var ok = await iap.is_eligible_for_intro_offer_ios("com.app.subgroup")`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
@@ -47,7 +47,7 @@ function IsEligibleForIntroOfferIOS() {
             <CodeBlock language="kotlin">{`suspend fun isEligibleForIntroOfferIOS(groupID: String): Boolean`}</CodeBlock>
           ),
           typescript: (
-            <CodeBlock language="typescript">{`isEligibleForIntroOfferIOS(groupID: string): Promise<boolean>`}</CodeBlock>
+            <CodeBlock language="typescript">{`isEligibleForIntroOfferIOS(groupId: string): Promise<boolean>`}</CodeBlock>
           ),
           dart: (
             <CodeBlock language="dart">{`Future<bool> isEligibleForIntroOfferIOS(String groupID);`}</CodeBlock>
@@ -63,11 +63,13 @@ function IsEligibleForIntroOfferIOS() {
       </AnchorLink>
       <ul className="api-params">
         <li>
-          <code>groupID</code>{' '}
+          <code>groupId</code>{' '}
           <em>
             (required, <code>string</code>)
           </em>{' '}
-          — Subscription group identifier.
+          — Subscription group identifier. (Native Swift / Kotlin signatures
+          spell it <code>groupID</code>; the JavaScript / Dart wrappers expose
+          it as <code>groupId</code>.)
         </li>
       </ul>
 

--- a/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-eligible-for-intro-offer-ios.tsx
@@ -37,27 +37,6 @@ function IsEligibleForIntroOfferIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <ul className="api-params">
-        <li>
-          <code>groupID</code>{' '}
-          <em>
-            (required, <code>string</code>)
-          </em>{' '}
-          — Subscription group identifier.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the user is
-        eligible for the group's introductory offer.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -78,6 +57,27 @@ function IsEligibleForIntroOfferIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <ul className="api-params">
+        <li>
+          <code>groupID</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Subscription group identifier.
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the user is
+        eligible for the group's introductory offer.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
@@ -35,27 +35,6 @@ function IsTransactionVerifiedIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <ul className="api-params">
-        <li>
-          <code>sku</code>{' '}
-          <em>
-            (required, <code>string</code>)
-          </em>{' '}
-          — Product identifier.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — Whether the latest transaction for{' '}
-        <code>sku</code> passed JWS verification.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -76,6 +55,27 @@ function IsTransactionVerifiedIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <ul className="api-params">
+        <li>
+          <code>sku</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Product identifier.
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — Whether the latest transaction for{' '}
+        <code>sku</code> passed JWS verification.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -32,6 +33,40 @@ function IsTransactionVerifiedIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>sku</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Yes</td>
+            <td>Product identifier.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — Whether the latest transaction for{' '}
+        <code>sku</code> passed JWS verification.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
@@ -20,6 +20,19 @@ function IsTransactionVerifiedIOS() {
         isTransactionVerifiedIOS
       </h1>
       <p>Verify a StoreKit 2 transaction signature (iOS 15+).</p>
+      <p>
+        Inspects the <code>VerificationResult</code> from{' '}
+        <code>Transaction.latest(for:)</code> — <code>.verified</code> vs{' '}
+        <code>.unverified</code>. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/verificationresult"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
@@ -51,7 +51,7 @@ function IsTransactionVerifiedIOS() {
             <CodeBlock language="dart">{`Future<bool> isTransactionVerifiedIOS(String sku);`}</CodeBlock>
           ),
           gdscript: (
-            <CodeBlock language="gdscript">{`func is_transaction_verified_ios(sku: String) -> Variant`}</CodeBlock>
+            <CodeBlock language="gdscript">{`func is_transaction_verified_ios(sku: String) -> bool`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
@@ -38,28 +38,15 @@ function IsTransactionVerifiedIOS() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>sku</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Yes</td>
-            <td>Product identifier.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>sku</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Product identifier.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/is-transaction-verified-ios.tsx
@@ -72,20 +72,20 @@ function IsTransactionVerifiedIOS() {
       <h2>Signature</h2>
       <LanguageTabs>
         {{
-          typescript: (
-            <CodeBlock language="typescript">{`isTransactionVerifiedIOS(sku: string): Promise<boolean>`}</CodeBlock>
-          ),
           swift: (
             <CodeBlock language="swift">{`func isTransactionVerifiedIOS(sku: String) async throws -> Bool`}</CodeBlock>
           ),
           kotlin: (
             <CodeBlock language="kotlin">{`suspend fun isTransactionVerifiedIOS(sku: String): Boolean`}</CodeBlock>
           ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun isTransactionVerifiedIOS(sku: String): Boolean`}</CodeBlock>
+          typescript: (
+            <CodeBlock language="typescript">{`isTransactionVerifiedIOS(sku: string): Promise<boolean>`}</CodeBlock>
           ),
           dart: (
             <CodeBlock language="dart">{`Future<bool> isTransactionVerifiedIOS(String sku);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func is_transaction_verified_ios(sku: String) -> Variant`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
@@ -93,47 +93,30 @@ function IsTransactionVerifiedIOS() {
       <h2>Example</h2>
       <LanguageTabs>
         {{
-          typescript: (
-            <CodeBlock language="typescript">{`// expo-iap
-import { isTransactionVerifiedIOS } from 'expo-iap';
-// Same API in react-native-iap:
-// import { isTransactionVerifiedIOS } from 'react-native-iap';
-
-const verified = await isTransactionVerifiedIOS('com.example.premium');
-if (!verified) {
-  // StoreKit 2 reported the JWS signature as unverified - don't grant entitlement.
-  return;
-}
-
-// --- Or alongside the useIAP() hook (also exported from react-native-iap) ---
-// isTransactionVerifiedIOS is a module-level helper; useIAP doesn't expose it
-// on the hook return, so call the module function from inside your component.
-import { useIAP } from 'expo-iap';
-
-function VerifyButton({ sku }: { sku: string }) {
-  const { connected } = useIAP();
-
-  const verify = async () => {
-    if (!connected) return;
-    const ok = await isTransactionVerifiedIOS(sku);
-    Alert.alert(ok ? 'Verified' : 'Verification failed');
-  };
-
-  return <Button title="Verify" onPress={verify} />;
-}`}</CodeBlock>
-          ),
           swift: (
-            <CodeBlock language="swift">{`let isVerified = try await OpenIapModule.shared.isTransactionVerifiedIOS(sku: "com.example.premium")`}</CodeBlock>
+            <CodeBlock language="swift">{`let ok = try await OpenIapModule.shared.isTransactionVerifiedIOS(sku: "com.app.premium")`}</CodeBlock>
           ),
           kotlin: (
-            <CodeBlock language="kotlin">{`val isVerified = openIapStore.isTransactionVerifiedIOS(sku = "com.example.premium")`}</CodeBlock>
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val ok = kmpIAP.isTransactionVerifiedIOS(sku = "com.app.premium")`}</CodeBlock>
           ),
-          kmp: (
-            <CodeBlock language="kotlin">{`val isVerified = kmpIAP.isTransactionVerifiedIOS(sku = "com.example.premium")`}</CodeBlock>
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { isTransactionVerifiedIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const ok = await isTransactionVerifiedIOS('com.app.premium');
+}`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`final isVerified = await FlutterInappPurchase.instance
-    .isTransactionVerifiedIOS('com.example.premium');`}</CodeBlock>
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final ok = await FlutterInappPurchase.instance
+      .isTransactionVerifiedIOS('com.app.premium');
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var ok = await iap.is_transaction_verified_ios("com.app.premium")`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
@@ -37,28 +37,15 @@ function LatestTransactionIOS() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>sku</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Yes</td>
-            <td>Product identifier.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>sku</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Product identifier.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
@@ -34,6 +34,27 @@ function LatestTransactionIOS() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`func latestTransactionIOS(sku: String) async throws -> Purchase?`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun latestTransactionIOS(sku: String): PurchaseIOS?`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`latestTransactionIOS(sku: string): Promise<PurchaseIOS | null>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<PurchaseIOS?> latestTransactionIOS(String sku);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func latest_transaction_ios(sku: String) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -57,27 +78,6 @@ function LatestTransactionIOS() {
         — iOS purchase shape, or <code>null</code> if the SKU has no matching
         transaction.
       </p>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          swift: (
-            <CodeBlock language="swift">{`func latestTransactionIOS(sku: String) async throws -> Purchase?`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`suspend fun latestTransactionIOS(sku: String): PurchaseIOS?`}</CodeBlock>
-          ),
-          typescript: (
-            <CodeBlock language="typescript">{`latestTransactionIOS(sku: string): Promise<PurchaseIOS | null>`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<PurchaseIOS?> latestTransactionIOS(String sku);`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func latest_transaction_ios(sku: String) -> Variant`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -30,6 +31,40 @@ function LatestTransactionIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>sku</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Yes</td>
+            <td>Product identifier.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;PurchaseIOS | null&gt;</code> — The latest verified
+        transaction for the product.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
@@ -77,6 +77,49 @@ function LatestTransactionIOS() {
           swift: (
             <CodeBlock language="swift">{`func latestTransactionIOS(sku: String) async throws -> Purchase?`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun latestTransactionIOS(sku: String): PurchaseIOS?`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`latestTransactionIOS(sku: string): Promise<PurchaseIOS | null>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<PurchaseIOS?> latestTransactionIOS(String sku);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func latest_transaction_ios(sku: String) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let tx = try await OpenIapModule.shared.latestTransactionIOS(sku: "com.app.premium")`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val tx = kmpIAP.latestTransactionIOS(sku = "com.app.premium")`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { latestTransactionIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const tx = await latestTransactionIOS('com.app.premium');
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final tx = await FlutterInappPurchase.instance
+      .latestTransactionIOS('com.app.premium');
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var tx = await iap.latest_transaction_ios("com.app.premium")`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
@@ -63,8 +64,11 @@ function LatestTransactionIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;PurchaseIOS | null&gt;</code> — The latest verified
-        transaction for the product.
+        <Link to="/docs/types/purchase">
+          <code>Promise&lt;PurchaseIOS | null&gt;</code>
+        </Link>{' '}
+        — iOS purchase shape, or <code>null</code> if the SKU has no matching
+        transaction.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/latest-transaction-ios.tsx
@@ -19,6 +19,18 @@ function LatestTransactionIOS() {
         latestTransactionIOS
       </h1>
       <p>Get the most recent transaction for a product (iOS 15+).</p>
+      <p>
+        Wraps <code>Transaction.latest(for:)</code> — returns the most recent
+        verified transaction (success or refund). See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/transaction/latest(for:)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
@@ -52,7 +52,7 @@ function PresentCodeRedemptionSheetIOS() {
             <CodeBlock language="dart">{`Future<bool> presentCodeRedemptionSheetIOS();`}</CodeBlock>
           ),
           gdscript: (
-            <CodeBlock language="gdscript">{`func present_code_redemption_sheet_ios() -> Variant`}</CodeBlock>
+            <CodeBlock language="gdscript">{`func present_code_redemption_sheet_ios() -> Types.VoidResult`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
@@ -55,6 +55,48 @@ function PresentCodeRedemptionSheetIOS() {
           swift: (
             <CodeBlock language="swift">{`func presentCodeRedemptionSheetIOS() async throws -> Bool`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun presentCodeRedemptionSheetIOS(): Boolean`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`presentCodeRedemptionSheetIOS(): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> presentCodeRedemptionSheetIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func present_code_redemption_sheet_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`try await OpenIapModule.shared.presentCodeRedemptionSheetIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+kmpIAP.presentCodeRedemptionSheetIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { presentCodeRedemptionSheetIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  await presentCodeRedemptionSheetIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  await FlutterInappPurchase.instance.presentCodeRedemptionSheetIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var result = await iap.present_code_redemption_sheet_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
 

--- a/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
@@ -36,14 +36,6 @@ function PresentCodeRedemptionSheetIOS() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the
-        redemption sheet has been presented.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -64,6 +56,14 @@ function PresentCodeRedemptionSheetIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the
+        redemption sheet has been presented.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -33,6 +34,19 @@ function PresentCodeRedemptionSheetIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the
+        redemption sheet has been presented.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
@@ -20,6 +20,19 @@ function PresentCodeRedemptionSheetIOS() {
         presentCodeRedemptionSheetIOS
       </h1>
       <p>Present the App Store promo code redemption sheet.</p>
+      <p>
+        Wraps <code>SKPaymentQueue.presentCodeRedemptionSheet()</code> (UIKit) /{' '}
+        <code>AppStore.presentOfferCodeRedeemSheet(in:)</code> (StoreKit 2). See
+        the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/appstore/presentoffercoderedeemsheet(in:)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
@@ -21,11 +21,12 @@ function PresentCodeRedemptionSheetIOS() {
       </h1>
       <p>Present the App Store promo code redemption sheet.</p>
       <p>
-        Wraps <code>SKPaymentQueue.presentCodeRedemptionSheet()</code> (UIKit) /{' '}
-        <code>AppStore.presentOfferCodeRedeemSheet(in:)</code> (StoreKit 2). See
-        the{' '}
+        Calls <code>SKPaymentQueue.default().presentCodeRedemptionSheet()</code>{' '}
+        (the StoreKit 1 API — the StoreKit 2 equivalent{' '}
+        <code>AppStore.presentOfferCodeRedeemSheet(in:)</code> is not currently
+        wired through this wrapper). See the{' '}
         <a
-          href="https://developer.apple.com/documentation/storekit/appstore/presentoffercoderedeemsheet(in:)"
+          href="https://developer.apple.com/documentation/storekit/skpaymentqueue/presentcoderedemptionsheet()"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-code-redemption-sheet-ios.tsx
@@ -36,11 +36,6 @@ function PresentCodeRedemptionSheetIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
@@ -20,16 +20,20 @@ function PresentExternalPurchaseLinkIOS() {
         <span className="platform-badge platform-badge--ios">iOS</span>{' '}
         presentExternalPurchaseLinkIOS
       </h1>
-      <p>Open external purchase URL in Safari (iOS 16+).</p>
+      <p>Open an external purchase URL outside the app (iOS 16+).</p>
       <p>
-        Wraps <code>ExternalPurchaseLink.open(url:)</code> — StoreKit External,
-        iOS 16+ (EU app store). See the{' '}
+        Opens the URL via{' '}
+        <code>UIApplication.open(_:options:completionHandler:)</code> after a{' '}
+        <code>canOpenURL</code> guard — the openiap-apple implementation routes
+        through UIKit rather than StoreKit's <code>ExternalPurchaseLink</code>{' '}
+        API. The native call must still be gated by the StoreKit
+        external-purchase entitlement on production builds. See the{' '}
         <a
-          href="https://developer.apple.com/documentation/storekit/externalpurchaselink"
+          href="https://developer.apple.com/documentation/uikit/uiapplication/1648685-open"
           target="_blank"
           rel="noopener noreferrer"
         >
-          Apple StoreKit reference
+          Apple UIApplication.open reference
         </a>
         .
       </p>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
@@ -82,6 +82,49 @@ struct ExternalPurchaseLinkResultIOS {
     let success: Bool
 }`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun presentExternalPurchaseLinkIOS(url: String): ExternalPurchaseLinkResultIOS`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`presentExternalPurchaseLinkIOS(url: string): Promise<ExternalPurchaseLinkResultIOS>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<ExternalPurchaseLinkResultIOS> presentExternalPurchaseLinkIOS(String url);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func present_external_purchase_link_ios(url: String) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let result = try await OpenIapModule.shared.presentExternalPurchaseLinkIOS("https://yourstore.com/checkout")`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val result = kmpIAP.presentExternalPurchaseLinkIOS(url = "https://yourstore.com/checkout")`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { presentExternalPurchaseLinkIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  await presentExternalPurchaseLinkIOS('https://yourstore.com/checkout');
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  await FlutterInappPurchase.instance
+      .presentExternalPurchaseLinkIOS('https://yourstore.com/checkout');
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var result = await iap.present_external_purchase_link_ios("https://yourstore.com/checkout")`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
@@ -63,8 +64,11 @@ function PresentExternalPurchaseLinkIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;ExternalPurchaseLinkResultIOS&gt;</code> — Result
-        envelope.
+        <Link to="/docs/types/external-purchase-link">
+          <code>Promise&lt;ExternalPurchaseLinkResultIOS&gt;</code>
+        </Link>{' '}
+        — carries the result of opening the external link (success flag + any
+        error string from StoreKit).
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -30,6 +31,40 @@ function PresentExternalPurchaseLinkIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>url</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Yes</td>
+            <td>External purchase URL to present.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;ExternalPurchaseLinkResultIOS&gt;</code> — Result
+        envelope.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
@@ -12,7 +12,7 @@ function PresentExternalPurchaseLinkIOS() {
     <div className="doc-page">
       <SEO
         title="presentExternalPurchaseLinkIOS"
-        description="Open external purchase URL in Safari (iOS 18.2+)."
+        description="Open external purchase URL in Safari (iOS 16+)."
         path="/docs/apis/ios/present-external-purchase-link-ios"
         keywords="presentExternalPurchaseLinkIOS, external link, external purchase"
       />
@@ -20,7 +20,7 @@ function PresentExternalPurchaseLinkIOS() {
         <span className="platform-badge platform-badge--ios">iOS</span>{' '}
         presentExternalPurchaseLinkIOS
       </h1>
-      <p>Open external purchase URL in Safari (iOS 18.2+).</p>
+      <p>Open external purchase URL in Safari (iOS 16+).</p>
       <p>
         Wraps <code>ExternalPurchaseLink.open(url:)</code> — StoreKit External,
         iOS 16+ (EU app store). See the{' '}

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
@@ -37,28 +37,15 @@ function PresentExternalPurchaseLinkIOS() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>url</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Yes</td>
-            <td>External purchase URL to present.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>url</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — External purchase URL to present.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
@@ -34,30 +34,6 @@ function PresentExternalPurchaseLinkIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <ul className="api-params">
-        <li>
-          <code>url</code>{' '}
-          <em>
-            (required, <code>string</code>)
-          </em>{' '}
-          — External purchase URL to present.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <Link to="/docs/types/external-purchase-link">
-          <code>Promise&lt;ExternalPurchaseLinkResultIOS&gt;</code>
-        </Link>{' '}
-        — carries the result of opening the external link (success flag + any
-        error string from StoreKit).
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -83,6 +59,30 @@ struct ExternalPurchaseLinkResultIOS {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <ul className="api-params">
+        <li>
+          <code>url</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — External purchase URL to present.
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <Link to="/docs/types/external-purchase-link">
+          <code>Promise&lt;ExternalPurchaseLinkResultIOS&gt;</code>
+        </Link>{' '}
+        — carries the result of opening the external link (success flag + any
+        error string from StoreKit).
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-link-ios.tsx
@@ -19,6 +19,18 @@ function PresentExternalPurchaseLinkIOS() {
         presentExternalPurchaseLinkIOS
       </h1>
       <p>Open external purchase URL in Safari (iOS 18.2+).</p>
+      <p>
+        Wraps <code>ExternalPurchaseLink.open(url:)</code> — StoreKit External,
+        iOS 16+ (EU app store). See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/externalpurchaselink"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
@@ -19,6 +19,18 @@ function PresentExternalPurchaseNoticeSheetIOS() {
         presentExternalPurchaseNoticeSheetIOS
       </h1>
       <p>Present Apple's compliance notice sheet (iOS 17.4+).</p>
+      <p>
+        Wraps <code>ExternalPurchase.presentNoticeSheet()</code> — returns a
+        token if the user accepts. iOS 17.4+. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -30,6 +31,19 @@ function PresentExternalPurchaseNoticeSheetIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;ExternalPurchaseNoticeResultIOS&gt;</code> — Carries a
+        token if the user accepts.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
@@ -43,7 +43,7 @@ function PresentExternalPurchaseNoticeSheetIOS() {
         Returns
       </AnchorLink>
       <p>
-        <Link to="/docs/types/external-purchase-link">
+        <Link to="/docs/types/external-purchase-link#external-purchase-types">
           <code>Promise&lt;ExternalPurchaseNoticeResultIOS&gt;</code>
         </Link>{' '}
         — carries:
@@ -62,21 +62,34 @@ function PresentExternalPurchaseNoticeSheetIOS() {
               <code>result</code>
             </td>
             <td>
-              <code>'continue' | 'cancelled'</code>
+              <code>'continue' | 'dismissed'</code>
             </td>
-            <td>Whether the user accepted the notice or dismissed it.</td>
+            <td>
+              User action on the notice sheet — see{' '}
+              <code>ExternalPurchaseNoticeAction</code>.
+            </td>
           </tr>
           <tr>
             <td>
-              <code>token</code>
+              <code>externalPurchaseToken</code>
             </td>
             <td>
               <code>string?</code>
             </td>
             <td>
-              Reporting token returned by Apple when the user continues. Pass to
-              your backend.
+              Reporting token returned by Apple when the user continues (
+              <code>result === 'continue'</code>). Pass to your backend / send
+              to Apple's External Purchase Server API.
             </td>
+          </tr>
+          <tr>
+            <td>
+              <code>error</code>
+            </td>
+            <td>
+              <code>string?</code>
+            </td>
+            <td>Populated when the sheet failed to present.</td>
           </tr>
         </tbody>
       </table>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
@@ -42,9 +43,43 @@ function PresentExternalPurchaseNoticeSheetIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;ExternalPurchaseNoticeResultIOS&gt;</code> — Carries a
-        token if the user accepts.
+        <Link to="/docs/types/external-purchase-link">
+          <code>Promise&lt;ExternalPurchaseNoticeResultIOS&gt;</code>
+        </Link>{' '}
+        — carries:
       </p>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>result</code>
+            </td>
+            <td>
+              <code>'continue' | 'cancelled'</code>
+            </td>
+            <td>Whether the user accepted the notice or dismissed it.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>token</code>
+            </td>
+            <td>
+              <code>string?</code>
+            </td>
+            <td>
+              Reporting token returned by Apple when the user continues. Pass to
+              your backend.
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
@@ -34,6 +34,33 @@ function PresentExternalPurchaseNoticeSheetIOS() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`func presentExternalPurchaseNoticeSheetIOS() async throws -> ExternalPurchaseNoticeResultIOS
+
+struct ExternalPurchaseNoticeResultIOS {
+    let result: ExternalPurchaseNoticeAction
+    let error: String?
+    let externalPurchaseToken: String?
+}`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun presentExternalPurchaseNoticeSheetIOS(): ExternalPurchaseNoticeResultIOS`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`presentExternalPurchaseNoticeSheetIOS(): Promise<ExternalPurchaseNoticeResultIOS>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<ExternalPurchaseNoticeResultIOS> presentExternalPurchaseNoticeSheetIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func present_external_purchase_notice_sheet_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>
@@ -69,33 +96,6 @@ function PresentExternalPurchaseNoticeSheetIOS() {
           — Populated when the sheet failed to present.
         </li>
       </ul>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          swift: (
-            <CodeBlock language="swift">{`func presentExternalPurchaseNoticeSheetIOS() async throws -> ExternalPurchaseNoticeResultIOS
-
-struct ExternalPurchaseNoticeResultIOS {
-    let result: ExternalPurchaseNoticeAction
-    let error: String?
-    let externalPurchaseToken: String?
-}`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`suspend fun presentExternalPurchaseNoticeSheetIOS(): ExternalPurchaseNoticeResultIOS`}</CodeBlock>
-          ),
-          typescript: (
-            <CodeBlock language="typescript">{`presentExternalPurchaseNoticeSheetIOS(): Promise<ExternalPurchaseNoticeResultIOS>`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<ExternalPurchaseNoticeResultIOS> presentExternalPurchaseNoticeSheetIOS();`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func present_external_purchase_notice_sheet_ios() -> Variant`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
@@ -34,11 +34,6 @@ function PresentExternalPurchaseNoticeSheetIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>
@@ -48,51 +43,32 @@ function PresentExternalPurchaseNoticeSheetIOS() {
         </Link>{' '}
         — carries:
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>result</code>
-            </td>
-            <td>
-              <code>'continue' | 'dismissed'</code>
-            </td>
-            <td>
-              User action on the notice sheet — see{' '}
-              <code>ExternalPurchaseNoticeAction</code>.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>externalPurchaseToken</code>
-            </td>
-            <td>
-              <code>string?</code>
-            </td>
-            <td>
-              Reporting token returned by Apple when the user continues (
-              <code>result === 'continue'</code>). Pass to your backend / send
-              to Apple's External Purchase Server API.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>error</code>
-            </td>
-            <td>
-              <code>string?</code>
-            </td>
-            <td>Populated when the sheet failed to present.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>result</code>{' '}
+          <em>
+            (<code>'continue' | 'dismissed'</code>)
+          </em>{' '}
+          — User action on the notice sheet — see{' '}
+          <code>ExternalPurchaseNoticeAction</code>.
+        </li>
+        <li>
+          <code>externalPurchaseToken</code>{' '}
+          <em>
+            (<code>string?</code>)
+          </em>{' '}
+          — Reporting token returned by Apple when the user continues (
+          <code>result === 'continue'</code>). Pass to your backend / send to
+          Apple's External Purchase Server API.
+        </li>
+        <li>
+          <code>error</code>{' '}
+          <em>
+            (<code>string?</code>)
+          </em>{' '}
+          — Populated when the sheet failed to present.
+        </li>
+      </ul>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/present-external-purchase-notice-sheet-ios.tsx
@@ -93,6 +93,49 @@ struct ExternalPurchaseNoticeResultIOS {
     let externalPurchaseToken: String?
 }`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun presentExternalPurchaseNoticeSheetIOS(): ExternalPurchaseNoticeResultIOS`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`presentExternalPurchaseNoticeSheetIOS(): Promise<ExternalPurchaseNoticeResultIOS>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<ExternalPurchaseNoticeResultIOS> presentExternalPurchaseNoticeSheetIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func present_external_purchase_notice_sheet_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let result = try await OpenIapModule.shared.presentExternalPurchaseNoticeSheetIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val result = kmpIAP.presentExternalPurchaseNoticeSheetIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { presentExternalPurchaseNoticeSheetIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const result = await presentExternalPurchaseNoticeSheetIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final result = await FlutterInappPurchase.instance
+      .presentExternalPurchaseNoticeSheetIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var result = await iap.present_external_purchase_notice_sheet_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/request-purchase-on-promoted-product-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/request-purchase-on-promoted-product-ios.tsx
@@ -22,6 +22,19 @@ function RequestPurchaseOnPromotedProductIOS() {
       <p>
         Deprecated. Use promotedProductListenerIOS plus requestPurchase instead.
       </p>
+      <p>
+        Triggers the promoted product's purchase. <strong>Deprecated</strong> —
+        prefer <code>promotedProductListenerIOS</code> +{' '}
+        <code>requestPurchase</code> for StoreKit 2. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/in-app-purchase/promoting-in-app-purchases"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <div className="alert-card alert-card--warning">
         <p>

--- a/packages/docs/src/pages/docs/apis/ios/request-purchase-on-promoted-product-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/request-purchase-on-promoted-product-ios.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -44,6 +45,22 @@ function RequestPurchaseOnPromotedProductIOS() {
           <Link to="/docs/apis/request-purchase">requestPurchase</Link> instead.
         </p>
       </div>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>
+        None. <strong>Deprecated</strong> — use{' '}
+        <code>promotedProductListenerIOS</code> + <code>requestPurchase</code>.
+      </p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the request
+        was dispatched.
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/request-purchase-on-promoted-product-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/request-purchase-on-promoted-product-ios.tsx
@@ -46,14 +46,6 @@ function RequestPurchaseOnPromotedProductIOS() {
         </p>
       </div>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the request
-        was dispatched.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -77,6 +69,14 @@ Future<bool> requestPurchaseOnPromotedProductIOS();`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the request
+        was dispatched.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/request-purchase-on-promoted-product-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/request-purchase-on-promoted-product-ios.tsx
@@ -46,14 +46,6 @@ function RequestPurchaseOnPromotedProductIOS() {
         </p>
       </div>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>
-        None. <strong>Deprecated</strong> — use{' '}
-        <code>promotedProductListenerIOS</code> + <code>requestPurchase</code>.
-      </p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/request-purchase-on-promoted-product-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/request-purchase-on-promoted-product-ios.tsx
@@ -69,6 +69,54 @@ function RequestPurchaseOnPromotedProductIOS() {
             <CodeBlock language="swift">{`@available(*, deprecated, message: "Use promotedProductListenerIOS + requestPurchase instead")
 func requestPurchaseOnPromotedProductIOS() async throws -> Bool`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`@Deprecated("Use promotedProductListenerIOS + requestPurchase instead")
+suspend fun requestPurchaseOnPromotedProductIOS(): Boolean`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`requestPurchaseOnPromotedProductIOS(): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`@Deprecated('Use promotedProductListenerIOS + requestPurchase instead')
+Future<bool> requestPurchaseOnPromotedProductIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func request_purchase_on_promoted_product_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`// Deprecated — prefer promotedProductListenerIOS + requestPurchase.
+try await OpenIapModule.shared.requestPurchaseOnPromotedProductIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+// Deprecated — prefer promotedProductListenerIOS + requestPurchase.
+kmpIAP.requestPurchaseOnPromotedProductIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+// Deprecated — prefer promotedProductListenerIOS + requestPurchase.
+import { requestPurchaseOnPromotedProductIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  await requestPurchaseOnPromotedProductIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`// Deprecated — prefer promotedProductListenerIOS + requestPurchase.
+if (Platform.isIOS) {
+  await FlutterInappPurchase.instance.requestPurchaseOnPromotedProductIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var ok = await iap.request_purchase_on_promoted_product_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
@@ -76,7 +76,7 @@ function ShowExternalPurchaseCustomLinkNoticeIOS() {
         Returns
       </AnchorLink>
       <p>
-        <Link to="/docs/types/external-purchase-link">
+        <Link to="/docs/types/external-purchase-link#external-purchase-custom-link-notice-result-ios">
           <code>Promise&lt;ExternalPurchaseCustomLinkNoticeResultIOS&gt;</code>
         </Link>{' '}
         — the user's response (<code>continue</code> / <code>cancelled</code>)

--- a/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
@@ -31,6 +31,18 @@ function ShowExternalPurchaseCustomLinkNoticeIOS() {
         deliberate customer interaction, before you can route the user to an
         external purchase URL.
       </p>
+      <p>
+        Wraps <code>ExternalPurchaseCustomLink.showNotice(type:)</code> —
+        required disclosure sheet before linking out. iOS 18.1+. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
@@ -91,6 +91,61 @@ function ShowExternalPurchaseCustomLinkNoticeIOS() {
     noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS
 ) async throws -> ExternalPurchaseCustomLinkNoticeResultIOS`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun showExternalPurchaseCustomLinkNoticeIOS(
+    noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS
+): ExternalPurchaseCustomLinkNoticeResultIOS`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`showExternalPurchaseCustomLinkNoticeIOS(
+  noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS,
+): Promise<ExternalPurchaseCustomLinkNoticeResultIOS>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<ExternalPurchaseCustomLinkNoticeResultIOS>
+    showExternalPurchaseCustomLinkNoticeIOS(
+  ExternalPurchaseCustomLinkNoticeTypeIOS noticeType,
+);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func show_external_purchase_custom_link_notice_ios(notice_type: String) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let result = try await OpenIapModule.shared.showExternalPurchaseCustomLinkNoticeIOS(
+    noticeType: .continue
+)`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val result = kmpIAP.showExternalPurchaseCustomLinkNoticeIOS(
+    noticeType = ExternalPurchaseCustomLinkNoticeTypeIOS.CONTINUE
+)`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { showExternalPurchaseCustomLinkNoticeIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  await showExternalPurchaseCustomLinkNoticeIOS('continue');
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  await FlutterInappPurchase.instance.showExternalPurchaseCustomLinkNoticeIOS(
+    ExternalPurchaseCustomLinkNoticeTypeIOS.continue_,
+  );
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var result = await iap.show_external_purchase_custom_link_notice_ios("continue")`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
 

--- a/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -42,6 +43,40 @@ function ShowExternalPurchaseCustomLinkNoticeIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>noticeType</code>
+            </td>
+            <td>
+              <code>ExternalPurchaseCustomLinkNoticeTypeIOS</code>
+            </td>
+            <td>Yes</td>
+            <td>Disclosure style.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;ExternalPurchaseCustomLinkNoticeResultIOS&gt;</code> —
+        Disclosure result.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
@@ -49,28 +49,15 @@ function ShowExternalPurchaseCustomLinkNoticeIOS() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>noticeType</code>
-            </td>
-            <td>
-              <code>ExternalPurchaseCustomLinkNoticeTypeIOS</code>
-            </td>
-            <td>Yes</td>
-            <td>Disclosure style.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>noticeType</code>{' '}
+          <em>
+            (required, <code>ExternalPurchaseCustomLinkNoticeTypeIOS</code>)
+          </em>{' '}
+          — Disclosure style.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
@@ -46,30 +46,6 @@ function ShowExternalPurchaseCustomLinkNoticeIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <ul className="api-params">
-        <li>
-          <code>noticeType</code>{' '}
-          <em>
-            (required, <code>ExternalPurchaseCustomLinkNoticeTypeIOS</code>)
-          </em>{' '}
-          — Disclosure style.
-        </li>
-      </ul>
-
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <Link to="/docs/types/external-purchase-link#external-purchase-custom-link-notice-result-ios">
-          <code>Promise&lt;ExternalPurchaseCustomLinkNoticeResultIOS&gt;</code>
-        </Link>{' '}
-        — the user's response (<code>continue</code> / <code>cancelled</code>)
-        plus the disclosure type that was shown.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -99,6 +75,30 @@ function ShowExternalPurchaseCustomLinkNoticeIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <ul className="api-params">
+        <li>
+          <code>noticeType</code>{' '}
+          <em>
+            (required, <code>ExternalPurchaseCustomLinkNoticeTypeIOS</code>)
+          </em>{' '}
+          — Disclosure style.
+        </li>
+      </ul>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <Link to="/docs/types/external-purchase-link#external-purchase-custom-link-notice-result-ios">
+          <code>Promise&lt;ExternalPurchaseCustomLinkNoticeResultIOS&gt;</code>
+        </Link>{' '}
+        — the user's response (<code>continue</code> / <code>cancelled</code>)
+        plus the disclosure type that was shown.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
@@ -96,50 +96,66 @@ function ShowExternalPurchaseCustomLinkNoticeIOS() {
         <Link to="/docs/types/external-purchase-link#external-purchase-custom-link-notice-result-ios">
           <code>Promise&lt;ExternalPurchaseCustomLinkNoticeResultIOS&gt;</code>
         </Link>{' '}
-        — the user's response (<code>continue</code> / <code>cancelled</code>)
-        plus the disclosure type that was shown.
+        — carries:
       </p>
+      <ul className="api-params">
+        <li>
+          <code>continued</code>{' '}
+          <em>
+            (<code>boolean</code>)
+          </em>{' '}
+          — Whether the user chose to continue to the external purchase.
+        </li>
+        <li>
+          <code>error</code>{' '}
+          <em>
+            (<code>string?</code>)
+          </em>{' '}
+          — Populated when the sheet fails to present.
+        </li>
+      </ul>
 
       <h2>Example</h2>
       <LanguageTabs>
         {{
           swift: (
             <CodeBlock language="swift">{`let result = try await OpenIapModule.shared.showExternalPurchaseCustomLinkNoticeIOS(
-    noticeType: .continue
+    noticeType: .browser
 )`}</CodeBlock>
           ),
           kotlin: (
             <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
 val result = kmpIAP.showExternalPurchaseCustomLinkNoticeIOS(
-    noticeType = ExternalPurchaseCustomLinkNoticeTypeIOS.CONTINUE
+    noticeType = ExternalPurchaseCustomLinkNoticeTypeIOS.Browser
 )`}</CodeBlock>
           ),
           typescript: (
             <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { Platform } from 'react-native';
 import { showExternalPurchaseCustomLinkNoticeIOS } from 'expo-iap';
 
 if (Platform.OS === 'ios') {
-  await showExternalPurchaseCustomLinkNoticeIOS('continue');
+  await showExternalPurchaseCustomLinkNoticeIOS('browser');
 }`}</CodeBlock>
           ),
           dart: (
             <CodeBlock language="dart">{`if (Platform.isIOS) {
   await FlutterInappPurchase.instance.showExternalPurchaseCustomLinkNoticeIOS(
-    ExternalPurchaseCustomLinkNoticeTypeIOS.continue_,
+    ExternalPurchaseCustomLinkNoticeTypeIOS.Browser,
   );
 }`}</CodeBlock>
           ),
           gdscript: (
             <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
-    var result = await iap.show_external_purchase_custom_link_notice_ios("continue")`}</CodeBlock>
+    var result = await iap.show_external_purchase_custom_link_notice_ios("browser")`}</CodeBlock>
           ),
         }}
       </LanguageTabs>
 
       <p>
-        <code>noticeType</code> picks the disclosure style required by the flow
-        you are entering (e.g. <code>.acquisition</code> for first-time
-        payments, <code>.services</code> for ongoing services).
+        <code>ExternalPurchaseCustomLinkNoticeTypeIOS</code> currently has a
+        single value: <code>'browser'</code> (case-sensitive — Swift / Kotlin /
+        Dart spell it as <code>.browser</code> / <code>.Browser</code>).
       </p>
     </div>
   );

--- a/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-external-purchase-custom-link-notice-ios.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
@@ -75,8 +76,11 @@ function ShowExternalPurchaseCustomLinkNoticeIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;ExternalPurchaseCustomLinkNoticeResultIOS&gt;</code> —
-        Disclosure result.
+        <Link to="/docs/types/external-purchase-link">
+          <code>Promise&lt;ExternalPurchaseCustomLinkNoticeResultIOS&gt;</code>
+        </Link>{' '}
+        — the user's response (<code>continue</code> / <code>cancelled</code>)
+        plus the disclosure type that was shown.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
@@ -26,10 +26,10 @@ function ShowManageSubscriptionsIOS() {
       <p>
         Opens Apple's subscription-management surface for the user. The current
         iOS implementation forwards to the module's{' '}
-        <code>deepLinkToSubscriptions(nil)</code> path (which calls{' '}
-        <code>AppStore.showManageSubscriptions(in:)</code> when a window scene
-        is available, otherwise falls back to opening the App Store deep link).
-        iOS 15+. See the{' '}
+        <code>deepLinkToSubscriptions(nil)</code> path, which calls{' '}
+        <code>AppStore.showManageSubscriptions(in:)</code> with the active{' '}
+        <code>UIWindowScene</code>; if no scene is available the call throws
+        instead of falling back to a URL. iOS 15+. See the{' '}
         <a
           href="https://developer.apple.com/documentation/storekit/appstore/showmanagesubscriptions(in:)"
           target="_blank"

--- a/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
@@ -65,6 +65,49 @@ function ShowManageSubscriptionsIOS() {
           swift: (
             <CodeBlock language="swift">{`func showManageSubscriptionsIOS() async throws -> [Purchase]`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun showManageSubscriptionsIOS(): List<PurchaseIOS>`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`showManageSubscriptionsIOS(): Promise<PurchaseIOS[]>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<List<PurchaseIOS>> showManageSubscriptionsIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func show_manage_subscriptions_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let changed = try await OpenIapModule.shared.showManageSubscriptionsIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val changed = kmpIAP.showManageSubscriptionsIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { showManageSubscriptionsIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const changed = await showManageSubscriptionsIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final changed = await FlutterInappPurchase.instance
+      .showManageSubscriptionsIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var changed = await iap.show_manage_subscriptions_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
@@ -42,18 +42,6 @@ function ShowManageSubscriptionsIOS() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <Link to="/docs/types/purchase">
-          <code>Promise&lt;PurchaseIOS[]&gt;</code>
-        </Link>{' '}
-        — purchases whose status changed while the manage-subscriptions sheet
-        was on screen (e.g. cancelled or auto-renew toggled). Empty array when
-        nothing changed.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -74,6 +62,18 @@ function ShowManageSubscriptionsIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <Link to="/docs/types/purchase">
+          <code>Promise&lt;PurchaseIOS[]&gt;</code>
+        </Link>{' '}
+        — purchases whose status changed while the manage-subscriptions sheet
+        was on screen (e.g. cancelled or auto-renew toggled). Empty array when
+        nothing changed.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
@@ -42,11 +42,6 @@ function ShowManageSubscriptionsIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -38,6 +39,19 @@ function ShowManageSubscriptionsIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;PurchaseIOS[]&gt;</code> — Purchases whose status
+        changed while the sheet was presented.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
@@ -24,8 +24,12 @@ function ShowManageSubscriptionsIOS() {
         changed.
       </p>
       <p>
-        Wraps <code>AppStore.showManageSubscriptions(in:)</code> — presents the
-        system manage-subscriptions sheet. iOS 15+. See the{' '}
+        Opens Apple's subscription-management surface for the user. The current
+        iOS implementation forwards to the module's{' '}
+        <code>deepLinkToSubscriptions(nil)</code> path (which calls{' '}
+        <code>AppStore.showManageSubscriptions(in:)</code> when a window scene
+        is available, otherwise falls back to opening the App Store deep link).
+        iOS 15+. See the{' '}
         <a
           href="https://developer.apple.com/documentation/storekit/appstore/showmanagesubscriptions(in:)"
           target="_blank"

--- a/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
@@ -50,8 +51,12 @@ function ShowManageSubscriptionsIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;PurchaseIOS[]&gt;</code> — Purchases whose status
-        changed while the sheet was presented.
+        <Link to="/docs/types/purchase">
+          <code>Promise&lt;PurchaseIOS[]&gt;</code>
+        </Link>{' '}
+        — purchases whose status changed while the manage-subscriptions sheet
+        was on screen (e.g. cancelled or auto-renew toggled). Empty array when
+        nothing changed.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/show-manage-subscriptions-ios.tsx
@@ -23,6 +23,18 @@ function ShowManageSubscriptionsIOS() {
         15+). Returns purchases for subscriptions whose auto-renewal status
         changed.
       </p>
+      <p>
+        Wraps <code>AppStore.showManageSubscriptions(in:)</code> — presents the
+        system manage-subscriptions sheet. iOS 15+. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/appstore/showmanagesubscriptions(in:)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
@@ -117,6 +117,49 @@ function SubscriptionStatusIOS() {
           swift: (
             <CodeBlock language="swift">{`func subscriptionStatusIOS(sku: String) async throws -> [SubscriptionStatusIOS]`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun subscriptionStatusIOS(sku: String): List<SubscriptionStatusIOS>`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`subscriptionStatusIOS(sku: string): Promise<SubscriptionStatusIOS[]>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<List<SubscriptionStatusIOS>> subscriptionStatusIOS(String sku);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func subscription_status_ios(sku: String) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`let status = try await OpenIapModule.shared.subscriptionStatusIOS(sku: "com.app.monthly")`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+val status = kmpIAP.subscriptionStatusIOS(sku = "com.app.monthly")`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { subscriptionStatusIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  const status = await subscriptionStatusIOS('com.app.monthly');
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  final status = await FlutterInappPurchase.instance
+      .subscriptionStatusIOS('com.app.monthly');
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var status = await iap.subscription_status_ios("com.app.monthly")`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
@@ -38,6 +38,27 @@ function SubscriptionStatusIOS() {
         .
       </p>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`func subscriptionStatusIOS(sku: String) async throws -> [SubscriptionStatusIOS]`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun subscriptionStatusIOS(sku: String): List<SubscriptionStatusIOS>`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`subscriptionStatusIOS(sku: string): Promise<SubscriptionStatusIOS[]>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<List<SubscriptionStatusIOS>> subscriptionStatusIOS(String sku);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func subscription_status_ios(sku: String) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -82,27 +103,6 @@ function SubscriptionStatusIOS() {
           May be <code>null</code>.
         </li>
       </ul>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          swift: (
-            <CodeBlock language="swift">{`func subscriptionStatusIOS(sku: String) async throws -> [SubscriptionStatusIOS]`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`suspend fun subscriptionStatusIOS(sku: String): List<SubscriptionStatusIOS>`}</CodeBlock>
-          ),
-          typescript: (
-            <CodeBlock language="typescript">{`subscriptionStatusIOS(sku: string): Promise<SubscriptionStatusIOS[]>`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<List<SubscriptionStatusIOS>> subscriptionStatusIOS(String sku);`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func subscription_status_ios(sku: String) -> Variant`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
@@ -41,28 +41,15 @@ function SubscriptionStatusIOS() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>sku</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>Yes</td>
-            <td>Subscription product identifier.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>sku</code>{' '}
+          <em>
+            (required, <code>string</code>)
+          </em>{' '}
+          — Subscription product identifier.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns
@@ -73,43 +60,28 @@ function SubscriptionStatusIOS() {
         </Link>{' '}
         — one entry per status the user has on the subscription:
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>state</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>
-              StoreKit 2 renewal state (e.g. <code>"subscribed"</code>,{' '}
-              <code>"inGracePeriod"</code>, <code>"expired"</code>).
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>renewalInfo</code>
-            </td>
-            <td>
-              <Link to="/docs/types/ios/renewal-info-ios">
-                <code>RenewalInfoIOS?</code>
-              </Link>
-            </td>
-            <td>
-              Renewal metadata (auto-renew flag, renewal date, expiration
-              reason). May be <code>null</code>.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>state</code>{' '}
+          <em>
+            (<code>string</code>)
+          </em>{' '}
+          — StoreKit 2 renewal state (e.g. <code>"subscribed"</code>,{' '}
+          <code>"inGracePeriod"</code>, <code>"expired"</code>).
+        </li>
+        <li>
+          <code>renewalInfo</code>{' '}
+          <em>
+            (
+            <Link to="/docs/types/ios/renewal-info-ios">
+              <code>RenewalInfoIOS?</code>
+            </Link>
+            )
+          </em>{' '}
+          — Renewal metadata (auto-renew flag, renewal date, expiration reason).
+          May be <code>null</code>.
+        </li>
+      </ul>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
@@ -67,9 +68,48 @@ function SubscriptionStatusIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;SubscriptionStatusIOS[]&gt;</code> — Status objects
-        from <code>Product.SubscriptionInfo.status</code>.
+        <Link to="/docs/types/ios/subscription-status-ios">
+          <code>Promise&lt;SubscriptionStatusIOS[]&gt;</code>
+        </Link>{' '}
+        — one entry per status the user has on the subscription:
       </p>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>state</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>
+              StoreKit 2 renewal state (e.g. <code>"subscribed"</code>,{' '}
+              <code>"inGracePeriod"</code>, <code>"expired"</code>).
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>renewalInfo</code>
+            </td>
+            <td>
+              <Link to="/docs/types/ios/renewal-info-ios">
+                <code>RenewalInfoIOS?</code>
+              </Link>
+            </td>
+            <td>
+              Renewal metadata (auto-renew flag, renewal date, expiration
+              reason). May be <code>null</code>.
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -34,6 +35,40 @@ function SubscriptionStatusIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>sku</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>Yes</td>
+            <td>Subscription product identifier.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;SubscriptionStatusIOS[]&gt;</code> — Status objects
+        from <code>Product.SubscriptionInfo.status</code>.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
@@ -20,9 +20,12 @@ function SubscriptionStatusIOS() {
       </h1>
       <p>Get detailed subscription status using StoreKit 2 (iOS 15+).</p>
       <p>
-        Wraps <code>Product.SubscriptionInfo.status</code> — returns the array
-        of <code>Status</code> objects with <code>transaction</code>,{' '}
-        <code>renewalInfo</code>, <code>state</code>. iOS 15+. See the{' '}
+        Wraps <code>Product.SubscriptionInfo.status</code> — returns an array
+        projected onto <code>SubscriptionStatusIOS</code>, which exposes only{' '}
+        <code>renewalInfo</code> and <code>state</code>. The{' '}
+        <code>transaction</code> field on Apple's <code>Status</code> type is
+        not surfaced by this wrapper; if you need the underlying transaction,
+        call <code>latestTransactionIOS(sku)</code> separately. iOS 15+. See the{' '}
         <a
           href="https://developer.apple.com/documentation/storekit/product/subscriptioninfo/status"
           target="_blank"

--- a/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/subscription-status-ios.tsx
@@ -19,6 +19,19 @@ function SubscriptionStatusIOS() {
         subscriptionStatusIOS
       </h1>
       <p>Get detailed subscription status using StoreKit 2 (iOS 15+).</p>
+      <p>
+        Wraps <code>Product.SubscriptionInfo.status</code> — returns the array
+        of <code>Status</code> objects with <code>transaction</code>,{' '}
+        <code>renewalInfo</code>, <code>state</code>. iOS 15+. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/product/subscriptioninfo/status"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
@@ -49,7 +49,7 @@ function SyncIOS() {
             <CodeBlock language="dart">{`Future<bool> syncIOS();`}</CodeBlock>
           ),
           gdscript: (
-            <CodeBlock language="gdscript">{`func sync_ios() -> Variant`}</CodeBlock>
+            <CodeBlock language="gdscript">{`func sync_ios() -> Types.VoidResult`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
@@ -33,14 +33,6 @@ function SyncIOS() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the App
-        Store sync completes.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -61,6 +53,14 @@ function SyncIOS() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the App
+        Store sync completes.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
@@ -52,6 +52,48 @@ function SyncIOS() {
           swift: (
             <CodeBlock language="swift">{`func syncIOS() async throws -> Bool`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun syncIOS(): Boolean`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`syncIOS(): Promise<boolean>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<bool> syncIOS();`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func sync_ios() -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`try await OpenIapModule.shared.syncIOS()`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+kmpIAP.syncIOS()`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
+import { syncIOS } from 'expo-iap';
+
+if (Platform.OS === 'ios') {
+  await syncIOS();
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`if (Platform.isIOS) {
+  await FlutterInappPurchase.instance.syncIOS();
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var result = await iap.sync_ios()`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
@@ -18,6 +18,19 @@ function SyncIOS() {
         <span className="platform-badge platform-badge--ios">iOS</span> syncIOS
       </h1>
       <p>Force a StoreKit sync for transactions (iOS 15+).</p>
+      <p>
+        Wraps <code>AppStore.sync()</code> — forces StoreKit to refresh
+        transactions and entitlements, prompts the user to authenticate. iOS
+        15+. See the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/appstore/sync()"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -30,6 +31,19 @@ function SyncIOS() {
           Apple StoreKit reference
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;boolean&gt;</code> — <code>true</code> once the App
+        Store sync completes.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/sync-ios.tsx
@@ -33,11 +33,6 @@ function SyncIOS() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
@@ -94,6 +94,51 @@ function ValidateReceiptIOS() {
             <CodeBlock language="swift">{`@available(*, deprecated, message: "Use verifyPurchase()")
 func validateReceiptIOS(options: ReceiptValidationProps) async throws -> ReceiptValidationResultIOS`}</CodeBlock>
           ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`@Deprecated("Use verifyPurchase()")
+suspend fun validateReceiptIOS(options: VerifyPurchaseProps): VerifyPurchaseResultIOS`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`validateReceiptIOS(options: VerifyPurchaseProps): Promise<VerifyPurchaseResultIOS>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`@Deprecated('Use verifyPurchase()')
+Future<VerifyPurchaseResultIOS> validateReceiptIOS(VerifyPurchaseProps options);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func validate_receipt_ios(options: Dictionary) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
+      <h2>Example</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`// Deprecated — prefer verifyPurchase().
+try await OpenIapModule.shared.validateReceiptIOS(options: .init(sku: "com.app.premium"))`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`// kmp-iap (iOS targets only — no-op on Android)
+// Deprecated — prefer verifyPurchase().
+kmpIAP.validateReceiptIOS(options = VerifyPurchaseProps(sku = "com.app.premium"))`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`// Deprecated — prefer verifyPurchase().
+await validateReceiptIOS({ sku: 'com.app.premium' });`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`// Deprecated — prefer verifyPurchase().
+if (Platform.isIOS) {
+  await FlutterInappPurchase.instance.validateReceiptIOS(
+    VerifyPurchaseProps(sku: 'com.app.premium'),
+  );
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`if iap.get_platform() == "iOS":
+    var result = await iap.validate_receipt_ios({"sku": "com.app.premium"})`}</CodeBlock>
+          ),
         }}
       </LanguageTabs>
     </div>

--- a/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
@@ -46,6 +46,30 @@ function ValidateReceiptIOS() {
         </p>
       </div>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          swift: (
+            <CodeBlock language="swift">{`@available(*, deprecated, message: "Use verifyPurchase()")
+func validateReceiptIOS(options: ReceiptValidationProps) async throws -> ReceiptValidationResultIOS`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`@Deprecated("Use verifyPurchase()")
+suspend fun validateReceiptIOS(options: VerifyPurchaseProps): VerifyPurchaseResultIOS`}</CodeBlock>
+          ),
+          typescript: (
+            <CodeBlock language="typescript">{`validateReceiptIOS(options: VerifyPurchaseProps): Promise<VerifyPurchaseResultIOS>`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`@Deprecated('Use verifyPurchase()')
+Future<VerifyPurchaseResultIOS> validateReceiptIOS(VerifyPurchaseProps options);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func validate_receipt_ios(options: Dictionary) -> Variant`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -71,30 +95,6 @@ function ValidateReceiptIOS() {
         receipt/JWS metadata. <strong>Deprecated</strong> — use{' '}
         <Link to="/docs/apis/get-active-subscriptions">verifyPurchase</Link>.
       </p>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          swift: (
-            <CodeBlock language="swift">{`@available(*, deprecated, message: "Use verifyPurchase()")
-func validateReceiptIOS(options: ReceiptValidationProps) async throws -> ReceiptValidationResultIOS`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`@Deprecated("Use verifyPurchase()")
-suspend fun validateReceiptIOS(options: VerifyPurchaseProps): VerifyPurchaseResultIOS`}</CodeBlock>
-          ),
-          typescript: (
-            <CodeBlock language="typescript">{`validateReceiptIOS(options: VerifyPurchaseProps): Promise<VerifyPurchaseResultIOS>`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`@Deprecated('Use verifyPurchase()')
-Future<VerifyPurchaseResultIOS> validateReceiptIOS(VerifyPurchaseProps options);`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func validate_receipt_ios(options: Dictionary) -> Variant`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
@@ -20,6 +20,19 @@ function ValidateReceiptIOS() {
         validateReceiptIOS
       </h1>
       <p>Deprecated. Use verifyPurchase instead.</p>
+      <p>
+        <strong>Deprecated.</strong> Legacy <code>appStoreReceiptURL</code>{' '}
+        validation. Use <code>verifyPurchase</code> with the JWS instead. See
+        the{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/original_api_for_in-app_purchase"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple StoreKit reference
+        </a>
+        .
+      </p>
 
       <div className="alert-card alert-card--warning">
         <p>

--- a/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
@@ -49,31 +49,16 @@ function ValidateReceiptIOS() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>options</code>
-            </td>
-            <td>
-              <code>VerifyPurchaseProps</code>
-            </td>
-            <td>Yes</td>
-            <td>
-              Receipt props. <strong>Deprecated</strong> — use{' '}
-              <code>verifyPurchase</code>.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>options</code>{' '}
+          <em>
+            (required, <code>VerifyPurchaseProps</code>)
+          </em>{' '}
+          — Receipt props. <strong>Deprecated</strong> — use{' '}
+          <code>verifyPurchase</code>.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
@@ -44,6 +45,43 @@ function ValidateReceiptIOS() {
           instead.
         </p>
       </div>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>options</code>
+            </td>
+            <td>
+              <code>VerifyPurchaseProps</code>
+            </td>
+            <td>Yes</td>
+            <td>
+              Receipt props. <strong>Deprecated</strong> — use{' '}
+              <code>verifyPurchase</code>.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;VerifyPurchaseResultIOS&gt;</code> — Legacy receipt
+        validation result.
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
@@ -79,8 +79,12 @@ function ValidateReceiptIOS() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;VerifyPurchaseResultIOS&gt;</code> — Legacy receipt
-        validation result.
+        <Link to="/docs/types/verify-purchase">
+          <code>Promise&lt;VerifyPurchaseResultIOS&gt;</code>
+        </Link>{' '}
+        — legacy receipt validation result. Carries <code>isValid</code> +
+        receipt/JWS metadata. <strong>Deprecated</strong> — use{' '}
+        <Link to="/docs/apis/get-active-subscriptions">verifyPurchase</Link>.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
+++ b/packages/docs/src/pages/docs/apis/ios/validate-receipt-ios.tsx
@@ -93,7 +93,10 @@ Future<VerifyPurchaseResultIOS> validateReceiptIOS(VerifyPurchaseProps options);
         </Link>{' '}
         — legacy receipt validation result. Carries <code>isValid</code> +
         receipt/JWS metadata. <strong>Deprecated</strong> — use{' '}
-        <Link to="/docs/apis/get-active-subscriptions">verifyPurchase</Link>.
+        <Link to="/docs/features/validation#verify-purchase">
+          verifyPurchase
+        </Link>
+        .
       </p>
 
       <h2>Example</h2>

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -20,6 +20,30 @@ function RequestPurchase() {
         Initiate a purchase flow. The result is delivered through
         purchaseUpdatedListener, not the return value.
       </p>
+      <p>
+        <strong>iOS:</strong> Calls <code>Product.purchase(options:)</code> and
+        emits the result on the <code>Transaction.updates</code> listener — the
+        return value is just the dispatch ack.{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/product/purchase(options:)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        . <strong>Android:</strong> Calls{' '}
+        <code>BillingClient.launchBillingFlow</code> and emits the result on{' '}
+        <code>PurchasesUpdatedListener</code>. Subscription offers require an{' '}
+        <code>offerToken</code>.{' '}
+        <a
+          href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#launchBillingFlow(android.app.Activity,com.android.billingclient.api.BillingFlowParams)"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google docs
+        </a>
+        .
+      </p>
 
       <div className="alert-card alert-card--warning">
         <p>

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -87,10 +87,17 @@ function RequestPurchase() {
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
+      <p>
+        Pass a single{' '}
+        <Link to="/docs/types/request-purchase-props">
+          <code>RequestPurchaseProps</code>
+        </Link>
+        , discriminated by <code>type</code>:
+      </p>
       <table className="doc-table">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Field</th>
             <th>Type</th>
             <th>Required</th>
             <th>Description</th>
@@ -99,20 +106,94 @@ function RequestPurchase() {
         <tbody>
           <tr>
             <td>
-              <code>props</code>
+              <code>type</code>
             </td>
             <td>
-              <Link to="/docs/types/request-purchase-props">
-                <code>RequestPurchaseProps</code>
-              </Link>
+              <code>'in-app' | 'subs'</code>
             </td>
             <td>Yes</td>
             <td>
-              Discriminated by <code>type: 'in-app' | 'subs'</code>. Pass
-              platform fields under <code>request.apple.sku</code> (iOS) and/or{' '}
-              <code>request.google.skus</code> (Android); subscriptions also
-              need <code>request.google.subscriptionOffers</code>.
+              Selects the request shape. Use <code>'in-app'</code> for one-time
+              products and <code>'subs'</code> for subscriptions.
             </td>
+          </tr>
+          <tr>
+            <td>
+              <code>request.apple.sku</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>iOS only</td>
+            <td>Single SKU for the iOS purchase.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>request.apple.appAccountToken</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>No</td>
+            <td>
+              UUID-format account token forwarded to Apple. Non-UUID values land
+              as <code>null</code> on the resulting <code>Purchase</code>.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>request.apple.quantity</code>
+            </td>
+            <td>
+              <code>number</code>
+            </td>
+            <td>No</td>
+            <td>Quantity for consumable bulk purchases.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>request.google.skus</code>
+            </td>
+            <td>
+              <code>string[]</code>
+            </td>
+            <td>Android only</td>
+            <td>Product SKUs to launch the Play purchase flow for.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>request.google.subscriptionOffers</code>
+            </td>
+            <td>
+              <code>{`{ sku: string; offerToken: string }[]`}</code>
+            </td>
+            <td>
+              <code>'subs'</code> only
+            </td>
+            <td>
+              <strong>Android.</strong> Required for subscription requests; pair
+              each SKU with its offerToken from <code>fetchProducts</code>.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>request.google.obfuscatedAccountIdAndroid</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>No</td>
+            <td>Optional account identifier passed to Play.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>request.google.obfuscatedProfileIdAndroid</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>No</td>
+            <td>Optional profile identifier passed to Play.</td>
           </tr>
         </tbody>
       </table>
@@ -121,10 +202,17 @@ function RequestPurchase() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;Purchase | null&gt;</code> — Dispatched purchase
+        <code>Promise&lt;Purchase | null&gt;</code> — dispatched purchase
         payload. <strong>Do not rely on this for the actual outcome</strong> —
-        listen via <code>purchaseUpdatedListener</code> /{' '}
-        <code>purchaseErrorListener</code> instead.
+        listen via{' '}
+        <Link to="/docs/events/purchase-updated-listener">
+          <code>purchaseUpdatedListener</code>
+        </Link>{' '}
+        /{' '}
+        <Link to="/docs/events/purchase-error-listener">
+          <code>purchaseErrorListener</code>
+        </Link>{' '}
+        instead.
       </p>
 
       <AnchorLink id="throws" level="h2">

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -202,7 +202,7 @@ function RequestPurchase() {
         Returns
       </AnchorLink>
       <p>
-        <code>Promise&lt;Purchase | null&gt;</code> — dispatched purchase
+        <code>Promise&lt;Purchase | void&gt;</code> — dispatched purchase
         payload. <strong>Do not rely on this for the actual outcome</strong> —
         listen via{' '}
         <Link to="/docs/events/purchase-updated-listener">

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -94,109 +94,72 @@ function RequestPurchase() {
         </Link>
         , discriminated by <code>type</code>:
       </p>
-      <table className="doc-table">
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>type</code>
-            </td>
-            <td>
-              <code>'in-app' | 'subs'</code>
-            </td>
-            <td>Yes</td>
-            <td>
-              Selects the request shape. Use <code>'in-app'</code> for one-time
-              products and <code>'subs'</code> for subscriptions.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>request.apple.sku</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>iOS only</td>
-            <td>Single SKU for the iOS purchase.</td>
-          </tr>
-          <tr>
-            <td>
-              <code>request.apple.appAccountToken</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>No</td>
-            <td>
-              UUID-format account token forwarded to Apple. Non-UUID values land
-              as <code>null</code> on the resulting <code>Purchase</code>.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>request.apple.quantity</code>
-            </td>
-            <td>
-              <code>number</code>
-            </td>
-            <td>No</td>
-            <td>Quantity for consumable bulk purchases.</td>
-          </tr>
-          <tr>
-            <td>
-              <code>request.google.skus</code>
-            </td>
-            <td>
-              <code>string[]</code>
-            </td>
-            <td>Android only</td>
-            <td>Product SKUs to launch the Play purchase flow for.</td>
-          </tr>
-          <tr>
-            <td>
-              <code>request.google.subscriptionOffers</code>
-            </td>
-            <td>
-              <code>{`{ sku: string; offerToken: string }[]`}</code>
-            </td>
-            <td>
-              <code>'subs'</code> only
-            </td>
-            <td>
-              <strong>Android.</strong> Required for subscription requests; pair
-              each SKU with its offerToken from <code>fetchProducts</code>.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>request.google.obfuscatedAccountIdAndroid</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>No</td>
-            <td>Optional account identifier passed to Play.</td>
-          </tr>
-          <tr>
-            <td>
-              <code>request.google.obfuscatedProfileIdAndroid</code>
-            </td>
-            <td>
-              <code>string</code>
-            </td>
-            <td>No</td>
-            <td>Optional profile identifier passed to Play.</td>
-          </tr>
-        </tbody>
-      </table>
+      <ul className="api-params">
+        <li>
+          <code>type</code>{' '}
+          <em>
+            (required, <code>'in-app' | 'subs'</code>)
+          </em>{' '}
+          — Selects the request shape. Use <code>'in-app'</code> for one-time
+          products and <code>'subs'</code> for subscriptions.
+        </li>
+        <li>
+          <code>request.apple.sku</code>{' '}
+          <em>
+            (iOS only, <code>string</code>)
+          </em>{' '}
+          — <strong>iOS.</strong> Single SKU for the iOS purchase.
+        </li>
+        <li>
+          <code>request.apple.appAccountToken</code>{' '}
+          <em>
+            (optional, <code>string</code>)
+          </em>{' '}
+          — <strong>iOS.</strong> UUID-format account token forwarded to Apple.
+          Non-UUID values land as <code>null</code> on the resulting{' '}
+          <code>Purchase</code>.
+        </li>
+        <li>
+          <code>request.apple.quantity</code>{' '}
+          <em>
+            (optional, <code>number</code>)
+          </em>{' '}
+          — <strong>iOS.</strong> Quantity for consumable bulk purchases.
+        </li>
+        <li>
+          <code>request.google.skus</code>{' '}
+          <em>
+            (Android only, <code>string[]</code>)
+          </em>{' '}
+          — <strong>Android.</strong> Product SKUs to launch the Play purchase
+          flow for.
+        </li>
+        <li>
+          <code>request.google.subscriptionOffers</code>{' '}
+          <em>
+            (required for <code>'subs'</code>,{' '}
+            <code>{`{ sku: string; offerToken: string }[]`}</code>)
+          </em>{' '}
+          — <strong>Android.</strong> Required for subscription requests; pair
+          each SKU with its offerToken from <code>fetchProducts</code>.
+        </li>
+        <li>
+          <code>request.google.obfuscatedAccountIdAndroid</code>{' '}
+          <em>
+            (optional, <code>string</code>)
+          </em>{' '}
+          — <strong>Android.</strong> Optional account identifier passed to
+          Play.
+        </li>
+        <li>
+          <code>request.google.obfuscatedProfileIdAndroid</code>{' '}
+          <em>
+            (optional, <code>string</code>)
+          </em>{' '}
+          — <strong>Android.</strong> Optional profile identifier passed to
+          Play.
+        </li>
+      </ul>
 
       <AnchorLink id="returns" level="h2">
         Returns

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -82,6 +83,57 @@ function RequestPurchase() {
           requests — use the appropriate listeners to handle the actual results.
         </p>
       </div>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <table className="doc-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>props</code>
+            </td>
+            <td>
+              <Link to="/docs/types/request-purchase-props">
+                <code>RequestPurchaseProps</code>
+              </Link>
+            </td>
+            <td>Yes</td>
+            <td>
+              Discriminated by <code>type: 'in-app' | 'subs'</code>. Pass
+              platform fields under <code>request.apple.sku</code> (iOS) and/or{' '}
+              <code>request.google.skus</code> (Android); subscriptions also
+              need <code>request.google.subscriptionOffers</code>.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;Purchase | null&gt;</code> — Dispatched purchase
+        payload. <strong>Do not rely on this for the actual outcome</strong> —
+        listen via <code>purchaseUpdatedListener</code> /{' '}
+        <code>purchaseErrorListener</code> instead.
+      </p>
+
+      <AnchorLink id="throws" level="h2">
+        Throws
+      </AnchorLink>
+      <p>
+        Synchronous rejection from the store (<code>E_NOT_PREPARED</code>,
+        missing offerToken on subs, etc.).
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -84,6 +84,34 @@ function RequestPurchase() {
         </p>
       </div>
 
+      <h2>Signature</h2>
+      <LanguageTabs>
+        {{
+          typescript: (
+            <CodeBlock language="typescript">{`requestPurchase(props: RequestPurchaseProps): Promise<Purchase | void>
+
+type RequestPurchaseProps =
+  | { request: RequestPurchasePropsByPlatforms; type: 'in-app' }
+  | { request: RequestSubscriptionPropsByPlatforms; type: 'subs' }`}</CodeBlock>
+          ),
+          swift: (
+            <CodeBlock language="swift">{`func requestPurchase(_ params: RequestPurchaseProps) async throws -> RequestPurchaseResult?`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`suspend fun requestPurchase(props: RequestPurchaseProps): Purchase?`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`suspend fun requestPurchase(props: RequestPurchaseProps): Purchase?`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`Future<Purchase?> requestPurchase(RequestPurchaseProps props);`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`func request_purchase(props: RequestPurchaseProps) -> Purchase`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -185,34 +213,6 @@ function RequestPurchase() {
         Synchronous rejection from the store (<code>E_NOT_PREPARED</code>,
         missing offerToken on subs, etc.).
       </p>
-
-      <h2>Signature</h2>
-      <LanguageTabs>
-        {{
-          typescript: (
-            <CodeBlock language="typescript">{`requestPurchase(props: RequestPurchaseProps): Promise<Purchase | void>
-
-type RequestPurchaseProps =
-  | { request: RequestPurchasePropsByPlatforms; type: 'in-app' }
-  | { request: RequestSubscriptionPropsByPlatforms; type: 'subs' }`}</CodeBlock>
-          ),
-          swift: (
-            <CodeBlock language="swift">{`func requestPurchase(_ params: RequestPurchaseProps) async throws -> RequestPurchaseResult?`}</CodeBlock>
-          ),
-          kotlin: (
-            <CodeBlock language="kotlin">{`suspend fun requestPurchase(props: RequestPurchaseProps): Purchase?`}</CodeBlock>
-          ),
-          kmp: (
-            <CodeBlock language="kotlin">{`suspend fun requestPurchase(props: RequestPurchaseProps): Purchase?`}</CodeBlock>
-          ),
-          dart: (
-            <CodeBlock language="dart">{`Future<Purchase?> requestPurchase(RequestPurchaseProps props);`}</CodeBlock>
-          ),
-          gdscript: (
-            <CodeBlock language="gdscript">{`func request_purchase(props: RequestPurchaseProps) -> Purchase`}</CodeBlock>
-          ),
-        }}
-      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/restore-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/restore-purchases.tsx
@@ -44,16 +44,6 @@ function RestorePurchases() {
         .
       </p>
 
-      <AnchorLink id="returns" level="h2">
-        Returns
-      </AnchorLink>
-      <p>
-        <code>Promise&lt;void&gt;</code> — Resolves once the platform finishes
-        the restore. The restored purchases are emitted via{' '}
-        <code>purchaseUpdatedListener</code> / surface as{' '}
-        <code>getAvailablePurchases</code> results, depending on platform.
-      </p>
-
       <h2>Signature</h2>
       <LanguageTabs>
         {{
@@ -77,6 +67,16 @@ function RestorePurchases() {
           ),
         }}
       </LanguageTabs>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;void&gt;</code> — Resolves once the platform finishes
+        the restore. The restored purchases are emitted via{' '}
+        <code>purchaseUpdatedListener</code> / surface as{' '}
+        <code>getAvailablePurchases</code> results, depending on platform.
+      </p>
 
       <h2>Example</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/restore-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/restore-purchases.tsx
@@ -1,3 +1,4 @@
+import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -41,6 +42,21 @@ function RestorePurchases() {
           Google docs
         </a>
         .
+      </p>
+
+      <AnchorLink id="parameters" level="h2">
+        Parameters
+      </AnchorLink>
+      <p>None.</p>
+
+      <AnchorLink id="returns" level="h2">
+        Returns
+      </AnchorLink>
+      <p>
+        <code>Promise&lt;void&gt;</code> — Resolves once the platform finishes
+        the restore. The restored purchases are emitted via{' '}
+        <code>purchaseUpdatedListener</code> / surface as{' '}
+        <code>getAvailablePurchases</code> results, depending on platform.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/restore-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/restore-purchases.tsx
@@ -20,9 +20,9 @@ function RestorePurchases() {
         Purchases" button for users who reinstall the app.
       </p>
       <p>
-        <strong>iOS:</strong> Triggers <code>AppStore.sync()</code> and
-        re-emits entitlements on <code>Transaction.currentEntitlements</code>.
-        Asks the user to authenticate.{' '}
+        <strong>iOS:</strong> Triggers <code>AppStore.sync()</code> and re-emits
+        entitlements on <code>Transaction.currentEntitlements</code>. Asks the
+        user to authenticate.{' '}
         <a
           href="https://developer.apple.com/documentation/storekit/appstore/sync()"
           target="_blank"
@@ -31,8 +31,8 @@ function RestorePurchases() {
           Apple docs
         </a>
         . <strong>Android:</strong> Calls <code>queryPurchasesAsync</code> for
-        both <code>INAPP</code> and <code>SUBS</code>. No system-level UI
-        prompt — Play has no concept of an explicit "restore" action.{' '}
+        both <code>INAPP</code> and <code>SUBS</code>. No system-level UI prompt
+        — Play has no concept of an explicit "restore" action.{' '}
         <a
           href="https://developer.android.com/google/play/billing/integrate#fetch"
           target="_blank"

--- a/packages/docs/src/pages/docs/apis/restore-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/restore-purchases.tsx
@@ -19,6 +19,29 @@ function RestorePurchases() {
         Restore completed transactions. Use this to implement a "Restore
         Purchases" button for users who reinstall the app.
       </p>
+      <p>
+        <strong>iOS:</strong> Triggers <code>AppStore.sync()</code> and
+        re-emits entitlements on <code>Transaction.currentEntitlements</code>.
+        Asks the user to authenticate.{' '}
+        <a
+          href="https://developer.apple.com/documentation/storekit/appstore/sync()"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        . <strong>Android:</strong> Calls <code>queryPurchasesAsync</code> for
+        both <code>INAPP</code> and <code>SUBS</code>. No system-level UI
+        prompt — Play has no concept of an explicit "restore" action.{' '}
+        <a
+          href="https://developer.android.com/google/play/billing/integrate#fetch"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google docs
+        </a>
+        .
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/restore-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/restore-purchases.tsx
@@ -44,11 +44,6 @@ function RestorePurchases() {
         .
       </p>
 
-      <AnchorLink id="parameters" level="h2">
-        Parameters
-      </AnchorLink>
-      <p>None.</p>
-
       <AnchorLink id="returns" level="h2">
         Returns
       </AnchorLink>

--- a/packages/docs/src/pages/docs/apis/restore-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/restore-purchases.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
@@ -21,8 +22,12 @@ function RestorePurchases() {
         Purchases" button for users who reinstall the app.
       </p>
       <p>
-        <strong>iOS:</strong> Triggers <code>AppStore.sync()</code> and re-emits
-        entitlements on <code>Transaction.currentEntitlements</code>. Asks the
+        <strong>iOS:</strong> Triggers <code>AppStore.sync()</code> to refresh
+        StoreKit's transaction state; restored purchases are then read via{' '}
+        <Link to="/docs/apis/get-available-purchases">
+          <code>getAvailablePurchases</code>
+        </Link>{' '}
+        (or directly via <code>Transaction.currentEntitlements</code>). Asks the
         user to authenticate.{' '}
         <a
           href="https://developer.apple.com/documentation/storekit/appstore/sync()"
@@ -35,7 +40,7 @@ function RestorePurchases() {
         both <code>INAPP</code> and <code>SUBS</code>. No system-level UI prompt
         — Play has no concept of an explicit "restore" action.{' '}
         <a
-          href="https://developer.android.com/google/play/billing/integrate#fetch"
+          href="https://developer.android.com/google/play/billing/integrate"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/packages/docs/src/pages/docs/index.tsx
+++ b/packages/docs/src/pages/docs/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import {
   Route,
   Routes,
@@ -151,29 +152,49 @@ function Docs() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  // Portal the sidebar toggle to document.body so it sits OUTSIDE any
+  // ancestor's stacking context, AND fully unmount it while the drawer
+  // is open. Earlier rounds left the toggle in the DOM with
+  // `.hidden { opacity: 0; pointer-events: none }` while the drawer was
+  // open, which on iOS Safari still let the toggle absorb taps that
+  // landed on the drawer's first menu item ("APIs" header sits at
+  // y≈88-120px, exactly where the fixed toggle at top: 70px lives).
+  // Removing the element from the DOM entirely guarantees the drawer
+  // items underneath get every tap they should.
+  const sidebarToggle = isSidebarOpen
+    ? null
+    : createPortal(
+        <button
+          type="button"
+          className={`docs-sidebar-toggle ${isScrolled ? 'scrolled' : ''}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            setIsSidebarOpen(true);
+          }}
+          aria-label="Toggle sidebar"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 5h14M3 10h14M3 15h14"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+          <span>Menu</span>
+        </button>,
+        document.body
+      );
+
   return (
     <div className="docs-container">
-      <button
-        className={`docs-sidebar-toggle ${isSidebarOpen ? 'hidden' : ''} ${isScrolled ? 'scrolled' : ''}`}
-        onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-        aria-label="Toggle sidebar"
-      >
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 20 20"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3 5h14M3 10h14M3 15h14"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-          />
-        </svg>
-        <span>Menu</span>
-      </button>
+      {sidebarToggle}
 
       {isSidebarOpen && (
         <div className="sidebar-overlay" onClick={closeSidebar}></div>

--- a/packages/docs/src/pages/docs/types/active-subscription.tsx
+++ b/packages/docs/src/pages/docs/types/active-subscription.tsx
@@ -29,6 +29,29 @@ function ActiveSubscription() {
           </Link>
           . Provides a unified view of subscription status across platforms.
         </p>
+        <p>
+          Cross-platform shape returned by <code>getActiveSubscriptions</code>.{' '}
+          <strong>iOS:</strong> derived from{' '}
+          <code>Transaction.currentEntitlements</code> filtered to subscription
+          products (
+          <a
+            href="https://developer.apple.com/documentation/storekit/transaction/currententitlements"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ). <strong>Android:</strong> derived from{' '}
+          <code>BillingClient.queryPurchasesAsync(SUBS)</code> (
+          <a
+            href="https://developer.android.com/google/play/billing/subscriptions#lifecycle"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/alternative-billing-types.tsx
+++ b/packages/docs/src/pages/docs/types/alternative-billing-types.tsx
@@ -25,6 +25,20 @@ function AlternativeBillingTypes() {
           Types for configuring alternative billing systems, primarily used for
           Android.
         </p>
+        <p>
+          Modes for opting into Google&apos;s alternative-billing programs.{' '}
+          <strong>Android only</strong> — passed via{' '}
+          <code>InitConnectionConfig.alternativeBillingModeAndroid</code>{' '}
+          (deprecated; prefer <code>enableBillingProgramAndroid</code>) (
+          <a
+            href="https://developer.android.com/google/play/billing/alternative"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/android/one-time-purchase-offer-detail-android.tsx
+++ b/packages/docs/src/pages/docs/types/android/one-time-purchase-offer-detail-android.tsx
@@ -39,6 +39,18 @@ function OneTimePurchaseOfferDetailAndroid() {
           . For implementation examples, see the{' '}
           <Link to="/docs/features/discount">Discounts feature guide</Link>.
         </p>
+        <p>
+          <strong>Android only.</strong> Mirrors{' '}
+          <code>ProductDetails.OneTimePurchaseOfferDetails</code> (
+          <a
+            href="https://developer.android.com/reference/com/android/billingclient/api/ProductDetails.OneTimePurchaseOfferDetails"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native reference:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/android/pricing-phase-android.tsx
+++ b/packages/docs/src/pages/docs/types/android/pricing-phase-android.tsx
@@ -29,6 +29,19 @@ function PricingPhaseAndroid() {
           </a>{' '}
           one-to-one.
         </p>
+        <p>
+          <strong>Android only.</strong> Mirrors{' '}
+          <code>ProductDetails.PricingPhase</code> — one billing-cycle phase of
+          a subscription&apos;s pricing schedule (
+          <a
+            href="https://developer.android.com/reference/com/android/billingclient/api/ProductDetails.PricingPhase"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <table className="doc-table">
           <thead>
             <tr>

--- a/packages/docs/src/pages/docs/types/android/subscription-offer-android.tsx
+++ b/packages/docs/src/pages/docs/types/android/subscription-offer-android.tsx
@@ -28,6 +28,20 @@ function SubscriptionOfferAndroid() {
           (cross-platform) instead.
         </p>
         <p>Offer details for subscription purchases:</p>
+        <p>
+          <strong>Android only.</strong> Mirrors{' '}
+          <code>ProductDetails.SubscriptionOfferDetails</code> — the
+          offerToken-bearing offer payload required for subscription{' '}
+          <code>requestPurchase</code> (
+          <a
+            href="https://developer.android.com/reference/com/android/billingclient/api/ProductDetails.SubscriptionOfferDetails"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native reference:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/billing-programs.tsx
+++ b/packages/docs/src/pages/docs/types/billing-programs.tsx
@@ -26,6 +26,18 @@ function BillingPrograms() {
           API, which provides a more structured approach to external offers and
           content links. Version 8.3.0 adds External Payments for Japan.
         </p>
+        <p>
+          Identifiers for Play Billing 8.2.0+ programs (External Payments,
+          etc.). <strong>Android only</strong> (
+          <a
+            href="https://developer.android.com/google/play/billing/billing-programs"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/discount-offer.tsx
+++ b/packages/docs/src/pages/docs/types/discount-offer.tsx
@@ -31,6 +31,27 @@ function DiscountOffer() {
           </Link>
           ; iOS does not support one-time product discounts.
         </p>
+        <p>
+          Cross-platform discount-offer envelope. <strong>iOS:</strong> maps to
+          a signed <code>Product.SubscriptionOffer</code> (
+          <a
+            href="https://developer.apple.com/documentation/storekit/product/subscriptionoffer"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ). <strong>Android:</strong> maps to a Play{' '}
+          <code>SubscriptionOfferDetails</code> entry (
+          <a
+            href="https://developer.android.com/reference/com/android/billingclient/api/ProductDetails.SubscriptionOfferDetails"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/discount-offer.tsx
+++ b/packages/docs/src/pages/docs/types/discount-offer.tsx
@@ -26,10 +26,8 @@ function DiscountOffer() {
           <code>Introductory</code>, <code>Promotional</code>) and one-time
           product offers (<code>OneTime</code>, Android only on Google Play
           Billing Library 7.0+). For iOS-specific WinBack offers see{' '}
-          <Link to="/docs/types/ios/subscription-offer-ios">
-            SubscriptionOfferTypeIOS
-          </Link>
-          ; iOS does not support one-time product discounts.
+          <Link to="/docs/types/ios/discount-offer-ios">DiscountOfferIOS</Link>;
+          iOS does not support one-time product discounts.
         </p>
         <p>
           Cross-platform discount-offer envelope. <strong>iOS:</strong> maps to

--- a/packages/docs/src/pages/docs/types/external-purchase-link.tsx
+++ b/packages/docs/src/pages/docs/types/external-purchase-link.tsx
@@ -192,6 +192,117 @@ function ExternalPurchaseLink() {
           </tbody>
         </table>
 
+        <AnchorLink
+          id="external-purchase-custom-link-token-result-ios"
+          level="h4"
+        >
+          ExternalPurchaseCustomLinkTokenResultIOS
+        </AnchorLink>
+        <p>
+          Returned by{' '}
+          <Link to="/docs/apis/ios/get-external-purchase-custom-link-token-ios">
+            <code>getExternalPurchaseCustomLinkTokenIOS</code>
+          </Link>{' '}
+          (iOS 18.1+).
+        </p>
+        <table className="doc-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Summary</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code>token</code>
+              </td>
+              <td>
+                <code>string</code>
+              </td>
+              <td>
+                Token to send to Apple's External Purchase Server reporting API.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>tokenType</code>
+              </td>
+              <td>
+                <code>'acquisition' | 'services'</code>
+              </td>
+              <td>
+                Echoes the requested token type (new customers vs. existing
+                customers).
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>error</code>
+              </td>
+              <td>
+                <code>string?</code>
+              </td>
+              <td>Populated when token creation fails.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <AnchorLink
+          id="external-purchase-custom-link-notice-result-ios"
+          level="h4"
+        >
+          ExternalPurchaseCustomLinkNoticeResultIOS
+        </AnchorLink>
+        <p>
+          Returned by{' '}
+          <Link to="/docs/apis/ios/show-external-purchase-custom-link-notice-ios">
+            <code>showExternalPurchaseCustomLinkNoticeIOS</code>
+          </Link>{' '}
+          (iOS 18.1+).
+        </p>
+        <table className="doc-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Summary</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code>result</code>
+              </td>
+              <td>
+                <code>'continue' | 'cancelled'</code>
+              </td>
+              <td>
+                Whether the user accepted the disclosure notice or dismissed it.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>noticeType</code>
+              </td>
+              <td>
+                <code>ExternalPurchaseCustomLinkNoticeTypeIOS</code>
+              </td>
+              <td>Echoes the disclosure type that was shown.</td>
+            </tr>
+            <tr>
+              <td>
+                <code>error</code>
+              </td>
+              <td>
+                <code>string?</code>
+              </td>
+              <td>Populated when the sheet failed to present.</td>
+            </tr>
+          </tbody>
+        </table>
+
         <LanguageTabs>
           {{
             typescript: (

--- a/packages/docs/src/pages/docs/types/external-purchase-link.tsx
+++ b/packages/docs/src/pages/docs/types/external-purchase-link.tsx
@@ -26,6 +26,19 @@ function ExternalPurchaseLink() {
           payment using Apple&apos;s StoreKit <code>ExternalPurchase</code> API.
           Available from iOS 17.4+ (notice sheet) and iOS 18.2+ (custom links).
         </p>
+        <p>
+          Result of <code>presentExternalPurchaseLinkIOS</code>.{' '}
+          <strong>iOS only</strong> — wraps{' '}
+          <code>ExternalPurchaseLink.open(url:)</code> (
+          <a
+            href="https://developer.apple.com/documentation/storekit/externalpurchaselink"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/external-purchase-link.tsx
+++ b/packages/docs/src/pages/docs/types/external-purchase-link.tsx
@@ -273,23 +273,14 @@ function ExternalPurchaseLink() {
           <tbody>
             <tr>
               <td>
-                <code>result</code>
+                <code>continued</code>
               </td>
               <td>
-                <code>'continue' | 'cancelled'</code>
+                <code>boolean</code>
               </td>
               <td>
-                Whether the user accepted the disclosure notice or dismissed it.
+                Whether the user chose to continue to the external purchase.
               </td>
-            </tr>
-            <tr>
-              <td>
-                <code>noticeType</code>
-              </td>
-              <td>
-                <code>ExternalPurchaseCustomLinkNoticeTypeIOS</code>
-              </td>
-              <td>Echoes the disclosure type that was shown.</td>
             </tr>
             <tr>
               <td>

--- a/packages/docs/src/pages/docs/types/ios/app-transaction-ios.tsx
+++ b/packages/docs/src/pages/docs/types/ios/app-transaction-ios.tsx
@@ -28,6 +28,18 @@ function AppTransactionIos() {
           </Link>
           . Contains metadata about the app&apos;s purchase and installation.
         </p>
+        <p>
+          <strong>iOS only.</strong> Mirrors <code>AppTransaction</code> (iOS
+          16+) — the JWS-verified record of how the app was acquired (
+          <a
+            href="https://developer.apple.com/documentation/storekit/apptransaction"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native reference:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/ios/discount-ios.tsx
+++ b/packages/docs/src/pages/docs/types/ios/discount-ios.tsx
@@ -25,6 +25,19 @@ function DiscountIos() {
           instead.
         </p>
         <p>Discount info returned as part of product details:</p>
+        <p>
+          <strong>iOS only.</strong> Mirrors{' '}
+          <code>Product.SubscriptionOffer</code> for promotional/intro discounts
+          (
+          <a
+            href="https://developer.apple.com/documentation/storekit/product/subscriptionoffer"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native reference:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/ios/discount-offer-ios.tsx
+++ b/packages/docs/src/pages/docs/types/ios/discount-offer-ios.tsx
@@ -28,6 +28,18 @@ function DiscountOfferIos() {
           Used when requesting a purchase with a promotional offer. Generate
           signature server-side.
         </p>
+        <p>
+          <strong>iOS only.</strong> Signed-discount payload for{' '}
+          <code>Product.purchase(options:)</code> (
+          <a
+            href="https://developer.apple.com/documentation/storekit/product/purchaseoption/promotionaloffer(_:signature:)"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native reference:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/ios/payment-mode-ios.tsx
+++ b/packages/docs/src/pages/docs/types/ios/payment-mode-ios.tsx
@@ -19,6 +19,20 @@ function PaymentModeIos() {
           PaymentMode
         </AnchorLink>
         <p>Payment mode for offers:</p>
+        <p>
+          <strong>iOS only.</strong> Mirrors{' '}
+          <code>Product.SubscriptionOffer.PaymentMode</code> (
+          <code>payAsYouGo</code>, <code>payUpFront</code>,{' '}
+          <code>freeTrial</code>) (
+          <a
+            href="https://developer.apple.com/documentation/storekit/product/subscriptionoffer/paymentmode"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native reference:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/ios/renewal-info-ios.tsx
+++ b/packages/docs/src/pages/docs/types/ios/renewal-info-ios.tsx
@@ -29,6 +29,19 @@ function RenewalInfoIOS() {
         . Carries auto-renewal intent, billing-retry state, price-increase
         responses, and the JWS payload for server-side verification.
       </p>
+      <p>
+        <strong>iOS only.</strong> Mirrors{' '}
+        <code>Product.SubscriptionInfo.RenewalInfo</code> — autoRenewStatus,
+        renewalDate, expirationReason (
+        <a
+          href="https://developer.apple.com/documentation/storekit/product/subscriptioninfo/renewalinfo"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Apple docs
+        </a>
+        ).
+      </p>
 
       <section>
         <AnchorLink id="renewal-info-ios" level="h2">

--- a/packages/docs/src/pages/docs/types/ios/subscription-period-ios.tsx
+++ b/packages/docs/src/pages/docs/types/ios/subscription-period-ios.tsx
@@ -19,6 +19,19 @@ function SubscriptionPeriodIos() {
           SubscriptionPeriodIOS
         </AnchorLink>
         <p>Subscription period units:</p>
+        <p>
+          <strong>iOS only.</strong> Mirrors{' '}
+          <code>Product.SubscriptionPeriod</code> — <code>unit</code> and{' '}
+          <code>value</code> (
+          <a
+            href="https://developer.apple.com/documentation/storekit/product/subscriptionperiod"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native reference:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/ios/subscription-status-ios.tsx
+++ b/packages/docs/src/pages/docs/types/ios/subscription-status-ios.tsx
@@ -23,6 +23,20 @@ function SubscriptionStatusIos() {
           <code>subscriptionStatusIOS(sku)</code> to get detailed subscription
           state.
         </p>
+        <p>
+          <strong>iOS only.</strong> Mirrors{' '}
+          <code>Product.SubscriptionInfo.Status</code> — combines{' '}
+          <code>transaction</code>, <code>renewalInfo</code>, and{' '}
+          <code>state</code> (
+          <a
+            href="https://developer.apple.com/documentation/storekit/product/subscriptioninfo/status"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native reference:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/ios/subscription-status-ios.tsx
+++ b/packages/docs/src/pages/docs/types/ios/subscription-status-ios.tsx
@@ -24,10 +24,10 @@ function SubscriptionStatusIos() {
           state.
         </p>
         <p>
-          <strong>iOS only.</strong> Mirrors{' '}
-          <code>Product.SubscriptionInfo.Status</code> — combines{' '}
-          <code>transaction</code>, <code>renewalInfo</code>, and{' '}
-          <code>state</code> (
+          <strong>iOS only.</strong> A trimmed projection of Apple's{' '}
+          <code>Product.SubscriptionInfo.Status</code> — the OpenIAP wrapper
+          exposes <code>renewalInfo</code> and <code>state</code> only;{' '}
+          <code>transaction</code> from the Apple type is not surfaced (
           <a
             href="https://developer.apple.com/documentation/storekit/product/subscriptioninfo/status"
             target="_blank"

--- a/packages/docs/src/pages/docs/types/product-request.tsx
+++ b/packages/docs/src/pages/docs/types/product-request.tsx
@@ -28,6 +28,27 @@ function ProductRequest() {
           </Link>
           .
         </p>
+        <p>
+          Input to <code>fetchProducts</code>. <strong>iOS:</strong> passed to{' '}
+          <code>Product.products(for:)</code> (
+          <a
+            href="https://developer.apple.com/documentation/storekit/product/products(for:)"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ). <strong>Android:</strong> passed to{' '}
+          <code>BillingClient.queryProductDetailsAsync</code> (
+          <a
+            href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryProductDetailsAsync(com.android.billingclient.api.QueryProductDetailsParams,com.android.billingclient.api.ProductDetailsResponseListener)"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/product.tsx
+++ b/packages/docs/src/pages/docs/types/product.tsx
@@ -32,6 +32,28 @@ function Product() {
           </Link>
           , discriminated by the <code>platform</code> field.
         </p>
+        <p>
+          Cross-platform one-time product shape returned by{' '}
+          <code>fetchProducts</code>. <strong>iOS:</strong> derived from{' '}
+          <code>Product</code> (
+          <a
+            href="https://developer.apple.com/documentation/storekit/product"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ). <strong>Android:</strong> derived from <code>ProductDetails</code>{' '}
+          (
+          <a
+            href="https://developer.android.com/reference/com/android/billingclient/api/ProductDetails"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/purchase.tsx
+++ b/packages/docs/src/pages/docs/types/purchase.tsx
@@ -32,6 +32,26 @@ function Purchase() {
           </Link>
           , discriminated by the <code>platform</code> field.
         </p>
+        <p>
+          Normalized purchase / transaction record. <strong>iOS:</strong>{' '}
+          derived from <code>Transaction</code> (
+          <a
+            href="https://developer.apple.com/documentation/storekit/transaction"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ). <strong>Android:</strong> derived from <code>Purchase</code> (
+          <a
+            href="https://developer.android.com/reference/com/android/billingclient/api/Purchase"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/purchase.tsx
+++ b/packages/docs/src/pages/docs/types/purchase.tsx
@@ -677,6 +677,86 @@ function Purchase() {
           }}
         </PlatformTabs>
       </section>
+
+      <section>
+        <AnchorLink id="purchase-options" level="h2">
+          PurchaseOptions
+        </AnchorLink>
+        <p>
+          Optional input to{' '}
+          <Link to="/docs/apis/get-available-purchases">
+            <code>getAvailablePurchases</code>
+          </Link>
+          . PurchaseOptions does not have its own dedicated page — it lives here
+          next to <code>Purchase</code> because every field is platform-
+          specific and changes which subset of purchases the query returns.
+        </p>
+        <p>
+          All fields are optional; pass <code>null</code> / omit the argument
+          entirely to use defaults. iOS-only fields are ignored on Android (and
+          vice-versa).
+        </p>
+        <table className="doc-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Platform</th>
+              <th>Default</th>
+              <th>Summary</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code>alsoPublishToEventListenerIOS</code>
+              </td>
+              <td>iOS</td>
+              <td>
+                <code>false</code>
+              </td>
+              <td>
+                When <code>true</code>, every purchase returned by the query is
+                also re-emitted on{' '}
+                <Link to="/docs/events/purchase-updated-listener">
+                  <code>purchaseUpdatedListener</code>
+                </Link>{' '}
+                so existing listeners can process them with the same code path
+                used for live purchases.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>onlyIncludeActiveItemsIOS</code>
+              </td>
+              <td>iOS</td>
+              <td>
+                <code>false</code>
+              </td>
+              <td>
+                Switches the query from <code>Transaction.all</code> (full
+                StoreKit 2 history, including refunded / revoked entries) to{' '}
+                <code>Transaction.currentEntitlements</code>, which narrows the
+                result to active non-consumables and live subscriptions.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>includeSuspendedAndroid</code>
+              </td>
+              <td>Android</td>
+              <td>
+                <code>false</code>
+              </td>
+              <td>
+                When <code>true</code>, includes subscriptions in a paused or
+                grace-period state in the returned list. Suspended subscriptions
+                should not grant entitlements — see{' '}
+                <code>isSuspendedAndroid</code> on the Purchase fields above.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
     </div>
   );
 }

--- a/packages/docs/src/pages/docs/types/request-purchase-props.tsx
+++ b/packages/docs/src/pages/docs/types/request-purchase-props.tsx
@@ -29,6 +29,29 @@ function RequestPurchaseProps() {
           </Link>
           .
         </p>
+        <p>
+          Discriminated input to <code>requestPurchase</code> (
+          <code>type: &apos;in-app&apos; | &apos;subs&apos;</code>).{' '}
+          <strong>iOS:</strong> maps to <code>Product.purchase(options:)</code>{' '}
+          (
+          <a
+            href="https://developer.apple.com/documentation/storekit/product/purchase(options:)"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ). <strong>Android:</strong> maps to{' '}
+          <code>BillingClient.launchBillingFlow</code> (
+          <a
+            href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#launchBillingFlow(android.app.Activity,com.android.billingclient.api.BillingFlowParams)"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/storefront.tsx
+++ b/packages/docs/src/pages/docs/types/storefront.tsx
@@ -30,6 +30,26 @@ function Storefront() {
           </Link>
           .
         </p>
+        <p>
+          Country-code shape returned by <code>getStorefront</code>.{' '}
+          <strong>iOS:</strong> <code>Storefront.current</code> (
+          <a
+            href="https://developer.apple.com/documentation/storekit/storefront"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ). <strong>Android:</strong> <code>BillingConfig.countryCode</code> (
+          <a
+            href="https://developer.android.com/reference/com/android/billingclient/api/BillingConfig"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/subscription-offer.tsx
+++ b/packages/docs/src/pages/docs/types/subscription-offer.tsx
@@ -26,6 +26,27 @@ function SubscriptionOffer() {
           both iOS (introductory and promotional offers) and Android (offer
           tokens with pricing phases).
         </p>
+        <p>
+          Cross-platform subscription-offer envelope. <strong>iOS:</strong>{' '}
+          maps to <code>Product.SubscriptionOffer</code> (
+          <a
+            href="https://developer.apple.com/documentation/storekit/product/subscriptionoffer"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ). <strong>Android:</strong> maps to{' '}
+          <code>SubscriptionOfferDetails</code> (
+          <a
+            href="https://developer.android.com/reference/com/android/billingclient/api/ProductDetails.SubscriptionOfferDetails"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/subscription-offer.tsx
+++ b/packages/docs/src/pages/docs/types/subscription-offer.tsx
@@ -27,8 +27,8 @@ function SubscriptionOffer() {
           tokens with pricing phases).
         </p>
         <p>
-          Cross-platform subscription-offer envelope. <strong>iOS:</strong>{' '}
-          maps to <code>Product.SubscriptionOffer</code> (
+          Cross-platform subscription-offer envelope. <strong>iOS:</strong> maps
+          to <code>Product.SubscriptionOffer</code> (
           <a
             href="https://developer.apple.com/documentation/storekit/product/subscriptionoffer"
             target="_blank"

--- a/packages/docs/src/pages/docs/types/subscription-product.tsx
+++ b/packages/docs/src/pages/docs/types/subscription-product.tsx
@@ -25,6 +25,28 @@ function SubscriptionProduct() {
           base Product type with subscription-specific fields like pricing
           phases, introductory offers, and billing periods.
         </p>
+        <p>
+          Cross-platform subscription product shape. <strong>iOS:</strong>{' '}
+          derived from <code>Product</code> with <code>subscription</code>{' '}
+          populated (
+          <a
+            href="https://developer.apple.com/documentation/storekit/product/subscriptioninfo"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ). <strong>Android:</strong> derived from <code>ProductDetails</code>{' '}
+          with <code>subscriptionOfferDetails</code> (
+          <a
+            href="https://developer.android.com/google/play/billing/subscriptions"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/pages/docs/types/verify-purchase-with-provider-props.tsx
+++ b/packages/docs/src/pages/docs/types/verify-purchase-with-provider-props.tsx
@@ -32,6 +32,18 @@ function VerifyPurchaseWithProviderProps() {
           </a>
           .
         </p>
+        <p>
+          Input to <code>verifyPurchaseWithProvider</code> — pick a managed
+          validator (IAPKit, Apple, Google, Horizon). See{' '}
+          <a
+            href="https://www.openiap.dev/docs/features/validation"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Validation docs
+          </a>
+          .
+        </p>
 
         <table className="doc-table">
           <thead>

--- a/packages/docs/src/pages/docs/types/verify-purchase-with-provider-props.tsx
+++ b/packages/docs/src/pages/docs/types/verify-purchase-with-provider-props.tsx
@@ -34,7 +34,8 @@ function VerifyPurchaseWithProviderProps() {
         </p>
         <p>
           Input to <code>verifyPurchaseWithProvider</code> — pick a managed
-          validator (IAPKit, Apple, Google, Horizon). See{' '}
+          validator. The <code>PurchaseVerificationProvider</code> enum
+          currently exposes only IAPKit. See{' '}
           <a
             href="https://www.openiap.dev/docs/features/validation"
             target="_blank"

--- a/packages/docs/src/pages/docs/types/verify-purchase-with-provider-result.tsx
+++ b/packages/docs/src/pages/docs/types/verify-purchase-with-provider-result.tsx
@@ -24,6 +24,18 @@ function VerifyPurchaseWithProviderResult() {
         <p>
           Result type returned by <code>verifyPurchaseWithProvider()</code>.
         </p>
+        <p>
+          Result envelope from <code>verifyPurchaseWithProvider</code>. Carries{' '}
+          <code>isValid</code> plus the underlying provider response. See{' '}
+          <a
+            href="https://www.openiap.dev/docs/features/validation"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Validation docs
+          </a>
+          .
+        </p>
 
         <table className="doc-table">
           <thead>

--- a/packages/docs/src/pages/docs/types/verify-purchase.tsx
+++ b/packages/docs/src/pages/docs/types/verify-purchase.tsx
@@ -23,6 +23,28 @@ function VerifyPurchase() {
           Types used with <code>verifyPurchase()</code> for server-side purchase
           verification.
         </p>
+        <p>
+          Input/output shape for <code>verifyPurchase</code>.{' '}
+          <strong>iOS:</strong> validates the JWS from{' '}
+          <code>Transaction.jsonRepresentation</code> (
+          <a
+            href="https://developer.apple.com/documentation/storekit/transaction/jsonrepresentation"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apple docs
+          </a>
+          ). <strong>Android:</strong> validates the <code>purchaseToken</code>{' '}
+          against Google Play Developer API (
+          <a
+            href="https://developer.android.com/google/play/developer-api"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Google docs
+          </a>
+          ).
+        </p>
         <p className="type-link">
           <strong>Native references:</strong>{' '}
           <a

--- a/packages/docs/src/styles/code.css
+++ b/packages/docs/src/styles/code.css
@@ -69,14 +69,38 @@ pre.code-block {
   margin: var(--spacing-md) 0;
 }
 
+/* Language badge + Copy button live as a tab-bar attached to the top of
+   the code block — same background, no floating overlap with horizontally
+   scrolling code (the previous absolute-positioned version masked code at
+   narrow widths even with a solid background). */
+.code-block-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
 .code-block-header {
-  position: absolute;
-  top: var(--spacing-sm);
-  right: var(--spacing-sm);
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: var(--spacing-sm);
-  z-index: 10;
+  padding: 6px var(--spacing-md);
+  background: #f6f8fa;
+  border: 1px solid var(--border-color);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+}
+
+:root.dark .code-block-header {
+  background: #1e1e1e;
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Code block bonds visually to the header above it. */
+.code-block-wrapper .code-block,
+.code-block-wrapper pre.code-block {
+  margin-top: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .code-block-language {

--- a/packages/docs/src/styles/code.css
+++ b/packages/docs/src/styles/code.css
@@ -363,6 +363,21 @@ pre code {
   font-weight: 500;
 }
 
+/* Linkified type names (anchors emitted by `linkifyType` in CodeBlock.tsx).
+   Inherit the class-name color, no anchor underline by default, but show one
+   on hover to make it discoverable. */
+.code-block a.token.type-ref,
+.code-snippet a.token.type-ref {
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.code-block a.token.type-ref:hover,
+.code-snippet a.token.type-ref:hover {
+  text-decoration: underline;
+}
+
 .code-block .token.decorator,
 .code-snippet .token.decorator {
   color: #6f42c1;

--- a/packages/docs/src/styles/documentation.css
+++ b/packages/docs/src/styles/documentation.css
@@ -896,8 +896,14 @@
   pointer-events: auto;
 }
 
+/* When the user scrolls, keep the toggle clear of the sticky top nav
+   (56px tall) instead of jumping it up to `top: 1rem` which lands the
+   button INSIDE the nav's bounding box. Even with z-index 9001 vs the
+   nav's 100, taps in the overlap zone were flaky on mobile WebKit —
+   keeping the toggle below the nav avoids the geometry collision
+   entirely. */
 .docs-sidebar-toggle.scrolled {
-  top: 1rem;
+  top: 64px;
 }
 
 .docs-sidebar-toggle svg {
@@ -976,13 +982,22 @@
     background: var(--bg-secondary);
     z-index: 9000;
     transition:
+      transform 0.25s ease,
       opacity 0.2s ease,
       visibility 0.2s ease;
     border-right: 1px solid var(--border-color);
     padding: var(--spacing-xl) 0;
     box-shadow: 4px 0 24px rgba(0, 0, 0, 0.15);
+    /* Closed state: slide fully off-screen, hide visually, AND disable
+       pointer events. iOS Safari has been observed to still deliver taps
+       to children of a `visibility: hidden; opacity: 0` fixed element,
+       so we belt-and-braces it: translateX moves the geometry out of the
+       hit-test area, and pointer-events: none turns off hit-testing for
+       this entire subtree even if the transform isn't honored. */
+    transform: translateX(-100%);
     opacity: 0;
     visibility: hidden;
+    pointer-events: none;
     overflow-y: auto;
     box-sizing: border-box;
   }
@@ -994,8 +1009,10 @@
   }
 
   .docs-sidebar.open {
+    transform: translateX(0);
     opacity: 1;
     visibility: visible;
+    pointer-events: auto;
   }
 
   .docs-content {

--- a/packages/docs/src/styles/documentation.css
+++ b/packages/docs/src/styles/documentation.css
@@ -922,7 +922,10 @@
 
 /* Sidebar Overlay (mobile only). Starts below the top nav (56px) so the
    nav stays visible/interactive — but the backdrop swallows every other
-   tap on the page so menu items behind don't fire by accident. */
+   tap on the page so menu items behind don't fire by accident. The
+   alpha is high enough that page content doesn't read THROUGH the
+   overlay, which previously made the drawer look like it had a z-index
+   bug on long pages with code blocks behind it. */
 .sidebar-overlay {
   display: none;
   position: fixed;
@@ -930,7 +933,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.78);
   z-index: 8999;
 }
 
@@ -949,7 +952,8 @@
 
   .sidebar-overlay {
     display: block;
-    backdrop-filter: blur(2px);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
   }
 
   .docs-sidebar {

--- a/packages/docs/src/styles/documentation.css
+++ b/packages/docs/src/styles/documentation.css
@@ -563,16 +563,21 @@
   opacity: 1;
 }
 
-/* Tables — full-width table layout. Non-last columns shrink to fit their
-   nowrap content; the last column absorbs remaining width and wraps. */
+/* Tables — full-width layout, but allow horizontal scrolling when the
+   minimum content width exceeds the available space (rare, but
+   prevents catastrophic squeeze on phones). The `display: block`
+   trick + `overflow-x: auto` is the most portable way to scope the
+   scroll to the table without needing a wrapper element. */
 .error-table,
 .doc-page table {
+  display: block;
   width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
   border-collapse: collapse;
   margin: 1.5rem 0;
   background: var(--bg-primary);
   border-radius: 0.5rem;
-  overflow: hidden;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
@@ -600,24 +605,27 @@
   border-bottom: 1px solid var(--border-color);
 }
 
-/* Non-last columns (Name, Type, etc.) shrink to fit their content and
-   keep identifiers on one line. */
-.error-table th:not(:last-child),
-.error-table td:not(:last-child),
-.doc-page table th:not(:last-child),
-.doc-page table td:not(:last-child) {
+/* Only the FIRST column (identifier name) stays on one line — applying
+   `nowrap; width:1%` to every non-last column also forced middle
+   columns like Description to refuse to wrap, which then squeezed the
+   last column (e.g. Availability `iOS 17.4+`) to per-character width
+   on narrow viewports. */
+.error-table th:first-child,
+.error-table td:first-child,
+.doc-page table th:first-child,
+.doc-page table td:first-child {
   width: 1%;
   white-space: nowrap;
   vertical-align: top;
 }
 
-/* Last column (Summary/Description) absorbs remaining width and wraps at
-   word boundaries only — never breaks single characters per line. */
-.error-table th:last-child,
-.error-table td:last-child,
-.doc-page table th:last-child,
-.doc-page table td:last-child {
-  width: auto;
+/* All other columns wrap at word boundaries; long fields like
+   identifiers stay readable thanks to overflow-wrap: anywhere as a
+   safety net (no per-character wrap unless absolutely necessary). */
+.error-table th:not(:first-child),
+.error-table td:not(:first-child),
+.doc-page table th:not(:first-child),
+.doc-page table td:not(:first-child) {
   white-space: normal;
   vertical-align: top;
   overflow-wrap: anywhere;

--- a/packages/docs/src/styles/documentation.css
+++ b/packages/docs/src/styles/documentation.css
@@ -28,7 +28,11 @@
   background: var(--bg-secondary);
   border-right: 1px solid var(--border-color);
   padding: var(--spacing-sm) 0 var(--spacing-lg);
-  margin-left: calc((var(--max-width) - 100vw) / 2);
+  /* Pull the sidebar to the viewport edge ONLY when viewport > --max-width
+     (calc is negative). Below --max-width the calc flips positive and would
+     visually shove the sidebar to the right of the viewport (the
+     tablet-range bug); clamp to 0 so it stays put. */
+  margin-left: min(0px, calc((var(--max-width) - 100vw) / 2));
   box-sizing: content-box;
 }
 
@@ -859,13 +863,15 @@
   scrollbar-color: var(--border-color) transparent;
 }
 
-/* Docs Sidebar Toggle - Mobile Only */
+/* Docs Sidebar Toggle - Mobile Only.
+   z-index pushed well above the top nav (which is z-index: 100) so it
+   stays clickable even if the nav's mobile dropdown is mid-transition. */
 .docs-sidebar-toggle {
   display: none;
   position: fixed;
   top: 100px;
   left: 1.5rem;
-  z-index: 1001;
+  z-index: 9001;
   background: var(--primary-color);
   color: white;
   border: none;
@@ -906,16 +912,18 @@
   pointer-events: none;
 }
 
-/* Sidebar Overlay (mobile only) */
+/* Sidebar Overlay (mobile only). Starts below the top nav (56px) so the
+   nav stays visible/interactive — but the backdrop swallows every other
+   tap on the page so menu items behind don't fire by accident. */
 .sidebar-overlay {
   display: none;
   position: fixed;
-  top: 0;
+  top: 56px;
   left: 0;
   right: 0;
   bottom: 0;
   background: rgba(0, 0, 0, 0.5);
-  z-index: 999;
+  z-index: 8999;
 }
 
 /* Mobile Responsive Styles */
@@ -938,7 +946,10 @@
 
   .docs-sidebar {
     position: fixed !important;
-    top: 0 !important;
+    /* Start the drawer BELOW the sticky top nav (which is 56px tall) so
+       the two never overlap geometrically — taps at the very top of the
+       drawer can't bleed into the nav's hamburger menu and vice versa. */
+    top: 56px !important;
     left: 0;
     bottom: 0;
     /* Reset desktop centering offset — at viewports below --max-width,
@@ -948,10 +959,10 @@
     --sidebar-edge-fill: 0px;
     width: 280px;
     max-width: 85vw;
-    height: 100vh !important;
-    max-height: 100vh !important;
+    height: calc(100vh - 56px) !important;
+    max-height: calc(100vh - 56px) !important;
     background: var(--bg-secondary);
-    z-index: 1000;
+    z-index: 9000;
     transition:
       opacity 0.2s ease,
       visibility 0.2s ease;

--- a/packages/docs/src/styles/responsive.css
+++ b/packages/docs/src/styles/responsive.css
@@ -48,14 +48,10 @@
     flex-direction: column;
   }
 
-  .docs-sidebar {
-    width: 100%;
-    margin-bottom: 2rem;
-  }
-
-  .docs-nav {
-    position: static;
-  }
+  /* Sidebar drawer styling lives in documentation.css's mobile block —
+     don't redefine width/position here (the older inline-sidebar layout
+     leaked `width: 100%` and `position: static` rules that would override
+     the drawer and let taps fall through to the top nav). */
 
   .features-container,
   .benefit-grid,

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/Types.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/Types.kt
@@ -4897,7 +4897,11 @@ public interface MutationResolver {
      */
     suspend fun validateReceipt(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify a purchase against your own backend (returns isValid + raw store metadata).
+     * Verify a purchase against your own backend. Returns a platform-specific
+     * variant of VerifyPurchaseResult — VerifyPurchaseResultIOS exposes isValid
+     * + receipt/JWS metadata, VerifyPurchaseResultAndroid carries Play Store
+     * receipt fields (no isValid), and VerifyPurchaseResultHorizon uses success.
+     * Inspect the concrete variant before reading fields.
      * See: https://www.openiap.dev/docs/features/validation#verify-purchase
      */
     suspend fun verifyPurchase(options: VerifyPurchaseProps): VerifyPurchaseResult

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/Types.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/Types.kt
@@ -4744,146 +4744,166 @@ public sealed interface VerifyPurchaseResult {
  */
 public interface MutationResolver {
     /**
-     * Acknowledge a non-consumable purchase or subscription
+     * Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+     * See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
      */
     suspend fun acknowledgePurchaseAndroid(purchaseToken: String): Boolean
     /**
-     * Initiate a refund request for a product (iOS 15+)
+     * Present the refund request sheet (iOS 15+). See also Features → Refund.
+     * See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
      */
     suspend fun beginRefundRequestIOS(sku: String): String?
     /**
-     * Check if alternative billing is available for this user/device
-     * Step 1 of alternative billing flow
+     * Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
      * 
-     * Returns true if available, false otherwise
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns true if available, false otherwise.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
      */
     suspend fun checkAlternativeBillingAvailabilityAndroid(): Boolean
     /**
-     * Clear pending transactions from the StoreKit payment queue
+     * Clear pending transactions in the queue (sandbox helper).
+     * See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
      */
     suspend fun clearTransactionIOS(): Boolean
     /**
-     * Consume a purchase token so it can be repurchased
+     * Consume a consumable purchase so it can be re-bought.
+     * See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
      */
     suspend fun consumePurchaseAndroid(purchaseToken: String): Boolean
     /**
-     * Create external transaction token for Google Play reporting
-     * Step 3 of alternative billing flow
-     * Must be called AFTER successful payment in your payment system
-     * Token must be reported to Google Play backend within 24 hours
+     * Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
+     * Must be called AFTER successful payment in your payment system.
+     * Token must be reported to Google Play backend within 24 hours.
      * 
-     * Returns token string, or null if creation failed
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns token string, or null if creation failed.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
      */
     suspend fun createAlternativeBillingTokenAndroid(): String?
     /**
-     * Create reporting details for a billing program
-     * Replaces the deprecated createExternalOfferReportingDetailsAsync API
+     * Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+     * Replaces the deprecated createExternalOfferReportingDetailsAsync API.
      * 
-     * Available in Google Play Billing Library 8.2.0+
-     * Returns external transaction token needed for reporting external transactions
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns external transaction token needed for reporting external transactions.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
      */
     suspend fun createBillingProgramReportingDetailsAndroid(program: BillingProgramAndroid): BillingProgramReportingDetailsAndroid
     /**
-     * Open the native subscription management surface
+     * Open the platform's subscription management UI.
+     * See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
      */
     suspend fun deepLinkToSubscriptions(options: DeepLinkOptions? = null): Unit
     /**
-     * Close the platform billing connection
+     * Close the store connection and release resources.
+     * See: https://www.openiap.dev/docs/apis/end-connection
      */
     suspend fun endConnection(): Boolean
     /**
-     * Finish a transaction after validating receipts
+     * Complete a transaction after server-side verification. Required on Android within 3 days.
+     * See: https://www.openiap.dev/docs/apis/finish-transaction
      */
     suspend fun finishTransaction(purchase: PurchaseInput, isConsumable: Boolean? = null): Unit
     /**
-     * Establish the platform billing connection
+     * Initialize the store connection. Call before any IAP API.
+     * See: https://www.openiap.dev/docs/apis/init-connection
      */
     suspend fun initConnection(config: InitConnectionConfig? = null): Boolean
     /**
-     * Check if a billing program is available for the current user
-     * Replaces the deprecated isExternalOfferAvailableAsync API
+     * Check whether a billing program (e.g., External Payments) is available for the current user.
+     * Replaces the deprecated isExternalOfferAvailableAsync API.
      * 
-     * Available in Google Play Billing Library 8.2.0+
-     * Returns availability result with isAvailable flag
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Available in Google Play Billing Library 8.2.0+.
+     * Returns availability result with isAvailable flag.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
      */
     suspend fun isBillingProgramAvailableAndroid(program: BillingProgramAndroid): BillingProgramAvailabilityResultAndroid
     /**
-     * Launch external link flow for external billing programs
-     * Replaces the deprecated showExternalOfferInformationDialog API
+     * Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+     * Replaces the deprecated showExternalOfferInformationDialog API.
      * 
-     * Available in Google Play Billing Library 8.2.0+
-     * Shows Play Store dialog and optionally launches external URL
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Shows Play Store dialog and optionally launches external URL.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
      */
     suspend fun launchExternalLinkAndroid(params: LaunchExternalLinkParamsAndroid): Boolean
     /**
-     * Present the App Store code redemption sheet
+     * Show the App Store offer code redemption sheet.
+     * See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
      */
     suspend fun presentCodeRedemptionSheetIOS(): Boolean
     /**
-     * Present external purchase custom link with StoreKit UI
+     * Present an external purchase link, StoreKit External (iOS 16+).
+     * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
      */
     suspend fun presentExternalPurchaseLinkIOS(url: String): ExternalPurchaseLinkResultIOS
     /**
-     * Present external purchase notice sheet (iOS 17.4+).
-     * Uses ExternalPurchase.presentNoticeSheet() which returns a token when user continues.
+     * Present the external purchase notice sheet (iOS 17.4+).
+     * Uses ExternalPurchase.presentNoticeSheet() which returns a token when the user continues.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()
+     * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
      */
     suspend fun presentExternalPurchaseNoticeSheetIOS(): ExternalPurchaseNoticeResultIOS
     /**
-     * Initiate a purchase flow; rely on events for final state
+     * Initiate a purchase or subscription flow; rely on events for final state.
+     * See: https://www.openiap.dev/docs/apis/request-purchase
      */
     suspend fun requestPurchase(params: RequestPurchaseProps): RequestPurchaseResult?
     /**
-     * Purchase the promoted product surfaced by the App Store.
+     * Buy the currently promoted product.
      * 
      * @deprecated Use promotedProductListenerIOS to receive the productId,
      * then call requestPurchase with that SKU instead. In StoreKit 2,
      * promoted products can be purchased directly via the standard purchase flow.
+     * See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
      */
     suspend fun requestPurchaseOnPromotedProductIOS(): Boolean
     /**
-     * Restore completed purchases across platforms
+     * Restore non-consumable and active subscription purchases.
+     * See: https://www.openiap.dev/docs/apis/restore-purchases
      */
     suspend fun restorePurchases(): Unit
     /**
-     * Show alternative billing information dialog to user
-     * Step 2 of alternative billing flow
-     * Must be called BEFORE processing payment in your payment system
+     * Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
+     * Must be called BEFORE processing payment in your payment system.
      * 
-     * Returns true if user accepted, false if user canceled
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns true if user accepted, false if user canceled.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
      */
     suspend fun showAlternativeBillingDialogAndroid(): Boolean
     /**
-     * Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-     * Displays the system disclosure notice sheet for custom external purchase links.
+     * Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
      * Call this after a deliberate customer interaction before linking out to external purchases.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+     * See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
      */
     suspend fun showExternalPurchaseCustomLinkNoticeIOS(noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS): ExternalPurchaseCustomLinkNoticeResultIOS
     /**
-     * Open subscription management UI and return changed purchases (iOS 15+)
+     * Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
      */
     suspend fun showManageSubscriptionsIOS(): List<PurchaseIOS>
     /**
-     * Force a StoreKit sync for transactions (iOS 15+)
+     * Force sync transactions with the App Store (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/sync-ios
      */
     suspend fun syncIOS(): Boolean
     /**
-     * Validate purchase receipts with the configured providers
+     * Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
+     * See: https://www.openiap.dev/docs/features/validation#verify-purchase
      */
     suspend fun validateReceipt(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify purchases with the configured providers
+     * Verify a purchase against your own backend (returns isValid + raw store metadata).
+     * See: https://www.openiap.dev/docs/features/validation#verify-purchase
      */
     suspend fun verifyPurchase(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify purchases with a specific provider (e.g., IAPKit)
+     * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+     * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
      */
     suspend fun verifyPurchaseWithProvider(options: VerifyPurchaseWithProviderProps): VerifyPurchaseWithProviderResult
 }
@@ -4893,95 +4913,116 @@ public interface MutationResolver {
  */
 public interface QueryResolver {
     /**
-     * Check if external purchase notice sheet can be presented (iOS 17.4+)
-     * Uses ExternalPurchase.canPresent
+     * Check eligibility for the external purchase notice sheet (iOS 17.4+).
+     * Uses ExternalPurchase.canPresent.
+     * See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
      */
     suspend fun canPresentExternalPurchaseNoticeIOS(): Boolean
     /**
-     * Get current StoreKit 2 entitlements (iOS 15+)
+     * Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
      */
     suspend fun currentEntitlementIOS(sku: String): PurchaseIOS?
     /**
-     * Retrieve products or subscriptions from the store
+     * Fetch products or subscriptions from the store.
+     * See: https://www.openiap.dev/docs/apis/fetch-products
      */
     suspend fun fetchProducts(params: ProductRequest): FetchProductsResult
     /**
-     * Get active subscriptions (filters by subscriptionIds when provided)
+     * Get details of all currently active subscriptions (filters by subscriptionIds when provided).
+     * See: https://www.openiap.dev/docs/apis/get-active-subscriptions
      */
     suspend fun getActiveSubscriptions(subscriptionIds: List<String>? = null): List<ActiveSubscription>
     /**
-     * Get the full StoreKit 2 transaction history as PurchaseIOS values.
+     * List every StoreKit transaction (finished + unfinished) for the current user.
      * Requires the SK2ConsumableTransactionHistory Info.plist key in the host app
      * for finished consumables to be included (iOS 18+).
      * Unlike getAvailablePurchases, always returns the iOS-specific PurchaseIOS shape.
+     * See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
      */
     suspend fun getAllTransactionsIOS(): List<PurchaseIOS>
     /**
-     * Fetch the current app transaction (iOS 16+)
+     * Fetch the app transaction (iOS 16+).
+     * See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
      */
     suspend fun getAppTransactionIOS(): AppTransaction?
     /**
-     * Get all available purchases for the current user
+     * List active purchases for the current user.
+     * See: https://www.openiap.dev/docs/apis/get-available-purchases
      */
     suspend fun getAvailablePurchases(options: PurchaseOptions? = null): List<Purchase>
     /**
-     * Get external purchase token for reporting to Apple (iOS 18.1+).
-     * Use this token with Apple's External Purchase Server API to report transactions.
+     * Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+     * Use this token to report transactions made through ExternalPurchaseCustomLink.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+     * See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
      */
     suspend fun getExternalPurchaseCustomLinkTokenIOS(tokenType: ExternalPurchaseCustomLinkTokenTypeIOS): ExternalPurchaseCustomLinkTokenResultIOS
     /**
-     * Retrieve all pending transactions in the StoreKit queue
+     * List unfinished StoreKit transactions in the queue.
+     * See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
      */
     suspend fun getPendingTransactionsIOS(): List<PurchaseIOS>
     /**
-     * Get the currently promoted product (iOS 11+)
+     * Read the App Store-promoted product, if any (iOS 11+).
+     * See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
      */
     suspend fun getPromotedProductIOS(): ProductIOS?
     /**
-     * Get base64-encoded receipt data for validation
+     * Get base64-encoded receipt data (legacy validation).
+     * See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
      */
     suspend fun getReceiptDataIOS(): String?
     /**
-     * Get the current storefront country code
+     * Return the user's storefront country code.
+     * See: https://www.openiap.dev/docs/apis/get-storefront
      */
     suspend fun getStorefront(): String
     /**
-     * Get the current App Store storefront country code
+     * Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
+     * See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
      */
     suspend fun getStorefrontIOS(): String
     /**
-     * Get the transaction JWS (StoreKit 2)
+     * Return the JWS string for a transaction (StoreKit 2).
+     * See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
      */
     suspend fun getTransactionJwsIOS(sku: String): String?
     /**
-     * Check whether the user has active subscriptions
+     * Check whether the user has any active subscription.
+     * See: https://www.openiap.dev/docs/apis/has-active-subscriptions
      */
     suspend fun hasActiveSubscriptions(subscriptionIds: List<String>? = null): Boolean
     /**
-     * Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+     * Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
      * Returns true if the app can use custom external purchase links.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+     * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
      */
     suspend fun isEligibleForExternalPurchaseCustomLinkIOS(): Boolean
     /**
-     * Check introductory offer eligibility for a subscription group
+     * Check intro-offer eligibility for a subscription group.
+     * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
      */
     suspend fun isEligibleForIntroOfferIOS(groupID: String): Boolean
     /**
-     * Verify a StoreKit 2 transaction signature
+     * Check whether a transaction's JWS verification passed (StoreKit 2).
+     * See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
      */
     suspend fun isTransactionVerifiedIOS(sku: String): Boolean
     /**
-     * Get the latest transaction for a product using StoreKit 2
+     * Get the latest verified transaction for a product, using StoreKit 2.
+     * See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
      */
     suspend fun latestTransactionIOS(sku: String): PurchaseIOS?
     /**
-     * Get StoreKit 2 subscription status details (iOS 15+)
+     * Get subscription status objects from StoreKit 2 (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
      */
     suspend fun subscriptionStatusIOS(sku: String): List<SubscriptionStatusIOS>
     /**
-     * Validate a receipt for a specific product
+     * Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
+     * See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
      */
     suspend fun validateReceiptIOS(options: VerifyPurchaseProps): VerifyPurchaseResultIOS
 }

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/Types.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/Types.kt
@@ -4902,7 +4902,9 @@ public interface MutationResolver {
      */
     suspend fun verifyPurchase(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+     * Verify via a managed provider without standing up your own server. The
+     * PurchaseVerificationProvider enum currently exposes only IAPKit; platform
+     * availability may differ by implementation.
      * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
      */
     suspend fun verifyPurchaseWithProvider(options: VerifyPurchaseWithProviderProps): VerifyPurchaseWithProviderResult

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
@@ -219,6 +219,17 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     // Connection Management - Using GraphQL handler pattern
     // -------------------------------------------------------------------------
 
+    /**
+     * Initialize the store connection. Must be called before any other IAP API.
+     *
+     * @param config Optional [InitConnectionConfig]. Use `enableBillingProgramAndroid` to
+     *   opt in to External Payments / similar Play Billing programs. Pass `null` for default.
+     * @return `true` once the Play Billing client is connected.
+     * @throws OpenIapError.InitConnection when the billing client fails to initialize
+     *   (e.g. Play Store missing, version too old).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/init-connection">init-connection</a>
+     */
     val initConnection: MutationInitConnectionHandler = { config ->
         setLoading { it.initConnection = true }
         try {
@@ -237,13 +248,26 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     }
 
     /**
-     * Convenience overload that calls initConnection with null config
+     * Initialize the store connection. Must be called before any other IAP API.
+     *
+     * Convenience overload — calls the config-accepting variant with `null`.
+     *
+     * @return `true` once the Play Billing client is connected.
+     * @throws OpenIapError.InitConnection when the billing client fails to initialize
+     *   (e.g. Play Store missing, version too old).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/init-connection">init-connection</a>
      */
     suspend fun initConnection(): Boolean {
         OpenIapLog.i("OpenIapStore.initConnection(): Calling initConnection(null)...", "OpenIapStore")
         return initConnection(null)
     }
 
+    /**
+     * Close the store connection and release resources.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/end-connection">https://www.openiap.dev/docs/apis/end-connection</a>
+     */
     val endConnection: MutationEndConnectionHandler = {
         removePurchaseUpdateListener(purchaseUpdateListener)
         removePurchaseErrorListener(purchaseErrorListener)
@@ -262,6 +286,18 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     // -------------------------------------------------------------------------
     // Product Management - Using GraphQL handler pattern
     // -------------------------------------------------------------------------
+    /**
+     * Retrieve products or subscriptions from Google Play by SKU.
+     *
+     * @param params [ProductRequest] with `skus` and an optional `type`
+     *   ([ProductQueryType.InApp], [ProductQueryType.Subs], or [ProductQueryType.All];
+     *   defaults to InApp).
+     * @return A [FetchProductsResult] sealed variant — `Products` for InApp,
+     *   `Subscriptions` for Subs, mixed list for All.
+     * @throws OpenIapError on store rejection (unknown SKU, network failure, not connected).
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/fetch-products">fetch-products</a>
+     */
     val fetchProducts: QueryFetchProductsHandler = { request ->
         android.util.Log.i("OpenIapStore", "fetchProducts called with SKUs: ${request.skus}, type: ${request.type}")
         setLoading { it.fetchProducts = true }
@@ -341,6 +377,17 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     // -------------------------------------------------------------------------
     // Purchases / Restore - Using GraphQL handler pattern
     // -------------------------------------------------------------------------
+    /**
+     * List the user's unfinished purchases. Use this to restore non-consumables /
+     * active subscriptions, or to pick up purchases that weren't finished previously.
+     *
+     * @param options Optional [PurchaseOptions]. Most fields are iOS-only and ignored
+     *   on Android.
+     * @return List of [Purchase] currently held by Play Billing.
+     * @throws OpenIapError when the Play Billing query fails.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/get-available-purchases">get-available-purchases</a>
+     */
     val getAvailablePurchases: QueryGetAvailablePurchasesHandler = { options ->
         android.util.Log.i("OpenIapStore", "getAvailablePurchases called, module type: ${module.javaClass.simpleName}")
         setLoading { it.restorePurchases = true }
@@ -363,6 +410,21 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     // -------------------------------------------------------------------------
     // Purchase Flow - Using GraphQL handler pattern
     // -------------------------------------------------------------------------
+    /**
+     * Initiate a purchase flow. The result is delivered via the purchase update listener,
+     * NOT through the return value.
+     *
+     * @param props [RequestPurchaseProps]. Use `request.google.skus` and pass
+     *   `subscriptionOffers = [{sku, offerToken}]` for subscriptions.
+     * @return The dispatched purchase payload (do not rely on this for the actual outcome).
+     * @throws OpenIapError on synchronous rejection (e.g. billing client not ready,
+     *   developer error such as missing offerToken on subs).
+     *
+     * Warning: Event-based. Collect from `purchaseUpdatedListener` / `purchaseErrorListener`
+     * (or `OpenIapStore.currentPurchase` / `currentError` flows) for the final state.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/request-purchase">request-purchase</a>
+     */
     val requestPurchase: MutationRequestPurchaseHandler = { props ->
         val skuForStatus = when (val request = props.request) {
             is RequestPurchaseProps.Request.Purchase -> request.value.android?.skus?.firstOrNull()
@@ -383,7 +445,18 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     }
 
 
-    // Using GraphQL handler pattern
+    /**
+     * Complete a purchase transaction. Call after server-side verification.
+     *
+     * @param purchase The [PurchaseInput] to finalize.
+     * @param isConsumable Pass `true` for consumables (consumes the token so the SKU can be
+     *   bought again), `false` for non-consumables and subscriptions (acknowledges only).
+     * @throws OpenIapError when the Play Billing finalize call fails.
+     *
+     * Important: Google auto-refunds Android purchases NOT acknowledged/consumed within 3 days.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/finish-transaction">finish-transaction</a>
+     */
     val finishTransaction: MutationFinishTransactionHandler = { purchaseInput, isConsumable ->
         val token = purchaseInput.purchaseToken
         // Check if already processed - but we can't check isAcknowledgedAndroid on PurchaseInput
@@ -402,32 +475,45 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     // -------------------------------------------------------------------------
     // Subscriptions
     // -------------------------------------------------------------------------
+    /**
+     * Get details of all currently active subscriptions.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/get-active-subscriptions">https://www.openiap.dev/docs/apis/get-active-subscriptions</a>
+     */
     suspend fun getActiveSubscriptions(subscriptionIds: List<String>? = null): List<ActiveSubscription> =
         module.queryHandlers.getActiveSubscriptions?.invoke(subscriptionIds) ?: emptyList()
 
+    /**
+     * Check whether the user has any active subscription.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/has-active-subscriptions">https://www.openiap.dev/docs/apis/has-active-subscriptions</a>
+     */
     suspend fun hasActiveSubscriptions(subscriptionIds: List<String>? = null): Boolean =
         module.queryHandlers.hasActiveSubscriptions?.invoke(subscriptionIds) ?: false
 
+    /**
+     * Open the platform's subscription management UI.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/deep-link-to-subscriptions">https://www.openiap.dev/docs/apis/deep-link-to-subscriptions</a>
+     */
     suspend fun deepLinkToSubscriptions(options: DeepLinkOptions) = module.mutationHandlers.deepLinkToSubscriptions?.invoke(options)
 
     // -------------------------------------------------------------------------
     // Alternative Billing (Step-by-Step API)
     // -------------------------------------------------------------------------
     /**
-     * Step 1: Check if alternative billing is available for this user/device
-     * @return true if available, false otherwise
-     * @deprecated Use isBillingProgramAvailable with BillingProgramAndroid.ExternalOffer instead
+     * Check whether alternative billing is available for the user.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android">https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android</a>
      */
     @Deprecated("Use isBillingProgramAvailable with BillingProgramAndroid.ExternalOffer instead")
     @Suppress("DEPRECATION")
     suspend fun checkAlternativeBillingAvailability(): Boolean = module.checkAlternativeBillingAvailability()
 
     /**
-     * Step 2: Show alternative billing information dialog to user
-     * Must be called BEFORE processing payment
-     * @param activity Current activity context
-     * @return true if user accepted, false if canceled
-     * @deprecated Use launchExternalLink instead
+     * Display Google's alternative billing information dialog.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android">https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android</a>
      */
     @Deprecated("Use launchExternalLink instead")
     @Suppress("DEPRECATION")
@@ -435,11 +521,9 @@ class OpenIapStore(private val module: OpenIapProtocol) {
         module.showAlternativeBillingInformationDialog(activity)
 
     /**
-     * Step 3: Create external transaction token for alternative billing
-     * Must be called AFTER successful payment in your payment system
-     * Token must be reported to Google Play backend within 24 hours
-     * @return External transaction token, or null if failed
-     * @deprecated Use createBillingProgramReportingDetails with BillingProgramAndroid.ExternalOffer instead
+     * Create a reporting token for an alternative billing flow.
+     *
+     * @see <a href="https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android">https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android</a>
      */
     @Deprecated("Use createBillingProgramReportingDetails with BillingProgramAndroid.ExternalOffer instead")
     @Suppress("DEPRECATION")
@@ -450,32 +534,25 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     // Billing Programs (Google Play Billing Library 8.2.0+)
     // -------------------------------------------------------------------------
     /**
-     * Check if a billing program is available for this user/device.
-     * This is the new API that replaces checkAlternativeBillingAvailability for external offers.
+     * Check whether a billing program (e.g., External Payments) is available.
      *
-     * @param program The billing program to check (EXTERNAL_CONTENT_LINK or EXTERNAL_OFFER)
-     * @return Result containing availability information
+     * @see <a href="https://www.openiap.dev/docs/apis/android/is-billing-program-available-android">https://www.openiap.dev/docs/apis/android/is-billing-program-available-android</a>
      */
     suspend fun isBillingProgramAvailable(program: BillingProgramAndroid): BillingProgramAvailabilityResultAndroid =
         module.isBillingProgramAvailable(program)
 
     /**
-     * Create reporting details for transactions made outside of Google Play Billing.
-     * This is the new API that replaces createAlternativeBillingReportingToken for external offers.
+     * Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
      *
-     * @param program The billing program (EXTERNAL_CONTENT_LINK or EXTERNAL_OFFER)
-     * @return Reporting details containing the external transaction token
+     * @see <a href="https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android">https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android</a>
      */
     suspend fun createBillingProgramReportingDetails(program: BillingProgramAndroid): BillingProgramReportingDetailsAndroid =
         module.createBillingProgramReportingDetails(program)
 
     /**
-     * Launch an external link for external offer or app download.
-     * This is the new API that replaces showAlternativeBillingInformationDialog for external offers.
+     * Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
      *
-     * @param activity Current activity context
-     * @param params Parameters for the external link
-     * @return true if launch was successful, false otherwise
+     * @see <a href="https://www.openiap.dev/docs/apis/android/launch-external-link-android">https://www.openiap.dev/docs/apis/android/launch-external-link-android</a>
      */
     suspend fun launchExternalLink(activity: Activity, params: LaunchExternalLinkParamsAndroid): Boolean =
         module.launchExternalLink(activity, params)

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
@@ -421,7 +421,8 @@ class OpenIapStore(private val module: OpenIapProtocol) {
      *   developer error such as missing offerToken on subs).
      *
      * Warning: Event-based. Collect from `purchaseUpdatedListener` / `purchaseErrorListener`
-     * (or `OpenIapStore.currentPurchase` / `currentError` flows) for the final state.
+     * (or `OpenIapStore.currentPurchase` and `OpenIapStore.status.lastError` flows) for the
+     * final state — there is no `currentError` field; errors live on `status.lastError`.
      *
      * @see <a href="https://www.openiap.dev/docs/apis/request-purchase">request-purchase</a>
      */

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
@@ -378,12 +378,16 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     // Purchases / Restore - Using GraphQL handler pattern
     // -------------------------------------------------------------------------
     /**
-     * List the user's unfinished purchases. Use this to restore non-consumables /
-     * active subscriptions, or to pick up purchases that weren't finished previously.
+     * List the owned/available purchases held by Play Billing — non-consumables,
+     * active subscriptions, and any pending transactions returned by
+     * `BillingClient.queryPurchasesAsync` for INAPP + SUBS. Use this to restore
+     * purchases or to recover anything not finished previously. (iOS uses
+     * `Transaction.unfinished` / `Transaction.all` semantics; on Android the
+     * concept is "owned by the user", not strictly "unfinished".)
      *
      * @param options Optional [PurchaseOptions]. Most fields are iOS-only and ignored
      *   on Android.
-     * @return List of [Purchase] currently held by Play Billing.
+     * @return List of [Purchase] currently owned according to Play Billing.
      * @throws OpenIapError when the Play Billing query fails.
      *
      * @see <a href="https://www.openiap.dev/docs/apis/get-available-purchases">get-available-purchases</a>

--- a/packages/gql/src/api-android.graphql
+++ b/packages/gql/src/api-android.graphql
@@ -2,78 +2,81 @@
 
 extend type Mutation {
   """
-  Acknowledge a non-consumable purchase or subscription
+  Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+  See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
   """
   # Future
   acknowledgePurchaseAndroid(purchaseToken: String!): Boolean!
   """
-  Consume a purchase token so it can be repurchased
+  Consume a consumable purchase so it can be re-bought.
+  See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
   """
   # Future
   consumePurchaseAndroid(purchaseToken: String!): Boolean!
 
   # Alternative Billing APIs
   """
-  Check if alternative billing is available for this user/device
-  Step 1 of alternative billing flow
+  Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
 
-  Returns true if available, false otherwise
-  Throws OpenIapError.NotPrepared if billing client not ready
+  Returns true if available, false otherwise.
+  Throws OpenIapError.NotPrepared if billing client not ready.
+  See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
   """
   # Future
   checkAlternativeBillingAvailabilityAndroid: Boolean!
   """
-  Show alternative billing information dialog to user
-  Step 2 of alternative billing flow
-  Must be called BEFORE processing payment in your payment system
+  Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
+  Must be called BEFORE processing payment in your payment system.
 
-  Returns true if user accepted, false if user canceled
-  Throws OpenIapError.NotPrepared if billing client not ready
+  Returns true if user accepted, false if user canceled.
+  Throws OpenIapError.NotPrepared if billing client not ready.
+  See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
   """
   # Future
   showAlternativeBillingDialogAndroid: Boolean!
   """
-  Create external transaction token for Google Play reporting
-  Step 3 of alternative billing flow
-  Must be called AFTER successful payment in your payment system
-  Token must be reported to Google Play backend within 24 hours
+  Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
+  Must be called AFTER successful payment in your payment system.
+  Token must be reported to Google Play backend within 24 hours.
 
-  Returns token string, or null if creation failed
-  Throws OpenIapError.NotPrepared if billing client not ready
+  Returns token string, or null if creation failed.
+  Throws OpenIapError.NotPrepared if billing client not ready.
+  See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
   """
   # Future
   createAlternativeBillingTokenAndroid: String
 
   # Billing Programs API (Google Play Billing Library 8.2.0+)
   """
-  Check if a billing program is available for the current user
-  Replaces the deprecated isExternalOfferAvailableAsync API
+  Check whether a billing program (e.g., External Payments) is available for the current user.
+  Replaces the deprecated isExternalOfferAvailableAsync API.
 
-  Available in Google Play Billing Library 8.2.0+
-  Returns availability result with isAvailable flag
-  Throws OpenIapError.NotPrepared if billing client not ready
+  Available in Google Play Billing Library 8.2.0+.
+  Returns availability result with isAvailable flag.
+  Throws OpenIapError.NotPrepared if billing client not ready.
+  See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
   """
   # Future
   isBillingProgramAvailableAndroid(program: BillingProgramAndroid!): BillingProgramAvailabilityResultAndroid!
 
   """
-  Create reporting details for a billing program
-  Replaces the deprecated createExternalOfferReportingDetailsAsync API
+  Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+  Replaces the deprecated createExternalOfferReportingDetailsAsync API.
 
-  Available in Google Play Billing Library 8.2.0+
-  Returns external transaction token needed for reporting external transactions
-  Throws OpenIapError.NotPrepared if billing client not ready
+  Returns external transaction token needed for reporting external transactions.
+  Throws OpenIapError.NotPrepared if billing client not ready.
+  See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
   """
   # Future
   createBillingProgramReportingDetailsAndroid(program: BillingProgramAndroid!): BillingProgramReportingDetailsAndroid!
 
   """
-  Launch external link flow for external billing programs
-  Replaces the deprecated showExternalOfferInformationDialog API
+  Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+  Replaces the deprecated showExternalOfferInformationDialog API.
 
-  Available in Google Play Billing Library 8.2.0+
-  Shows Play Store dialog and optionally launches external URL
-  Throws OpenIapError.NotPrepared if billing client not ready
+  Shows Play Store dialog and optionally launches external URL.
+  Throws OpenIapError.NotPrepared if billing client not ready.
+  See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
   """
   # Future
   launchExternalLinkAndroid(params: LaunchExternalLinkParamsAndroid!): Boolean!

--- a/packages/gql/src/api-ios.graphql
+++ b/packages/gql/src/api-ios.graphql
@@ -2,32 +2,37 @@
 
 extend type Query {
   """
-  Get the current App Store storefront country code
+  Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
+  See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
   """
   # Future
   getStorefrontIOS: String! @deprecated(reason: "Use getStorefront")
   """
-  Get the currently promoted product (iOS 11+)
+  Read the App Store-promoted product, if any (iOS 11+).
+  See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
   """
   # Future
   getPromotedProductIOS: ProductIOS
   """
-  Check if external purchase notice sheet can be presented (iOS 17.4+)
-  Uses ExternalPurchase.canPresent
+  Check eligibility for the external purchase notice sheet (iOS 17.4+).
+  Uses ExternalPurchase.canPresent.
+  See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
   """
   # Future
   canPresentExternalPurchaseNoticeIOS: Boolean!
   """
-  Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+  Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
   Returns true if the app can use custom external purchase links.
   Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+  See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
   """
   # Future
   isEligibleForExternalPurchaseCustomLinkIOS: Boolean!
   """
-  Get external purchase token for reporting to Apple (iOS 18.1+).
-  Use this token with Apple's External Purchase Server API to report transactions.
+  Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+  Use this token to report transactions made through ExternalPurchaseCustomLink.
   Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+  See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
   """
   # Future
   getExternalPurchaseCustomLinkTokenIOS(
@@ -37,60 +42,71 @@ extend type Query {
     tokenType: ExternalPurchaseCustomLinkTokenTypeIOS!
   ): ExternalPurchaseCustomLinkTokenResultIOS!
   """
-  Retrieve all pending transactions in the StoreKit queue
+  List unfinished StoreKit transactions in the queue.
+  See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
   """
   # Future
   getPendingTransactionsIOS: [PurchaseIOS!]!
   """
-  Check introductory offer eligibility for a subscription group
+  Check intro-offer eligibility for a subscription group.
+  See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
   """
   # Future
   isEligibleForIntroOfferIOS(groupID: String!): Boolean!
   """
-  Get StoreKit 2 subscription status details (iOS 15+)
+  Get subscription status objects from StoreKit 2 (iOS 15+).
+  See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
   """
   # Future
   subscriptionStatusIOS(sku: String!): [SubscriptionStatusIOS!]!
   """
-  Get current StoreKit 2 entitlements (iOS 15+)
+  Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
+  See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
   """
   # Future
   currentEntitlementIOS(sku: String!): PurchaseIOS
   """
-  Get the latest transaction for a product using StoreKit 2
+  Get the latest verified transaction for a product, using StoreKit 2.
+  See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
   """
   # Future
   latestTransactionIOS(sku: String!): PurchaseIOS
   """
-  Verify a StoreKit 2 transaction signature
+  Check whether a transaction's JWS verification passed (StoreKit 2).
+  See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
   """
   # Future
   isTransactionVerifiedIOS(sku: String!): Boolean!
   """
-  Get the transaction JWS (StoreKit 2)
+  Return the JWS string for a transaction (StoreKit 2).
+  See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
   """
   # Future
   getTransactionJwsIOS(sku: String!): String
   """
-  Get base64-encoded receipt data for validation
+  Get base64-encoded receipt data (legacy validation).
+  See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
   """
   # Future
   getReceiptDataIOS: String
   """
-  Fetch the current app transaction (iOS 16+)
+  Fetch the app transaction (iOS 16+).
+  See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
   """
   # Future
   getAppTransactionIOS: AppTransaction
   """
-  Get the full StoreKit 2 transaction history as PurchaseIOS values.
+  List every StoreKit transaction (finished + unfinished) for the current user.
   Requires the SK2ConsumableTransactionHistory Info.plist key in the host app
   for finished consumables to be included (iOS 18+).
   Unlike getAvailablePurchases, always returns the iOS-specific PurchaseIOS shape.
+  See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
   """
   # Future
   getAllTransactionsIOS: [PurchaseIOS!]!
   """
-  Validate a receipt for a specific product
+  Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
+  See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
   """
   # Future
   validateReceiptIOS(options: VerifyPurchaseProps!): VerifyPurchaseResultIOS! @deprecated(reason: "Use verifyPurchase")
@@ -98,56 +114,64 @@ extend type Query {
 
 extend type Mutation {
   """
-  Clear pending transactions from the StoreKit payment queue
+  Clear pending transactions in the queue (sandbox helper).
+  See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
   """
   # Future
   clearTransactionIOS: Boolean!
   """
-  Purchase the promoted product surfaced by the App Store.
+  Buy the currently promoted product.
 
   @deprecated Use promotedProductListenerIOS to receive the productId,
   then call requestPurchase with that SKU instead. In StoreKit 2,
   promoted products can be purchased directly via the standard purchase flow.
+  See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
   """
   # Future
   requestPurchaseOnPromotedProductIOS: Boolean! @deprecated(reason: "Use promotedProductListenerIOS + requestPurchase instead")
   """
-  Open subscription management UI and return changed purchases (iOS 15+)
+  Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
+  See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
   """
   # Future
   showManageSubscriptionsIOS: [PurchaseIOS!]!
   """
-  Initiate a refund request for a product (iOS 15+)
+  Present the refund request sheet (iOS 15+). See also Features → Refund.
+  See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
   """
   # Future
   beginRefundRequestIOS(sku: String!): String
   """
-  Force a StoreKit sync for transactions (iOS 15+)
+  Force sync transactions with the App Store (iOS 15+).
+  See: https://www.openiap.dev/docs/apis/ios/sync-ios
   """
   # Future
   syncIOS: Boolean!
   """
-  Present the App Store code redemption sheet
+  Show the App Store offer code redemption sheet.
+  See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
   """
   # Future
   presentCodeRedemptionSheetIOS: Boolean!
   """
-  Present external purchase notice sheet (iOS 17.4+).
-  Uses ExternalPurchase.presentNoticeSheet() which returns a token when user continues.
+  Present the external purchase notice sheet (iOS 17.4+).
+  Uses ExternalPurchase.presentNoticeSheet() which returns a token when the user continues.
   Reference: https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()
+  See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
   """
   # Future
   presentExternalPurchaseNoticeSheetIOS: ExternalPurchaseNoticeResultIOS!
   """
-  Present external purchase custom link with StoreKit UI
+  Present an external purchase link, StoreKit External (iOS 16+).
+  See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
   """
   # Future
   presentExternalPurchaseLinkIOS(url: String!): ExternalPurchaseLinkResultIOS!
   """
-  Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-  Displays the system disclosure notice sheet for custom external purchase links.
+  Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
   Call this after a deliberate customer interaction before linking out to external purchases.
   Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+  See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
   """
   # Future
   showExternalPurchaseCustomLinkNoticeIOS(

--- a/packages/gql/src/api.graphql
+++ b/packages/gql/src/api.graphql
@@ -3,27 +3,32 @@
 # Product management
 extend type Query {
   """
-  Retrieve products or subscriptions from the store
+  Fetch products or subscriptions from the store.
+  See: https://www.openiap.dev/docs/apis/fetch-products
   """
   # Future
   fetchProducts(params: ProductRequest!): FetchProductsResult!
   """
-  Get all available purchases for the current user
+  List active purchases for the current user.
+  See: https://www.openiap.dev/docs/apis/get-available-purchases
   """
   # Future
   getAvailablePurchases(options: PurchaseOptions): [Purchase!]!
   """
-  Get active subscriptions (filters by subscriptionIds when provided)
+  Get details of all currently active subscriptions (filters by subscriptionIds when provided).
+  See: https://www.openiap.dev/docs/apis/get-active-subscriptions
   """
   # Future
   getActiveSubscriptions(subscriptionIds: [String!]): [ActiveSubscription!]!
   """
-  Check whether the user has active subscriptions
+  Check whether the user has any active subscription.
+  See: https://www.openiap.dev/docs/apis/has-active-subscriptions
   """
   # Future
   hasActiveSubscriptions(subscriptionIds: [String!]): Boolean!
   """
-  Get the current storefront country code
+  Return the user's storefront country code.
+  See: https://www.openiap.dev/docs/apis/get-storefront
   """
   # Future
   getStorefront: String!
@@ -32,22 +37,26 @@ extend type Query {
 # Request APIs (event driven)
 extend type Mutation {
   """
-  Establish the platform billing connection
+  Initialize the store connection. Call before any IAP API.
+  See: https://www.openiap.dev/docs/apis/init-connection
   """
   # Future
   initConnection(config: InitConnectionConfig): Boolean!
   """
-  Close the platform billing connection
+  Close the store connection and release resources.
+  See: https://www.openiap.dev/docs/apis/end-connection
   """
   # Future
   endConnection: Boolean!
   """
-  Initiate a purchase flow; rely on events for final state
+  Initiate a purchase or subscription flow; rely on events for final state.
+  See: https://www.openiap.dev/docs/apis/request-purchase
   """
   # Future
   requestPurchase(params: RequestPurchaseProps!): RequestPurchaseResult
   """
-  Finish a transaction after validating receipts
+  Complete a transaction after server-side verification. Required on Android within 3 days.
+  See: https://www.openiap.dev/docs/apis/finish-transaction
   """
   # Future
   finishTransaction(
@@ -55,27 +64,32 @@ extend type Mutation {
     isConsumable: Boolean
   ): VoidResult!
   """
-  Restore completed purchases across platforms
+  Restore non-consumable and active subscription purchases.
+  See: https://www.openiap.dev/docs/apis/restore-purchases
   """
   # Future
   restorePurchases: VoidResult!
   """
-  Open the native subscription management surface
+  Open the platform's subscription management UI.
+  See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
   """
   # Future
   deepLinkToSubscriptions(options: DeepLinkOptions): VoidResult!
   """
-  Validate purchase receipts with the configured providers
+  Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
+  See: https://www.openiap.dev/docs/features/validation#verify-purchase
   """
   # Future
   validateReceipt(options: VerifyPurchaseProps!): VerifyPurchaseResult! @deprecated(reason: "Use verifyPurchase")
   """
-  Verify purchases with the configured providers
+  Verify a purchase against your own backend (returns isValid + raw store metadata).
+  See: https://www.openiap.dev/docs/features/validation#verify-purchase
   """
   # Future
   verifyPurchase(options: VerifyPurchaseProps!): VerifyPurchaseResult!
   """
-  Verify purchases with a specific provider (e.g., IAPKit)
+  Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+  See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
   """
   # Future
   verifyPurchaseWithProvider(

--- a/packages/gql/src/api.graphql
+++ b/packages/gql/src/api.graphql
@@ -82,7 +82,11 @@ extend type Mutation {
   # Future
   validateReceipt(options: VerifyPurchaseProps!): VerifyPurchaseResult! @deprecated(reason: "Use verifyPurchase")
   """
-  Verify a purchase against your own backend (returns isValid + raw store metadata).
+  Verify a purchase against your own backend. Returns a platform-specific
+  variant of VerifyPurchaseResult — VerifyPurchaseResultIOS exposes isValid
+  + receipt/JWS metadata, VerifyPurchaseResultAndroid carries Play Store
+  receipt fields (no isValid), and VerifyPurchaseResultHorizon uses success.
+  Inspect the concrete variant before reading fields.
   See: https://www.openiap.dev/docs/features/validation#verify-purchase
   """
   # Future

--- a/packages/gql/src/api.graphql
+++ b/packages/gql/src/api.graphql
@@ -88,7 +88,9 @@ extend type Mutation {
   # Future
   verifyPurchase(options: VerifyPurchaseProps!): VerifyPurchaseResult!
   """
-  Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+  Verify via a managed provider without standing up your own server. The
+  PurchaseVerificationProvider enum currently exposes only IAPKit; platform
+  availability may differ by implementation.
   See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
   """
   # Future

--- a/packages/gql/src/generated/Types.kt
+++ b/packages/gql/src/generated/Types.kt
@@ -4833,146 +4833,166 @@ public sealed interface VerifyPurchaseResult {
  */
 public interface MutationResolver {
     /**
-     * Acknowledge a non-consumable purchase or subscription
+     * Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+     * See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
      */
     suspend fun acknowledgePurchaseAndroid(purchaseToken: String): Boolean
     /**
-     * Initiate a refund request for a product (iOS 15+)
+     * Present the refund request sheet (iOS 15+). See also Features → Refund.
+     * See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
      */
     suspend fun beginRefundRequestIOS(sku: String): String?
     /**
-     * Check if alternative billing is available for this user/device
-     * Step 1 of alternative billing flow
+     * Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
      * 
-     * Returns true if available, false otherwise
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns true if available, false otherwise.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
      */
     suspend fun checkAlternativeBillingAvailabilityAndroid(): Boolean
     /**
-     * Clear pending transactions from the StoreKit payment queue
+     * Clear pending transactions in the queue (sandbox helper).
+     * See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
      */
     suspend fun clearTransactionIOS(): Boolean
     /**
-     * Consume a purchase token so it can be repurchased
+     * Consume a consumable purchase so it can be re-bought.
+     * See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
      */
     suspend fun consumePurchaseAndroid(purchaseToken: String): Boolean
     /**
-     * Create external transaction token for Google Play reporting
-     * Step 3 of alternative billing flow
-     * Must be called AFTER successful payment in your payment system
-     * Token must be reported to Google Play backend within 24 hours
+     * Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
+     * Must be called AFTER successful payment in your payment system.
+     * Token must be reported to Google Play backend within 24 hours.
      * 
-     * Returns token string, or null if creation failed
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns token string, or null if creation failed.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
      */
     suspend fun createAlternativeBillingTokenAndroid(): String?
     /**
-     * Create reporting details for a billing program
-     * Replaces the deprecated createExternalOfferReportingDetailsAsync API
+     * Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+     * Replaces the deprecated createExternalOfferReportingDetailsAsync API.
      * 
-     * Available in Google Play Billing Library 8.2.0+
-     * Returns external transaction token needed for reporting external transactions
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns external transaction token needed for reporting external transactions.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
      */
     suspend fun createBillingProgramReportingDetailsAndroid(program: BillingProgramAndroid): BillingProgramReportingDetailsAndroid
     /**
-     * Open the native subscription management surface
+     * Open the platform's subscription management UI.
+     * See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
      */
     suspend fun deepLinkToSubscriptions(options: DeepLinkOptions? = null): Unit
     /**
-     * Close the platform billing connection
+     * Close the store connection and release resources.
+     * See: https://www.openiap.dev/docs/apis/end-connection
      */
     suspend fun endConnection(): Boolean
     /**
-     * Finish a transaction after validating receipts
+     * Complete a transaction after server-side verification. Required on Android within 3 days.
+     * See: https://www.openiap.dev/docs/apis/finish-transaction
      */
     suspend fun finishTransaction(purchase: PurchaseInput, isConsumable: Boolean? = null): Unit
     /**
-     * Establish the platform billing connection
+     * Initialize the store connection. Call before any IAP API.
+     * See: https://www.openiap.dev/docs/apis/init-connection
      */
     suspend fun initConnection(config: InitConnectionConfig? = null): Boolean
     /**
-     * Check if a billing program is available for the current user
-     * Replaces the deprecated isExternalOfferAvailableAsync API
+     * Check whether a billing program (e.g., External Payments) is available for the current user.
+     * Replaces the deprecated isExternalOfferAvailableAsync API.
      * 
-     * Available in Google Play Billing Library 8.2.0+
-     * Returns availability result with isAvailable flag
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Available in Google Play Billing Library 8.2.0+.
+     * Returns availability result with isAvailable flag.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
      */
     suspend fun isBillingProgramAvailableAndroid(program: BillingProgramAndroid): BillingProgramAvailabilityResultAndroid
     /**
-     * Launch external link flow for external billing programs
-     * Replaces the deprecated showExternalOfferInformationDialog API
+     * Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+     * Replaces the deprecated showExternalOfferInformationDialog API.
      * 
-     * Available in Google Play Billing Library 8.2.0+
-     * Shows Play Store dialog and optionally launches external URL
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Shows Play Store dialog and optionally launches external URL.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
      */
     suspend fun launchExternalLinkAndroid(params: LaunchExternalLinkParamsAndroid): Boolean
     /**
-     * Present the App Store code redemption sheet
+     * Show the App Store offer code redemption sheet.
+     * See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
      */
     suspend fun presentCodeRedemptionSheetIOS(): Boolean
     /**
-     * Present external purchase custom link with StoreKit UI
+     * Present an external purchase link, StoreKit External (iOS 16+).
+     * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
      */
     suspend fun presentExternalPurchaseLinkIOS(url: String): ExternalPurchaseLinkResultIOS
     /**
-     * Present external purchase notice sheet (iOS 17.4+).
-     * Uses ExternalPurchase.presentNoticeSheet() which returns a token when user continues.
+     * Present the external purchase notice sheet (iOS 17.4+).
+     * Uses ExternalPurchase.presentNoticeSheet() which returns a token when the user continues.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()
+     * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
      */
     suspend fun presentExternalPurchaseNoticeSheetIOS(): ExternalPurchaseNoticeResultIOS
     /**
-     * Initiate a purchase flow; rely on events for final state
+     * Initiate a purchase or subscription flow; rely on events for final state.
+     * See: https://www.openiap.dev/docs/apis/request-purchase
      */
     suspend fun requestPurchase(params: RequestPurchaseProps): RequestPurchaseResult?
     /**
-     * Purchase the promoted product surfaced by the App Store.
+     * Buy the currently promoted product.
      * 
      * @deprecated Use promotedProductListenerIOS to receive the productId,
      * then call requestPurchase with that SKU instead. In StoreKit 2,
      * promoted products can be purchased directly via the standard purchase flow.
+     * See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
      */
     suspend fun requestPurchaseOnPromotedProductIOS(): Boolean
     /**
-     * Restore completed purchases across platforms
+     * Restore non-consumable and active subscription purchases.
+     * See: https://www.openiap.dev/docs/apis/restore-purchases
      */
     suspend fun restorePurchases(): Unit
     /**
-     * Show alternative billing information dialog to user
-     * Step 2 of alternative billing flow
-     * Must be called BEFORE processing payment in your payment system
+     * Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
+     * Must be called BEFORE processing payment in your payment system.
      * 
-     * Returns true if user accepted, false if user canceled
-     * Throws OpenIapError.NotPrepared if billing client not ready
+     * Returns true if user accepted, false if user canceled.
+     * Throws OpenIapError.NotPrepared if billing client not ready.
+     * See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
      */
     suspend fun showAlternativeBillingDialogAndroid(): Boolean
     /**
-     * Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-     * Displays the system disclosure notice sheet for custom external purchase links.
+     * Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
      * Call this after a deliberate customer interaction before linking out to external purchases.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+     * See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
      */
     suspend fun showExternalPurchaseCustomLinkNoticeIOS(noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS): ExternalPurchaseCustomLinkNoticeResultIOS
     /**
-     * Open subscription management UI and return changed purchases (iOS 15+)
+     * Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
      */
     suspend fun showManageSubscriptionsIOS(): List<PurchaseIOS>
     /**
-     * Force a StoreKit sync for transactions (iOS 15+)
+     * Force sync transactions with the App Store (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/sync-ios
      */
     suspend fun syncIOS(): Boolean
     /**
-     * Validate purchase receipts with the configured providers
+     * Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
+     * See: https://www.openiap.dev/docs/features/validation#verify-purchase
      */
     suspend fun validateReceipt(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify purchases with the configured providers
+     * Verify a purchase against your own backend (returns isValid + raw store metadata).
+     * See: https://www.openiap.dev/docs/features/validation#verify-purchase
      */
     suspend fun verifyPurchase(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify purchases with a specific provider (e.g., IAPKit)
+     * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+     * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
      */
     suspend fun verifyPurchaseWithProvider(options: VerifyPurchaseWithProviderProps): VerifyPurchaseWithProviderResult
 }
@@ -4982,95 +5002,116 @@ public interface MutationResolver {
  */
 public interface QueryResolver {
     /**
-     * Check if external purchase notice sheet can be presented (iOS 17.4+)
-     * Uses ExternalPurchase.canPresent
+     * Check eligibility for the external purchase notice sheet (iOS 17.4+).
+     * Uses ExternalPurchase.canPresent.
+     * See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
      */
     suspend fun canPresentExternalPurchaseNoticeIOS(): Boolean
     /**
-     * Get current StoreKit 2 entitlements (iOS 15+)
+     * Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
      */
     suspend fun currentEntitlementIOS(sku: String): PurchaseIOS?
     /**
-     * Retrieve products or subscriptions from the store
+     * Fetch products or subscriptions from the store.
+     * See: https://www.openiap.dev/docs/apis/fetch-products
      */
     suspend fun fetchProducts(params: ProductRequest): FetchProductsResult
     /**
-     * Get active subscriptions (filters by subscriptionIds when provided)
+     * Get details of all currently active subscriptions (filters by subscriptionIds when provided).
+     * See: https://www.openiap.dev/docs/apis/get-active-subscriptions
      */
     suspend fun getActiveSubscriptions(subscriptionIds: List<String>? = null): List<ActiveSubscription>
     /**
-     * Get the full StoreKit 2 transaction history as PurchaseIOS values.
+     * List every StoreKit transaction (finished + unfinished) for the current user.
      * Requires the SK2ConsumableTransactionHistory Info.plist key in the host app
      * for finished consumables to be included (iOS 18+).
      * Unlike getAvailablePurchases, always returns the iOS-specific PurchaseIOS shape.
+     * See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
      */
     suspend fun getAllTransactionsIOS(): List<PurchaseIOS>
     /**
-     * Fetch the current app transaction (iOS 16+)
+     * Fetch the app transaction (iOS 16+).
+     * See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
      */
     suspend fun getAppTransactionIOS(): AppTransaction?
     /**
-     * Get all available purchases for the current user
+     * List active purchases for the current user.
+     * See: https://www.openiap.dev/docs/apis/get-available-purchases
      */
     suspend fun getAvailablePurchases(options: PurchaseOptions? = null): List<Purchase>
     /**
-     * Get external purchase token for reporting to Apple (iOS 18.1+).
-     * Use this token with Apple's External Purchase Server API to report transactions.
+     * Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+     * Use this token to report transactions made through ExternalPurchaseCustomLink.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+     * See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
      */
     suspend fun getExternalPurchaseCustomLinkTokenIOS(tokenType: ExternalPurchaseCustomLinkTokenTypeIOS): ExternalPurchaseCustomLinkTokenResultIOS
     /**
-     * Retrieve all pending transactions in the StoreKit queue
+     * List unfinished StoreKit transactions in the queue.
+     * See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
      */
     suspend fun getPendingTransactionsIOS(): List<PurchaseIOS>
     /**
-     * Get the currently promoted product (iOS 11+)
+     * Read the App Store-promoted product, if any (iOS 11+).
+     * See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
      */
     suspend fun getPromotedProductIOS(): ProductIOS?
     /**
-     * Get base64-encoded receipt data for validation
+     * Get base64-encoded receipt data (legacy validation).
+     * See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
      */
     suspend fun getReceiptDataIOS(): String?
     /**
-     * Get the current storefront country code
+     * Return the user's storefront country code.
+     * See: https://www.openiap.dev/docs/apis/get-storefront
      */
     suspend fun getStorefront(): String
     /**
-     * Get the current App Store storefront country code
+     * Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
+     * See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
      */
     suspend fun getStorefrontIOS(): String
     /**
-     * Get the transaction JWS (StoreKit 2)
+     * Return the JWS string for a transaction (StoreKit 2).
+     * See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
      */
     suspend fun getTransactionJwsIOS(sku: String): String?
     /**
-     * Check whether the user has active subscriptions
+     * Check whether the user has any active subscription.
+     * See: https://www.openiap.dev/docs/apis/has-active-subscriptions
      */
     suspend fun hasActiveSubscriptions(subscriptionIds: List<String>? = null): Boolean
     /**
-     * Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+     * Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
      * Returns true if the app can use custom external purchase links.
      * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+     * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
      */
     suspend fun isEligibleForExternalPurchaseCustomLinkIOS(): Boolean
     /**
-     * Check introductory offer eligibility for a subscription group
+     * Check intro-offer eligibility for a subscription group.
+     * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
      */
     suspend fun isEligibleForIntroOfferIOS(groupID: String): Boolean
     /**
-     * Verify a StoreKit 2 transaction signature
+     * Check whether a transaction's JWS verification passed (StoreKit 2).
+     * See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
      */
     suspend fun isTransactionVerifiedIOS(sku: String): Boolean
     /**
-     * Get the latest transaction for a product using StoreKit 2
+     * Get the latest verified transaction for a product, using StoreKit 2.
+     * See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
      */
     suspend fun latestTransactionIOS(sku: String): PurchaseIOS?
     /**
-     * Get StoreKit 2 subscription status details (iOS 15+)
+     * Get subscription status objects from StoreKit 2 (iOS 15+).
+     * See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
      */
     suspend fun subscriptionStatusIOS(sku: String): List<SubscriptionStatusIOS>
     /**
-     * Validate a receipt for a specific product
+     * Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
+     * See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
      */
     suspend fun validateReceiptIOS(options: VerifyPurchaseProps): VerifyPurchaseResultIOS
 }

--- a/packages/gql/src/generated/Types.kt
+++ b/packages/gql/src/generated/Types.kt
@@ -4986,7 +4986,11 @@ public interface MutationResolver {
      */
     suspend fun validateReceipt(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify a purchase against your own backend (returns isValid + raw store metadata).
+     * Verify a purchase against your own backend. Returns a platform-specific
+     * variant of VerifyPurchaseResult — VerifyPurchaseResultIOS exposes isValid
+     * + receipt/JWS metadata, VerifyPurchaseResultAndroid carries Play Store
+     * receipt fields (no isValid), and VerifyPurchaseResultHorizon uses success.
+     * Inspect the concrete variant before reading fields.
      * See: https://www.openiap.dev/docs/features/validation#verify-purchase
      */
     suspend fun verifyPurchase(options: VerifyPurchaseProps): VerifyPurchaseResult

--- a/packages/gql/src/generated/Types.kt
+++ b/packages/gql/src/generated/Types.kt
@@ -4991,7 +4991,9 @@ public interface MutationResolver {
      */
     suspend fun verifyPurchase(options: VerifyPurchaseProps): VerifyPurchaseResult
     /**
-     * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+     * Verify via a managed provider without standing up your own server. The
+     * PurchaseVerificationProvider enum currently exposes only IAPKit; platform
+     * availability may differ by implementation.
      * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
      */
     suspend fun verifyPurchaseWithProvider(options: VerifyPurchaseWithProviderProps): VerifyPurchaseWithProviderResult

--- a/packages/gql/src/generated/Types.swift
+++ b/packages/gql/src/generated/Types.swift
@@ -2439,7 +2439,11 @@ public protocol MutationResolver {
     /// Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
     /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
     func validateReceipt(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResult
-    /// Verify a purchase against your own backend (returns isValid + raw store metadata).
+    /// Verify a purchase against your own backend. Returns a platform-specific
+    /// variant of VerifyPurchaseResult — VerifyPurchaseResultIOS exposes isValid
+    /// + receipt/JWS metadata, VerifyPurchaseResultAndroid carries Play Store
+    /// receipt fields (no isValid), and VerifyPurchaseResultHorizon uses success.
+    /// Inspect the concrete variant before reading fields.
     /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
     func verifyPurchase(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResult
     /// Verify via a managed provider without standing up your own server. The

--- a/packages/gql/src/generated/Types.swift
+++ b/packages/gql/src/generated/Types.swift
@@ -2442,7 +2442,9 @@ public protocol MutationResolver {
     /// Verify a purchase against your own backend (returns isValid + raw store metadata).
     /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
     func verifyPurchase(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResult
-    /// Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+    /// Verify via a managed provider without standing up your own server. The
+    /// PurchaseVerificationProvider enum currently exposes only IAPKit; platform
+    /// availability may differ by implementation.
     /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
     func verifyPurchaseWithProvider(_ options: VerifyPurchaseWithProviderProps) async throws -> VerifyPurchaseWithProviderResult
 }

--- a/packages/gql/src/generated/Types.swift
+++ b/packages/gql/src/generated/Types.swift
@@ -2334,150 +2334,191 @@ public enum VerifyPurchaseResult: Codable {
 
 /// GraphQL root mutation operations.
 public protocol MutationResolver {
-    /// Acknowledge a non-consumable purchase or subscription
+    /// Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+    /// See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
     func acknowledgePurchaseAndroid(_ purchaseToken: String) async throws -> Bool
-    /// Initiate a refund request for a product (iOS 15+)
+    /// Present the refund request sheet (iOS 15+). See also Features → Refund.
+    /// See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
     func beginRefundRequestIOS(_ sku: String) async throws -> String?
-    /// Check if alternative billing is available for this user/device
-    /// Step 1 of alternative billing flow
+    /// Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
     /// 
-    /// Returns true if available, false otherwise
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Returns true if available, false otherwise.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
     func checkAlternativeBillingAvailabilityAndroid() async throws -> Bool
-    /// Clear pending transactions from the StoreKit payment queue
+    /// Clear pending transactions in the queue (sandbox helper).
+    /// See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
     func clearTransactionIOS() async throws -> Bool
-    /// Consume a purchase token so it can be repurchased
+    /// Consume a consumable purchase so it can be re-bought.
+    /// See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
     func consumePurchaseAndroid(_ purchaseToken: String) async throws -> Bool
-    /// Create external transaction token for Google Play reporting
-    /// Step 3 of alternative billing flow
-    /// Must be called AFTER successful payment in your payment system
-    /// Token must be reported to Google Play backend within 24 hours
+    /// Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
+    /// Must be called AFTER successful payment in your payment system.
+    /// Token must be reported to Google Play backend within 24 hours.
     /// 
-    /// Returns token string, or null if creation failed
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Returns token string, or null if creation failed.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
     func createAlternativeBillingTokenAndroid() async throws -> String?
-    /// Create reporting details for a billing program
-    /// Replaces the deprecated createExternalOfferReportingDetailsAsync API
+    /// Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+    /// Replaces the deprecated createExternalOfferReportingDetailsAsync API.
     /// 
-    /// Available in Google Play Billing Library 8.2.0+
-    /// Returns external transaction token needed for reporting external transactions
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Returns external transaction token needed for reporting external transactions.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
     func createBillingProgramReportingDetailsAndroid(_ program: BillingProgramAndroid) async throws -> BillingProgramReportingDetailsAndroid
-    /// Open the native subscription management surface
+    /// Open the platform's subscription management UI.
+    /// See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
     func deepLinkToSubscriptions(_ options: DeepLinkOptions?) async throws -> Void
-    /// Close the platform billing connection
+    /// Close the store connection and release resources.
+    /// See: https://www.openiap.dev/docs/apis/end-connection
     func endConnection() async throws -> Bool
-    /// Finish a transaction after validating receipts
+    /// Complete a transaction after server-side verification. Required on Android within 3 days.
+    /// See: https://www.openiap.dev/docs/apis/finish-transaction
     func finishTransaction(purchase: PurchaseInput, isConsumable: Bool?) async throws -> Void
-    /// Establish the platform billing connection
+    /// Initialize the store connection. Call before any IAP API.
+    /// See: https://www.openiap.dev/docs/apis/init-connection
     func initConnection(_ config: InitConnectionConfig?) async throws -> Bool
-    /// Check if a billing program is available for the current user
-    /// Replaces the deprecated isExternalOfferAvailableAsync API
+    /// Check whether a billing program (e.g., External Payments) is available for the current user.
+    /// Replaces the deprecated isExternalOfferAvailableAsync API.
     /// 
-    /// Available in Google Play Billing Library 8.2.0+
-    /// Returns availability result with isAvailable flag
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Available in Google Play Billing Library 8.2.0+.
+    /// Returns availability result with isAvailable flag.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
     func isBillingProgramAvailableAndroid(_ program: BillingProgramAndroid) async throws -> BillingProgramAvailabilityResultAndroid
-    /// Launch external link flow for external billing programs
-    /// Replaces the deprecated showExternalOfferInformationDialog API
+    /// Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+    /// Replaces the deprecated showExternalOfferInformationDialog API.
     /// 
-    /// Available in Google Play Billing Library 8.2.0+
-    /// Shows Play Store dialog and optionally launches external URL
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Shows Play Store dialog and optionally launches external URL.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
     func launchExternalLinkAndroid(_ params: LaunchExternalLinkParamsAndroid) async throws -> Bool
-    /// Present the App Store code redemption sheet
+    /// Show the App Store offer code redemption sheet.
+    /// See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
     func presentCodeRedemptionSheetIOS() async throws -> Bool
-    /// Present external purchase custom link with StoreKit UI
+    /// Present an external purchase link, StoreKit External (iOS 16+).
+    /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
     func presentExternalPurchaseLinkIOS(_ url: String) async throws -> ExternalPurchaseLinkResultIOS
-    /// Present external purchase notice sheet (iOS 17.4+).
-    /// Uses ExternalPurchase.presentNoticeSheet() which returns a token when user continues.
+    /// Present the external purchase notice sheet (iOS 17.4+).
+    /// Uses ExternalPurchase.presentNoticeSheet() which returns a token when the user continues.
     /// Reference: https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()
+    /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
     func presentExternalPurchaseNoticeSheetIOS() async throws -> ExternalPurchaseNoticeResultIOS
-    /// Initiate a purchase flow; rely on events for final state
+    /// Initiate a purchase or subscription flow; rely on events for final state.
+    /// See: https://www.openiap.dev/docs/apis/request-purchase
     func requestPurchase(_ params: RequestPurchaseProps) async throws -> RequestPurchaseResult?
-    /// Purchase the promoted product surfaced by the App Store.
+    /// Buy the currently promoted product.
     /// 
     /// @deprecated Use promotedProductListenerIOS to receive the productId,
     /// then call requestPurchase with that SKU instead. In StoreKit 2,
     /// promoted products can be purchased directly via the standard purchase flow.
+    /// See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
     func requestPurchaseOnPromotedProductIOS() async throws -> Bool
-    /// Restore completed purchases across platforms
+    /// Restore non-consumable and active subscription purchases.
+    /// See: https://www.openiap.dev/docs/apis/restore-purchases
     func restorePurchases() async throws -> Void
-    /// Show alternative billing information dialog to user
-    /// Step 2 of alternative billing flow
-    /// Must be called BEFORE processing payment in your payment system
+    /// Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
+    /// Must be called BEFORE processing payment in your payment system.
     /// 
-    /// Returns true if user accepted, false if user canceled
-    /// Throws OpenIapError.NotPrepared if billing client not ready
+    /// Returns true if user accepted, false if user canceled.
+    /// Throws OpenIapError.NotPrepared if billing client not ready.
+    /// See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
     func showAlternativeBillingDialogAndroid() async throws -> Bool
-    /// Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-    /// Displays the system disclosure notice sheet for custom external purchase links.
+    /// Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
     /// Call this after a deliberate customer interaction before linking out to external purchases.
     /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+    /// See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
     func showExternalPurchaseCustomLinkNoticeIOS(_ noticeType: ExternalPurchaseCustomLinkNoticeTypeIOS) async throws -> ExternalPurchaseCustomLinkNoticeResultIOS
-    /// Open subscription management UI and return changed purchases (iOS 15+)
+    /// Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
+    /// See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
     func showManageSubscriptionsIOS() async throws -> [PurchaseIOS]
-    /// Force a StoreKit sync for transactions (iOS 15+)
+    /// Force sync transactions with the App Store (iOS 15+).
+    /// See: https://www.openiap.dev/docs/apis/ios/sync-ios
     func syncIOS() async throws -> Bool
-    /// Validate purchase receipts with the configured providers
+    /// Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
+    /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
     func validateReceipt(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResult
-    /// Verify purchases with the configured providers
+    /// Verify a purchase against your own backend (returns isValid + raw store metadata).
+    /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
     func verifyPurchase(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResult
-    /// Verify purchases with a specific provider (e.g., IAPKit)
+    /// Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+    /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
     func verifyPurchaseWithProvider(_ options: VerifyPurchaseWithProviderProps) async throws -> VerifyPurchaseWithProviderResult
 }
 
 /// GraphQL root query operations.
 public protocol QueryResolver {
-    /// Check if external purchase notice sheet can be presented (iOS 17.4+)
-    /// Uses ExternalPurchase.canPresent
+    /// Check eligibility for the external purchase notice sheet (iOS 17.4+).
+    /// Uses ExternalPurchase.canPresent.
+    /// See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
     func canPresentExternalPurchaseNoticeIOS() async throws -> Bool
-    /// Get current StoreKit 2 entitlements (iOS 15+)
+    /// Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
+    /// See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
     func currentEntitlementIOS(_ sku: String) async throws -> PurchaseIOS?
-    /// Retrieve products or subscriptions from the store
+    /// Fetch products or subscriptions from the store.
+    /// See: https://www.openiap.dev/docs/apis/fetch-products
     func fetchProducts(_ params: ProductRequest) async throws -> FetchProductsResult
-    /// Get active subscriptions (filters by subscriptionIds when provided)
+    /// Get details of all currently active subscriptions (filters by subscriptionIds when provided).
+    /// See: https://www.openiap.dev/docs/apis/get-active-subscriptions
     func getActiveSubscriptions(_ subscriptionIds: [String]?) async throws -> [ActiveSubscription]
-    /// Get the full StoreKit 2 transaction history as PurchaseIOS values.
+    /// List every StoreKit transaction (finished + unfinished) for the current user.
     /// Requires the SK2ConsumableTransactionHistory Info.plist key in the host app
     /// for finished consumables to be included (iOS 18+).
     /// Unlike getAvailablePurchases, always returns the iOS-specific PurchaseIOS shape.
+    /// See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
     func getAllTransactionsIOS() async throws -> [PurchaseIOS]
-    /// Fetch the current app transaction (iOS 16+)
+    /// Fetch the app transaction (iOS 16+).
+    /// See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
     func getAppTransactionIOS() async throws -> AppTransaction?
-    /// Get all available purchases for the current user
+    /// List active purchases for the current user.
+    /// See: https://www.openiap.dev/docs/apis/get-available-purchases
     func getAvailablePurchases(_ options: PurchaseOptions?) async throws -> [Purchase]
-    /// Get external purchase token for reporting to Apple (iOS 18.1+).
-    /// Use this token with Apple's External Purchase Server API to report transactions.
+    /// Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+    /// Use this token to report transactions made through ExternalPurchaseCustomLink.
     /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+    /// See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
     func getExternalPurchaseCustomLinkTokenIOS(_ tokenType: ExternalPurchaseCustomLinkTokenTypeIOS) async throws -> ExternalPurchaseCustomLinkTokenResultIOS
-    /// Retrieve all pending transactions in the StoreKit queue
+    /// List unfinished StoreKit transactions in the queue.
+    /// See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
     func getPendingTransactionsIOS() async throws -> [PurchaseIOS]
-    /// Get the currently promoted product (iOS 11+)
+    /// Read the App Store-promoted product, if any (iOS 11+).
+    /// See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
     func getPromotedProductIOS() async throws -> ProductIOS?
-    /// Get base64-encoded receipt data for validation
+    /// Get base64-encoded receipt data (legacy validation).
+    /// See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
     func getReceiptDataIOS() async throws -> String?
-    /// Get the current storefront country code
+    /// Return the user's storefront country code.
+    /// See: https://www.openiap.dev/docs/apis/get-storefront
     func getStorefront() async throws -> String
-    /// Get the current App Store storefront country code
+    /// Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
+    /// See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
     func getStorefrontIOS() async throws -> String
-    /// Get the transaction JWS (StoreKit 2)
+    /// Return the JWS string for a transaction (StoreKit 2).
+    /// See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
     func getTransactionJwsIOS(_ sku: String) async throws -> String?
-    /// Check whether the user has active subscriptions
+    /// Check whether the user has any active subscription.
+    /// See: https://www.openiap.dev/docs/apis/has-active-subscriptions
     func hasActiveSubscriptions(_ subscriptionIds: [String]?) async throws -> Bool
-    /// Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+    /// Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
     /// Returns true if the app can use custom external purchase links.
     /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+    /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
     func isEligibleForExternalPurchaseCustomLinkIOS() async throws -> Bool
-    /// Check introductory offer eligibility for a subscription group
+    /// Check intro-offer eligibility for a subscription group.
+    /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
     func isEligibleForIntroOfferIOS(_ groupID: String) async throws -> Bool
-    /// Verify a StoreKit 2 transaction signature
+    /// Check whether a transaction's JWS verification passed (StoreKit 2).
+    /// See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
     func isTransactionVerifiedIOS(_ sku: String) async throws -> Bool
-    /// Get the latest transaction for a product using StoreKit 2
+    /// Get the latest verified transaction for a product, using StoreKit 2.
+    /// See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
     func latestTransactionIOS(_ sku: String) async throws -> PurchaseIOS?
-    /// Get StoreKit 2 subscription status details (iOS 15+)
+    /// Get subscription status objects from StoreKit 2 (iOS 15+).
+    /// See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
     func subscriptionStatusIOS(_ sku: String) async throws -> [SubscriptionStatusIOS]
-    /// Validate a receipt for a specific product
+    /// Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
+    /// See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
     func validateReceiptIOS(_ options: VerifyPurchaseProps) async throws -> VerifyPurchaseResultIOS
 }
 

--- a/packages/gql/src/generated/types.dart
+++ b/packages/gql/src/generated/types.dart
@@ -4846,118 +4846,138 @@ sealed class VerifyPurchaseResult {
 
 /// GraphQL root mutation operations.
 abstract class MutationResolver {
-  /// Acknowledge a non-consumable purchase or subscription
+  /// Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+  /// See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
   Future<bool> acknowledgePurchaseAndroid(String purchaseToken);
-  /// Initiate a refund request for a product (iOS 15+)
+  /// Present the refund request sheet (iOS 15+). See also Features → Refund.
+  /// See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
   Future<String?> beginRefundRequestIOS(String sku);
-  /// Check if alternative billing is available for this user/device
-  /// Step 1 of alternative billing flow
+  /// Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
   /// 
-  /// Returns true if available, false otherwise
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Returns true if available, false otherwise.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
   Future<bool> checkAlternativeBillingAvailabilityAndroid();
-  /// Clear pending transactions from the StoreKit payment queue
+  /// Clear pending transactions in the queue (sandbox helper).
+  /// See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
   Future<bool> clearTransactionIOS();
-  /// Consume a purchase token so it can be repurchased
+  /// Consume a consumable purchase so it can be re-bought.
+  /// See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
   Future<bool> consumePurchaseAndroid(String purchaseToken);
-  /// Create external transaction token for Google Play reporting
-  /// Step 3 of alternative billing flow
-  /// Must be called AFTER successful payment in your payment system
-  /// Token must be reported to Google Play backend within 24 hours
+  /// Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
+  /// Must be called AFTER successful payment in your payment system.
+  /// Token must be reported to Google Play backend within 24 hours.
   /// 
-  /// Returns token string, or null if creation failed
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Returns token string, or null if creation failed.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
   Future<String?> createAlternativeBillingTokenAndroid();
-  /// Create reporting details for a billing program
-  /// Replaces the deprecated createExternalOfferReportingDetailsAsync API
+  /// Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+  /// Replaces the deprecated createExternalOfferReportingDetailsAsync API.
   /// 
-  /// Available in Google Play Billing Library 8.2.0+
-  /// Returns external transaction token needed for reporting external transactions
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Returns external transaction token needed for reporting external transactions.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
   Future<BillingProgramReportingDetailsAndroid> createBillingProgramReportingDetailsAndroid(BillingProgramAndroid program);
-  /// Open the native subscription management surface
+  /// Open the platform's subscription management UI.
+  /// See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
   Future<void> deepLinkToSubscriptions({
     String? packageNameAndroid,
     String? skuAndroid,
   });
-  /// Close the platform billing connection
+  /// Close the store connection and release resources.
+  /// See: https://www.openiap.dev/docs/apis/end-connection
   Future<bool> endConnection();
-  /// Finish a transaction after validating receipts
+  /// Complete a transaction after server-side verification. Required on Android within 3 days.
+  /// See: https://www.openiap.dev/docs/apis/finish-transaction
   Future<void> finishTransaction({
     required PurchaseInput purchase,
     bool? isConsumable,
   });
-  /// Establish the platform billing connection
+  /// Initialize the store connection. Call before any IAP API.
+  /// See: https://www.openiap.dev/docs/apis/init-connection
   Future<bool> initConnection({
     AlternativeBillingModeAndroid? alternativeBillingModeAndroid,
     BillingProgramAndroid? enableBillingProgramAndroid,
   });
-  /// Check if a billing program is available for the current user
-  /// Replaces the deprecated isExternalOfferAvailableAsync API
+  /// Check whether a billing program (e.g., External Payments) is available for the current user.
+  /// Replaces the deprecated isExternalOfferAvailableAsync API.
   /// 
-  /// Available in Google Play Billing Library 8.2.0+
-  /// Returns availability result with isAvailable flag
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Available in Google Play Billing Library 8.2.0+.
+  /// Returns availability result with isAvailable flag.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
   Future<BillingProgramAvailabilityResultAndroid> isBillingProgramAvailableAndroid(BillingProgramAndroid program);
-  /// Launch external link flow for external billing programs
-  /// Replaces the deprecated showExternalOfferInformationDialog API
+  /// Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+  /// Replaces the deprecated showExternalOfferInformationDialog API.
   /// 
-  /// Available in Google Play Billing Library 8.2.0+
-  /// Shows Play Store dialog and optionally launches external URL
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Shows Play Store dialog and optionally launches external URL.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
   Future<bool> launchExternalLinkAndroid({
     required BillingProgramAndroid billingProgram,
     required ExternalLinkLaunchModeAndroid launchMode,
     required ExternalLinkTypeAndroid linkType,
     required String linkUri,
   });
-  /// Present the App Store code redemption sheet
+  /// Show the App Store offer code redemption sheet.
+  /// See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
   Future<bool> presentCodeRedemptionSheetIOS();
-  /// Present external purchase custom link with StoreKit UI
+  /// Present an external purchase link, StoreKit External (iOS 16+).
+  /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
   Future<ExternalPurchaseLinkResultIOS> presentExternalPurchaseLinkIOS(String url);
-  /// Present external purchase notice sheet (iOS 17.4+).
-  /// Uses ExternalPurchase.presentNoticeSheet() which returns a token when user continues.
+  /// Present the external purchase notice sheet (iOS 17.4+).
+  /// Uses ExternalPurchase.presentNoticeSheet() which returns a token when the user continues.
   /// Reference: https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()
+  /// See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
   Future<ExternalPurchaseNoticeResultIOS> presentExternalPurchaseNoticeSheetIOS();
-  /// Initiate a purchase flow; rely on events for final state
+  /// Initiate a purchase or subscription flow; rely on events for final state.
+  /// See: https://www.openiap.dev/docs/apis/request-purchase
   Future<RequestPurchaseResult?> requestPurchase(RequestPurchaseProps params);
-  /// Purchase the promoted product surfaced by the App Store.
+  /// Buy the currently promoted product.
   /// 
   /// @deprecated Use promotedProductListenerIOS to receive the productId,
   /// then call requestPurchase with that SKU instead. In StoreKit 2,
   /// promoted products can be purchased directly via the standard purchase flow.
+  /// See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
   Future<bool> requestPurchaseOnPromotedProductIOS();
-  /// Restore completed purchases across platforms
+  /// Restore non-consumable and active subscription purchases.
+  /// See: https://www.openiap.dev/docs/apis/restore-purchases
   Future<void> restorePurchases();
-  /// Show alternative billing information dialog to user
-  /// Step 2 of alternative billing flow
-  /// Must be called BEFORE processing payment in your payment system
+  /// Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
+  /// Must be called BEFORE processing payment in your payment system.
   /// 
-  /// Returns true if user accepted, false if user canceled
-  /// Throws OpenIapError.NotPrepared if billing client not ready
+  /// Returns true if user accepted, false if user canceled.
+  /// Throws OpenIapError.NotPrepared if billing client not ready.
+  /// See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
   Future<bool> showAlternativeBillingDialogAndroid();
-  /// Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-  /// Displays the system disclosure notice sheet for custom external purchase links.
+  /// Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
   /// Call this after a deliberate customer interaction before linking out to external purchases.
   /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+  /// See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
   Future<ExternalPurchaseCustomLinkNoticeResultIOS> showExternalPurchaseCustomLinkNoticeIOS(ExternalPurchaseCustomLinkNoticeTypeIOS noticeType);
-  /// Open subscription management UI and return changed purchases (iOS 15+)
+  /// Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
+  /// See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
   Future<List<PurchaseIOS>> showManageSubscriptionsIOS();
-  /// Force a StoreKit sync for transactions (iOS 15+)
+  /// Force sync transactions with the App Store (iOS 15+).
+  /// See: https://www.openiap.dev/docs/apis/ios/sync-ios
   Future<bool> syncIOS();
-  /// Validate purchase receipts with the configured providers
+  /// Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
+  /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
   Future<VerifyPurchaseResult> validateReceipt({
     VerifyPurchaseAppleOptions? apple,
     VerifyPurchaseGoogleOptions? google,
     VerifyPurchaseHorizonOptions? horizon,
   });
-  /// Verify purchases with the configured providers
+  /// Verify a purchase against your own backend (returns isValid + raw store metadata).
+  /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
   Future<VerifyPurchaseResult> verifyPurchase({
     VerifyPurchaseAppleOptions? apple,
     VerifyPurchaseGoogleOptions? google,
     VerifyPurchaseHorizonOptions? horizon,
   });
-  /// Verify purchases with a specific provider (e.g., IAPKit)
+  /// Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+  /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
   Future<VerifyPurchaseWithProviderResult> verifyPurchaseWithProvider({
     RequestVerifyPurchaseWithIapkitProps? iapkit,
     required PurchaseVerificationProvider provider,
@@ -4966,62 +4986,83 @@ abstract class MutationResolver {
 
 /// GraphQL root query operations.
 abstract class QueryResolver {
-  /// Check if external purchase notice sheet can be presented (iOS 17.4+)
-  /// Uses ExternalPurchase.canPresent
+  /// Check eligibility for the external purchase notice sheet (iOS 17.4+).
+  /// Uses ExternalPurchase.canPresent.
+  /// See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
   Future<bool> canPresentExternalPurchaseNoticeIOS();
-  /// Get current StoreKit 2 entitlements (iOS 15+)
+  /// Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
+  /// See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
   Future<PurchaseIOS?> currentEntitlementIOS(String sku);
-  /// Retrieve products or subscriptions from the store
+  /// Fetch products or subscriptions from the store.
+  /// See: https://www.openiap.dev/docs/apis/fetch-products
   Future<FetchProductsResult> fetchProducts({
     required List<String> skus,
     ProductQueryType? type,
   });
-  /// Get active subscriptions (filters by subscriptionIds when provided)
+  /// Get details of all currently active subscriptions (filters by subscriptionIds when provided).
+  /// See: https://www.openiap.dev/docs/apis/get-active-subscriptions
   Future<List<ActiveSubscription>> getActiveSubscriptions([List<String>? subscriptionIds]);
-  /// Get the full StoreKit 2 transaction history as PurchaseIOS values.
+  /// List every StoreKit transaction (finished + unfinished) for the current user.
   /// Requires the SK2ConsumableTransactionHistory Info.plist key in the host app
   /// for finished consumables to be included (iOS 18+).
   /// Unlike getAvailablePurchases, always returns the iOS-specific PurchaseIOS shape.
+  /// See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
   Future<List<PurchaseIOS>> getAllTransactionsIOS();
-  /// Fetch the current app transaction (iOS 16+)
+  /// Fetch the app transaction (iOS 16+).
+  /// See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
   Future<AppTransaction?> getAppTransactionIOS();
-  /// Get all available purchases for the current user
+  /// List active purchases for the current user.
+  /// See: https://www.openiap.dev/docs/apis/get-available-purchases
   Future<List<Purchase>> getAvailablePurchases({
     bool? alsoPublishToEventListenerIOS,
     bool? includeSuspendedAndroid,
     bool? onlyIncludeActiveItemsIOS,
   });
-  /// Get external purchase token for reporting to Apple (iOS 18.1+).
-  /// Use this token with Apple's External Purchase Server API to report transactions.
+  /// Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+  /// Use this token to report transactions made through ExternalPurchaseCustomLink.
   /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+  /// See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
   Future<ExternalPurchaseCustomLinkTokenResultIOS> getExternalPurchaseCustomLinkTokenIOS(ExternalPurchaseCustomLinkTokenTypeIOS tokenType);
-  /// Retrieve all pending transactions in the StoreKit queue
+  /// List unfinished StoreKit transactions in the queue.
+  /// See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
   Future<List<PurchaseIOS>> getPendingTransactionsIOS();
-  /// Get the currently promoted product (iOS 11+)
+  /// Read the App Store-promoted product, if any (iOS 11+).
+  /// See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
   Future<ProductIOS?> getPromotedProductIOS();
-  /// Get base64-encoded receipt data for validation
+  /// Get base64-encoded receipt data (legacy validation).
+  /// See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
   Future<String?> getReceiptDataIOS();
-  /// Get the current storefront country code
+  /// Return the user's storefront country code.
+  /// See: https://www.openiap.dev/docs/apis/get-storefront
   Future<String> getStorefront();
-  /// Get the current App Store storefront country code
+  /// Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
+  /// See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
   Future<String> getStorefrontIOS();
-  /// Get the transaction JWS (StoreKit 2)
+  /// Return the JWS string for a transaction (StoreKit 2).
+  /// See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
   Future<String?> getTransactionJwsIOS(String sku);
-  /// Check whether the user has active subscriptions
+  /// Check whether the user has any active subscription.
+  /// See: https://www.openiap.dev/docs/apis/has-active-subscriptions
   Future<bool> hasActiveSubscriptions([List<String>? subscriptionIds]);
-  /// Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+  /// Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
   /// Returns true if the app can use custom external purchase links.
   /// Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+  /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
   Future<bool> isEligibleForExternalPurchaseCustomLinkIOS();
-  /// Check introductory offer eligibility for a subscription group
+  /// Check intro-offer eligibility for a subscription group.
+  /// See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
   Future<bool> isEligibleForIntroOfferIOS(String groupID);
-  /// Verify a StoreKit 2 transaction signature
+  /// Check whether a transaction's JWS verification passed (StoreKit 2).
+  /// See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
   Future<bool> isTransactionVerifiedIOS(String sku);
-  /// Get the latest transaction for a product using StoreKit 2
+  /// Get the latest verified transaction for a product, using StoreKit 2.
+  /// See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
   Future<PurchaseIOS?> latestTransactionIOS(String sku);
-  /// Get StoreKit 2 subscription status details (iOS 15+)
+  /// Get subscription status objects from StoreKit 2 (iOS 15+).
+  /// See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
   Future<List<SubscriptionStatusIOS>> subscriptionStatusIOS(String sku);
-  /// Validate a receipt for a specific product
+  /// Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
+  /// See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
   Future<VerifyPurchaseResultIOS> validateReceiptIOS({
     VerifyPurchaseAppleOptions? apple,
     VerifyPurchaseGoogleOptions? google,

--- a/packages/gql/src/generated/types.dart
+++ b/packages/gql/src/generated/types.dart
@@ -4969,7 +4969,11 @@ abstract class MutationResolver {
     VerifyPurchaseGoogleOptions? google,
     VerifyPurchaseHorizonOptions? horizon,
   });
-  /// Verify a purchase against your own backend (returns isValid + raw store metadata).
+  /// Verify a purchase against your own backend. Returns a platform-specific
+  /// variant of VerifyPurchaseResult — VerifyPurchaseResultIOS exposes isValid
+  /// + receipt/JWS metadata, VerifyPurchaseResultAndroid carries Play Store
+  /// receipt fields (no isValid), and VerifyPurchaseResultHorizon uses success.
+  /// Inspect the concrete variant before reading fields.
   /// See: https://www.openiap.dev/docs/features/validation#verify-purchase
   Future<VerifyPurchaseResult> verifyPurchase({
     VerifyPurchaseAppleOptions? apple,

--- a/packages/gql/src/generated/types.dart
+++ b/packages/gql/src/generated/types.dart
@@ -4976,7 +4976,9 @@ abstract class MutationResolver {
     VerifyPurchaseGoogleOptions? google,
     VerifyPurchaseHorizonOptions? horizon,
   });
-  /// Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+  /// Verify via a managed provider without standing up your own server. The
+  /// PurchaseVerificationProvider enum currently exposes only IAPKit; platform
+  /// availability may differ by implementation.
   /// See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
   Future<VerifyPurchaseWithProviderResult> verifyPurchaseWithProvider({
     RequestVerifyPurchaseWithIapkitProps? iapkit,

--- a/packages/gql/src/generated/types.gd
+++ b/packages/gql/src/generated/types.gd
@@ -4800,7 +4800,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Retrieve products or subscriptions from the store
+	## Fetch products or subscriptions from the store.
 	class fetchProductsField:
 		const name = "fetchProducts"
 		const snake_name = "fetch_products"
@@ -4820,7 +4820,7 @@ class Query:
 		const return_type = "FetchProductsResult"
 		const is_array = false
 
-	## Get all available purchases for the current user
+	## List active purchases for the current user.
 	class getAvailablePurchasesField:
 		const name = "getAvailablePurchases"
 		const snake_name = "get_available_purchases"
@@ -4840,7 +4840,7 @@ class Query:
 		const return_type = "Purchase"
 		const is_array = true
 
-	## Get active subscriptions (filters by subscriptionIds when provided)
+	## Get details of all currently active subscriptions (filters by subscriptionIds when provided).
 	class getActiveSubscriptionsField:
 		const name = "getActiveSubscriptions"
 		const snake_name = "get_active_subscriptions"
@@ -4860,7 +4860,7 @@ class Query:
 		const return_type = "ActiveSubscription"
 		const is_array = true
 
-	## Check whether the user has active subscriptions
+	## Check whether the user has any active subscription.
 	class hasActiveSubscriptionsField:
 		const name = "hasActiveSubscriptions"
 		const snake_name = "has_active_subscriptions"
@@ -4880,7 +4880,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Get the current storefront country code
+	## Return the user's storefront country code.
 	class getStorefrontField:
 		const name = "getStorefront"
 		const snake_name = "get_storefront"
@@ -4889,7 +4889,7 @@ class Query:
 		const return_type = "String"
 		const is_array = false
 
-	## Get the current App Store storefront country code
+	## Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
 	class getStorefrontIOSField:
 		const name = "getStorefrontIOS"
 		const snake_name = "get_storefront_ios"
@@ -4898,7 +4898,7 @@ class Query:
 		const return_type = "String"
 		const is_array = false
 
-	## Get the currently promoted product (iOS 11+)
+	## Read the App Store-promoted product, if any (iOS 11+).
 	class getPromotedProductIOSField:
 		const name = "getPromotedProductIOS"
 		const snake_name = "get_promoted_product_ios"
@@ -4907,7 +4907,7 @@ class Query:
 		const return_type = "ProductIOS"
 		const is_array = false
 
-	## Check if external purchase notice sheet can be presented (iOS 17.4+)
+	## Check eligibility for the external purchase notice sheet (iOS 17.4+).
 	class canPresentExternalPurchaseNoticeIOSField:
 		const name = "canPresentExternalPurchaseNoticeIOS"
 		const snake_name = "can_present_external_purchase_notice_ios"
@@ -4916,7 +4916,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+	## Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
 	class isEligibleForExternalPurchaseCustomLinkIOSField:
 		const name = "isEligibleForExternalPurchaseCustomLinkIOS"
 		const snake_name = "is_eligible_for_external_purchase_custom_link_ios"
@@ -4925,7 +4925,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Get external purchase token for reporting to Apple (iOS 18.1+).
+	## Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
 	class getExternalPurchaseCustomLinkTokenIOSField:
 		const name = "getExternalPurchaseCustomLinkTokenIOS"
 		const snake_name = "get_external_purchase_custom_link_token_ios"
@@ -4953,7 +4953,7 @@ class Query:
 		const return_type = "ExternalPurchaseCustomLinkTokenResultIOS"
 		const is_array = false
 
-	## Retrieve all pending transactions in the StoreKit queue
+	## List unfinished StoreKit transactions in the queue.
 	class getPendingTransactionsIOSField:
 		const name = "getPendingTransactionsIOS"
 		const snake_name = "get_pending_transactions_ios"
@@ -4962,7 +4962,7 @@ class Query:
 		const return_type = "PurchaseIOS"
 		const is_array = true
 
-	## Check introductory offer eligibility for a subscription group
+	## Check intro-offer eligibility for a subscription group.
 	class isEligibleForIntroOfferIOSField:
 		const name = "isEligibleForIntroOfferIOS"
 		const snake_name = "is_eligible_for_intro_offer_ios"
@@ -4982,7 +4982,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Get StoreKit 2 subscription status details (iOS 15+)
+	## Get subscription status objects from StoreKit 2 (iOS 15+).
 	class subscriptionStatusIOSField:
 		const name = "subscriptionStatusIOS"
 		const snake_name = "subscription_status_ios"
@@ -5002,7 +5002,7 @@ class Query:
 		const return_type = "SubscriptionStatusIOS"
 		const is_array = true
 
-	## Get current StoreKit 2 entitlements (iOS 15+)
+	## Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
 	class currentEntitlementIOSField:
 		const name = "currentEntitlementIOS"
 		const snake_name = "current_entitlement_ios"
@@ -5022,7 +5022,7 @@ class Query:
 		const return_type = "PurchaseIOS"
 		const is_array = false
 
-	## Get the latest transaction for a product using StoreKit 2
+	## Get the latest verified transaction for a product, using StoreKit 2.
 	class latestTransactionIOSField:
 		const name = "latestTransactionIOS"
 		const snake_name = "latest_transaction_ios"
@@ -5042,7 +5042,7 @@ class Query:
 		const return_type = "PurchaseIOS"
 		const is_array = false
 
-	## Verify a StoreKit 2 transaction signature
+	## Check whether a transaction's JWS verification passed (StoreKit 2).
 	class isTransactionVerifiedIOSField:
 		const name = "isTransactionVerifiedIOS"
 		const snake_name = "is_transaction_verified_ios"
@@ -5062,7 +5062,7 @@ class Query:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Get the transaction JWS (StoreKit 2)
+	## Return the JWS string for a transaction (StoreKit 2).
 	class getTransactionJwsIOSField:
 		const name = "getTransactionJwsIOS"
 		const snake_name = "get_transaction_jws_ios"
@@ -5082,7 +5082,7 @@ class Query:
 		const return_type = "String"
 		const is_array = false
 
-	## Get base64-encoded receipt data for validation
+	## Get base64-encoded receipt data (legacy validation).
 	class getReceiptDataIOSField:
 		const name = "getReceiptDataIOS"
 		const snake_name = "get_receipt_data_ios"
@@ -5091,7 +5091,7 @@ class Query:
 		const return_type = "String"
 		const is_array = false
 
-	## Fetch the current app transaction (iOS 16+)
+	## Fetch the app transaction (iOS 16+).
 	class getAppTransactionIOSField:
 		const name = "getAppTransactionIOS"
 		const snake_name = "get_app_transaction_ios"
@@ -5100,7 +5100,7 @@ class Query:
 		const return_type = "AppTransaction"
 		const is_array = false
 
-	## Get the full StoreKit 2 transaction history as PurchaseIOS values.
+	## List every StoreKit transaction (finished + unfinished) for the current user.
 	class getAllTransactionsIOSField:
 		const name = "getAllTransactionsIOS"
 		const snake_name = "get_all_transactions_ios"
@@ -5109,7 +5109,7 @@ class Query:
 		const return_type = "PurchaseIOS"
 		const is_array = true
 
-	## Validate a receipt for a specific product
+	## Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
 	class validateReceiptIOSField:
 		const name = "validateReceiptIOS"
 		const snake_name = "validate_receipt_ios"
@@ -5143,7 +5143,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Establish the platform billing connection
+	## Initialize the store connection. Call before any IAP API.
 	class initConnectionField:
 		const name = "initConnection"
 		const snake_name = "init_connection"
@@ -5163,7 +5163,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Close the platform billing connection
+	## Close the store connection and release resources.
 	class endConnectionField:
 		const name = "endConnection"
 		const snake_name = "end_connection"
@@ -5172,7 +5172,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Initiate a purchase flow; rely on events for final state
+	## Initiate a purchase or subscription flow; rely on events for final state.
 	class requestPurchaseField:
 		const name = "requestPurchase"
 		const snake_name = "request_purchase"
@@ -5192,7 +5192,7 @@ class Mutation:
 		const return_type = "RequestPurchaseResult"
 		const is_array = false
 
-	## Finish a transaction after validating receipts
+	## Complete a transaction after server-side verification. Required on Android within 3 days.
 	class finishTransactionField:
 		const name = "finishTransaction"
 		const snake_name = "finish_transaction"
@@ -5216,7 +5216,7 @@ class Mutation:
 		const return_type = "VoidResult"
 		const is_array = false
 
-	## Restore completed purchases across platforms
+	## Restore non-consumable and active subscription purchases.
 	class restorePurchasesField:
 		const name = "restorePurchases"
 		const snake_name = "restore_purchases"
@@ -5225,7 +5225,7 @@ class Mutation:
 		const return_type = "VoidResult"
 		const is_array = false
 
-	## Open the native subscription management surface
+	## Open the platform's subscription management UI.
 	class deepLinkToSubscriptionsField:
 		const name = "deepLinkToSubscriptions"
 		const snake_name = "deep_link_to_subscriptions"
@@ -5245,7 +5245,7 @@ class Mutation:
 		const return_type = "VoidResult"
 		const is_array = false
 
-	## Validate purchase receipts with the configured providers
+	## Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
 	class validateReceiptField:
 		const name = "validateReceipt"
 		const snake_name = "validate_receipt"
@@ -5265,7 +5265,7 @@ class Mutation:
 		const return_type = "VerifyPurchaseResult"
 		const is_array = false
 
-	## Verify purchases with the configured providers
+	## Verify a purchase against your own backend (returns isValid + raw store metadata).
 	class verifyPurchaseField:
 		const name = "verifyPurchase"
 		const snake_name = "verify_purchase"
@@ -5285,7 +5285,7 @@ class Mutation:
 		const return_type = "VerifyPurchaseResult"
 		const is_array = false
 
-	## Verify purchases with a specific provider (e.g., IAPKit)
+	## Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
 	class verifyPurchaseWithProviderField:
 		const name = "verifyPurchaseWithProvider"
 		const snake_name = "verify_purchase_with_provider"
@@ -5305,7 +5305,7 @@ class Mutation:
 		const return_type = "VerifyPurchaseWithProviderResult"
 		const is_array = false
 
-	## Clear pending transactions from the StoreKit payment queue
+	## Clear pending transactions in the queue (sandbox helper).
 	class clearTransactionIOSField:
 		const name = "clearTransactionIOS"
 		const snake_name = "clear_transaction_ios"
@@ -5314,7 +5314,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Purchase the promoted product surfaced by the App Store.
+	## Buy the currently promoted product.
 	class requestPurchaseOnPromotedProductIOSField:
 		const name = "requestPurchaseOnPromotedProductIOS"
 		const snake_name = "request_purchase_on_promoted_product_ios"
@@ -5323,7 +5323,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Open subscription management UI and return changed purchases (iOS 15+)
+	## Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
 	class showManageSubscriptionsIOSField:
 		const name = "showManageSubscriptionsIOS"
 		const snake_name = "show_manage_subscriptions_ios"
@@ -5332,7 +5332,7 @@ class Mutation:
 		const return_type = "PurchaseIOS"
 		const is_array = true
 
-	## Initiate a refund request for a product (iOS 15+)
+	## Present the refund request sheet (iOS 15+). See also Features → Refund.
 	class beginRefundRequestIOSField:
 		const name = "beginRefundRequestIOS"
 		const snake_name = "begin_refund_request_ios"
@@ -5352,7 +5352,7 @@ class Mutation:
 		const return_type = "String"
 		const is_array = false
 
-	## Force a StoreKit sync for transactions (iOS 15+)
+	## Force sync transactions with the App Store (iOS 15+).
 	class syncIOSField:
 		const name = "syncIOS"
 		const snake_name = "sync_ios"
@@ -5361,7 +5361,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Present the App Store code redemption sheet
+	## Show the App Store offer code redemption sheet.
 	class presentCodeRedemptionSheetIOSField:
 		const name = "presentCodeRedemptionSheetIOS"
 		const snake_name = "present_code_redemption_sheet_ios"
@@ -5370,7 +5370,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Present external purchase notice sheet (iOS 17.4+).
+	## Present the external purchase notice sheet (iOS 17.4+).
 	class presentExternalPurchaseNoticeSheetIOSField:
 		const name = "presentExternalPurchaseNoticeSheetIOS"
 		const snake_name = "present_external_purchase_notice_sheet_ios"
@@ -5379,7 +5379,7 @@ class Mutation:
 		const return_type = "ExternalPurchaseNoticeResultIOS"
 		const is_array = false
 
-	## Present external purchase custom link with StoreKit UI
+	## Present an external purchase link, StoreKit External (iOS 16+).
 	class presentExternalPurchaseLinkIOSField:
 		const name = "presentExternalPurchaseLinkIOS"
 		const snake_name = "present_external_purchase_link_ios"
@@ -5399,7 +5399,7 @@ class Mutation:
 		const return_type = "ExternalPurchaseLinkResultIOS"
 		const is_array = false
 
-	## Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
+	## Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
 	class showExternalPurchaseCustomLinkNoticeIOSField:
 		const name = "showExternalPurchaseCustomLinkNoticeIOS"
 		const snake_name = "show_external_purchase_custom_link_notice_ios"
@@ -5427,7 +5427,7 @@ class Mutation:
 		const return_type = "ExternalPurchaseCustomLinkNoticeResultIOS"
 		const is_array = false
 
-	## Acknowledge a non-consumable purchase or subscription
+	## Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
 	class acknowledgePurchaseAndroidField:
 		const name = "acknowledgePurchaseAndroid"
 		const snake_name = "acknowledge_purchase_android"
@@ -5447,7 +5447,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Consume a purchase token so it can be repurchased
+	## Consume a consumable purchase so it can be re-bought.
 	class consumePurchaseAndroidField:
 		const name = "consumePurchaseAndroid"
 		const snake_name = "consume_purchase_android"
@@ -5467,7 +5467,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Check if alternative billing is available for this user/device
+	## Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
 	class checkAlternativeBillingAvailabilityAndroidField:
 		const name = "checkAlternativeBillingAvailabilityAndroid"
 		const snake_name = "check_alternative_billing_availability_android"
@@ -5476,7 +5476,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Show alternative billing information dialog to user
+	## Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
 	class showAlternativeBillingDialogAndroidField:
 		const name = "showAlternativeBillingDialogAndroid"
 		const snake_name = "show_alternative_billing_dialog_android"
@@ -5485,7 +5485,7 @@ class Mutation:
 		const return_type = "Boolean"
 		const is_array = false
 
-	## Create external transaction token for Google Play reporting
+	## Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
 	class createAlternativeBillingTokenAndroidField:
 		const name = "createAlternativeBillingTokenAndroid"
 		const snake_name = "create_alternative_billing_token_android"
@@ -5494,7 +5494,7 @@ class Mutation:
 		const return_type = "String"
 		const is_array = false
 
-	## Check if a billing program is available for the current user
+	## Check whether a billing program (e.g., External Payments) is available for the current user.
 	class isBillingProgramAvailableAndroidField:
 		const name = "isBillingProgramAvailableAndroid"
 		const snake_name = "is_billing_program_available_android"
@@ -5521,7 +5521,7 @@ class Mutation:
 		const return_type = "BillingProgramAvailabilityResultAndroid"
 		const is_array = false
 
-	## Create reporting details for a billing program
+	## Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
 	class createBillingProgramReportingDetailsAndroidField:
 		const name = "createBillingProgramReportingDetailsAndroid"
 		const snake_name = "create_billing_program_reporting_details_android"
@@ -5548,7 +5548,7 @@ class Mutation:
 		const return_type = "BillingProgramReportingDetailsAndroid"
 		const is_array = false
 
-	## Launch external link flow for external billing programs
+	## Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
 	class launchExternalLinkAndroidField:
 		const name = "launchExternalLinkAndroid"
 		const snake_name = "launch_external_link_android"
@@ -5576,7 +5576,7 @@ class Mutation:
 
 # Query API helpers
 
-## Retrieve products or subscriptions from the store
+## Fetch products or subscriptions from the store.
 static func fetch_products_args(params: ProductRequest) -> Dictionary:
 	var args = {}
 	if params != null:
@@ -5586,7 +5586,7 @@ static func fetch_products_args(params: ProductRequest) -> Dictionary:
 			args["params"] = params
 	return args
 
-## Get all available purchases for the current user
+## List active purchases for the current user.
 static func get_available_purchases_args(options: PurchaseOptions) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5596,97 +5596,97 @@ static func get_available_purchases_args(options: PurchaseOptions) -> Dictionary
 			args["options"] = options
 	return args
 
-## Get active subscriptions (filters by subscriptionIds when provided)
+## Get details of all currently active subscriptions (filters by subscriptionIds when provided).
 static func get_active_subscriptions_args(subscription_ids: Array[String]) -> Dictionary:
 	var args = {}
 	args["subscriptionIds"] = subscription_ids
 	return args
 
-## Check whether the user has active subscriptions
+## Check whether the user has any active subscription.
 static func has_active_subscriptions_args(subscription_ids: Array[String]) -> Dictionary:
 	var args = {}
 	args["subscriptionIds"] = subscription_ids
 	return args
 
-## Get the current storefront country code
+## Return the user's storefront country code.
 static func get_storefront_args() -> Dictionary:
 	return {}
 
-## Get the current App Store storefront country code
+## Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
 static func get_storefront_ios_args() -> Dictionary:
 	return {}
 
-## Get the currently promoted product (iOS 11+)
+## Read the App Store-promoted product, if any (iOS 11+).
 static func get_promoted_product_ios_args() -> Dictionary:
 	return {}
 
-## Check if external purchase notice sheet can be presented (iOS 17.4+)
+## Check eligibility for the external purchase notice sheet (iOS 17.4+).
 static func can_present_external_purchase_notice_ios_args() -> Dictionary:
 	return {}
 
-## Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+## Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
 static func is_eligible_for_external_purchase_custom_link_ios_args() -> Dictionary:
 	return {}
 
-## Get external purchase token for reporting to Apple (iOS 18.1+).
+## Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
 static func get_external_purchase_custom_link_token_ios_args(token_type: ExternalPurchaseCustomLinkTokenTypeIOS) -> Dictionary:
 	var args = {}
 	args["tokenType"] = token_type
 	return args
 
-## Retrieve all pending transactions in the StoreKit queue
+## List unfinished StoreKit transactions in the queue.
 static func get_pending_transactions_ios_args() -> Dictionary:
 	return {}
 
-## Check introductory offer eligibility for a subscription group
+## Check intro-offer eligibility for a subscription group.
 static func is_eligible_for_intro_offer_ios_args(group_id: String) -> Dictionary:
 	var args = {}
 	args["groupID"] = group_id
 	return args
 
-## Get StoreKit 2 subscription status details (iOS 15+)
+## Get subscription status objects from StoreKit 2 (iOS 15+).
 static func subscription_status_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Get current StoreKit 2 entitlements (iOS 15+)
+## Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
 static func current_entitlement_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Get the latest transaction for a product using StoreKit 2
+## Get the latest verified transaction for a product, using StoreKit 2.
 static func latest_transaction_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Verify a StoreKit 2 transaction signature
+## Check whether a transaction's JWS verification passed (StoreKit 2).
 static func is_transaction_verified_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Get the transaction JWS (StoreKit 2)
+## Return the JWS string for a transaction (StoreKit 2).
 static func get_transaction_jws_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Get base64-encoded receipt data for validation
+## Get base64-encoded receipt data (legacy validation).
 static func get_receipt_data_ios_args() -> Dictionary:
 	return {}
 
-## Fetch the current app transaction (iOS 16+)
+## Fetch the app transaction (iOS 16+).
 static func get_app_transaction_ios_args() -> Dictionary:
 	return {}
 
-## Get the full StoreKit 2 transaction history as PurchaseIOS values.
+## List every StoreKit transaction (finished + unfinished) for the current user.
 static func get_all_transactions_ios_args() -> Dictionary:
 	return {}
 
-## Validate a receipt for a specific product
+## Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
 static func validate_receipt_ios_args(options: VerifyPurchaseProps) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5698,7 +5698,7 @@ static func validate_receipt_ios_args(options: VerifyPurchaseProps) -> Dictionar
 
 # Mutation API helpers
 
-## Establish the platform billing connection
+## Initialize the store connection. Call before any IAP API.
 static func init_connection_args(config: InitConnectionConfig) -> Dictionary:
 	var args = {}
 	if config != null:
@@ -5708,11 +5708,11 @@ static func init_connection_args(config: InitConnectionConfig) -> Dictionary:
 			args["config"] = config
 	return args
 
-## Close the platform billing connection
+## Close the store connection and release resources.
 static func end_connection_args() -> Dictionary:
 	return {}
 
-## Initiate a purchase flow; rely on events for final state
+## Initiate a purchase or subscription flow; rely on events for final state.
 static func request_purchase_args(params: RequestPurchaseProps) -> Dictionary:
 	var args = {}
 	if params != null:
@@ -5722,7 +5722,7 @@ static func request_purchase_args(params: RequestPurchaseProps) -> Dictionary:
 			args["params"] = params
 	return args
 
-## Finish a transaction after validating receipts
+## Complete a transaction after server-side verification. Required on Android within 3 days.
 static func finish_transaction_args(purchase: PurchaseInput, is_consumable: bool) -> Dictionary:
 	var args = {}
 	if purchase != null:
@@ -5733,11 +5733,11 @@ static func finish_transaction_args(purchase: PurchaseInput, is_consumable: bool
 	args["isConsumable"] = is_consumable
 	return args
 
-## Restore completed purchases across platforms
+## Restore non-consumable and active subscription purchases.
 static func restore_purchases_args() -> Dictionary:
 	return {}
 
-## Open the native subscription management surface
+## Open the platform's subscription management UI.
 static func deep_link_to_subscriptions_args(options: DeepLinkOptions) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5747,7 +5747,7 @@ static func deep_link_to_subscriptions_args(options: DeepLinkOptions) -> Diction
 			args["options"] = options
 	return args
 
-## Validate purchase receipts with the configured providers
+## Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
 static func validate_receipt_args(options: VerifyPurchaseProps) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5757,7 +5757,7 @@ static func validate_receipt_args(options: VerifyPurchaseProps) -> Dictionary:
 			args["options"] = options
 	return args
 
-## Verify purchases with the configured providers
+## Verify a purchase against your own backend (returns isValid + raw store metadata).
 static func verify_purchase_args(options: VerifyPurchaseProps) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5767,7 +5767,7 @@ static func verify_purchase_args(options: VerifyPurchaseProps) -> Dictionary:
 			args["options"] = options
 	return args
 
-## Verify purchases with a specific provider (e.g., IAPKit)
+## Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
 static func verify_purchase_with_provider_args(options: VerifyPurchaseWithProviderProps) -> Dictionary:
 	var args = {}
 	if options != null:
@@ -5777,85 +5777,85 @@ static func verify_purchase_with_provider_args(options: VerifyPurchaseWithProvid
 			args["options"] = options
 	return args
 
-## Clear pending transactions from the StoreKit payment queue
+## Clear pending transactions in the queue (sandbox helper).
 static func clear_transaction_ios_args() -> Dictionary:
 	return {}
 
-## Purchase the promoted product surfaced by the App Store.
+## Buy the currently promoted product.
 static func request_purchase_on_promoted_product_ios_args() -> Dictionary:
 	return {}
 
-## Open subscription management UI and return changed purchases (iOS 15+)
+## Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
 static func show_manage_subscriptions_ios_args() -> Dictionary:
 	return {}
 
-## Initiate a refund request for a product (iOS 15+)
+## Present the refund request sheet (iOS 15+). See also Features → Refund.
 static func begin_refund_request_ios_args(sku: String) -> Dictionary:
 	var args = {}
 	args["sku"] = sku
 	return args
 
-## Force a StoreKit sync for transactions (iOS 15+)
+## Force sync transactions with the App Store (iOS 15+).
 static func sync_ios_args() -> Dictionary:
 	return {}
 
-## Present the App Store code redemption sheet
+## Show the App Store offer code redemption sheet.
 static func present_code_redemption_sheet_ios_args() -> Dictionary:
 	return {}
 
-## Present external purchase notice sheet (iOS 17.4+).
+## Present the external purchase notice sheet (iOS 17.4+).
 static func present_external_purchase_notice_sheet_ios_args() -> Dictionary:
 	return {}
 
-## Present external purchase custom link with StoreKit UI
+## Present an external purchase link, StoreKit External (iOS 16+).
 static func present_external_purchase_link_ios_args(url: String) -> Dictionary:
 	var args = {}
 	args["url"] = url
 	return args
 
-## Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
+## Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
 static func show_external_purchase_custom_link_notice_ios_args(notice_type: ExternalPurchaseCustomLinkNoticeTypeIOS) -> Dictionary:
 	var args = {}
 	args["noticeType"] = notice_type
 	return args
 
-## Acknowledge a non-consumable purchase or subscription
+## Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
 static func acknowledge_purchase_android_args(purchase_token: String) -> Dictionary:
 	var args = {}
 	args["purchaseToken"] = purchase_token
 	return args
 
-## Consume a purchase token so it can be repurchased
+## Consume a consumable purchase so it can be re-bought.
 static func consume_purchase_android_args(purchase_token: String) -> Dictionary:
 	var args = {}
 	args["purchaseToken"] = purchase_token
 	return args
 
-## Check if alternative billing is available for this user/device
+## Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
 static func check_alternative_billing_availability_android_args() -> Dictionary:
 	return {}
 
-## Show alternative billing information dialog to user
+## Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
 static func show_alternative_billing_dialog_android_args() -> Dictionary:
 	return {}
 
-## Create external transaction token for Google Play reporting
+## Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
 static func create_alternative_billing_token_android_args() -> Dictionary:
 	return {}
 
-## Check if a billing program is available for the current user
+## Check whether a billing program (e.g., External Payments) is available for the current user.
 static func is_billing_program_available_android_args(program: BillingProgramAndroid) -> Dictionary:
 	var args = {}
 	args["program"] = program
 	return args
 
-## Create reporting details for a billing program
+## Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
 static func create_billing_program_reporting_details_android_args(program: BillingProgramAndroid) -> Dictionary:
 	var args = {}
 	args["program"] = program
 	return args
 
-## Launch external link flow for external billing programs
+## Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
 static func launch_external_link_android_args(params: LaunchExternalLinkParamsAndroid) -> Dictionary:
 	var args = {}
 	if params != null:

--- a/packages/gql/src/generated/types.gd
+++ b/packages/gql/src/generated/types.gd
@@ -5285,7 +5285,7 @@ class Mutation:
 		const return_type = "VerifyPurchaseResult"
 		const is_array = false
 
-	## Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+	## Verify via a managed provider without standing up your own server. The
 	class verifyPurchaseWithProviderField:
 		const name = "verifyPurchaseWithProvider"
 		const snake_name = "verify_purchase_with_provider"
@@ -5767,7 +5767,7 @@ static func verify_purchase_args(options: VerifyPurchaseProps) -> Dictionary:
 			args["options"] = options
 	return args
 
-## Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+## Verify via a managed provider without standing up your own server. The
 static func verify_purchase_with_provider_args(options: VerifyPurchaseWithProviderProps) -> Dictionary:
 	var args = {}
 	if options != null:

--- a/packages/gql/src/generated/types.gd
+++ b/packages/gql/src/generated/types.gd
@@ -5265,7 +5265,7 @@ class Mutation:
 		const return_type = "VerifyPurchaseResult"
 		const is_array = false
 
-	## Verify a purchase against your own backend (returns isValid + raw store metadata).
+	## Verify a purchase against your own backend. Returns a platform-specific
 	class verifyPurchaseField:
 		const name = "verifyPurchase"
 		const snake_name = "verify_purchase"
@@ -5757,7 +5757,7 @@ static func validate_receipt_args(options: VerifyPurchaseProps) -> Dictionary:
 			args["options"] = options
 	return args
 
-## Verify a purchase against your own backend (returns isValid + raw store metadata).
+## Verify a purchase against your own backend. Returns a platform-specific
 static func verify_purchase_args(options: VerifyPurchaseProps) -> Dictionary:
 	var args = {}
 	if options != null:

--- a/packages/gql/src/generated/types.ts
+++ b/packages/gql/src/generated/types.ts
@@ -746,7 +746,9 @@ export interface Mutation {
    */
   verifyPurchase: Promise<VerifyPurchaseResult>;
   /**
-   * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+   * Verify via a managed provider without standing up your own server. The
+   * PurchaseVerificationProvider enum currently exposes only IAPKit; platform
+   * availability may differ by implementation.
    * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
    */
   verifyPurchaseWithProvider: Promise<VerifyPurchaseWithProviderResult>;

--- a/packages/gql/src/generated/types.ts
+++ b/packages/gql/src/generated/types.ts
@@ -741,7 +741,11 @@ export interface Mutation {
    */
   validateReceipt: Promise<VerifyPurchaseResult>;
   /**
-   * Verify a purchase against your own backend (returns isValid + raw store metadata).
+   * Verify a purchase against your own backend. Returns a platform-specific
+   * variant of VerifyPurchaseResult — VerifyPurchaseResultIOS exposes isValid
+   * + receipt/JWS metadata, VerifyPurchaseResultAndroid carries Play Store
+   * receipt fields (no isValid), and VerifyPurchaseResultHorizon uses success.
+   * Inspect the concrete variant before reading fields.
    * See: https://www.openiap.dev/docs/features/validation#verify-purchase
    */
   verifyPurchase: Promise<VerifyPurchaseResult>;

--- a/packages/gql/src/generated/types.ts
+++ b/packages/gql/src/generated/types.ts
@@ -585,118 +585,170 @@ export interface LimitedQuantityInfoAndroid {
 }
 
 export interface Mutation {
-  /** Acknowledge a non-consumable purchase or subscription */
+  /**
+   * Acknowledge a non-consumable purchase. Required within 3 days or Google auto-refunds.
+   * See: https://www.openiap.dev/docs/apis/android/acknowledge-purchase-android
+   */
   acknowledgePurchaseAndroid: Promise<boolean>;
-  /** Initiate a refund request for a product (iOS 15+) */
+  /**
+   * Present the refund request sheet (iOS 15+). See also Features → Refund.
+   * See: https://www.openiap.dev/docs/apis/ios/begin-refund-request-ios
+   */
   beginRefundRequestIOS?: Promise<(string | null)>;
   /**
-   * Check if alternative billing is available for this user/device
-   * Step 1 of alternative billing flow
+   * Check whether alternative billing is available for the user. Step 1 of the alternative billing flow.
    *
-   * Returns true if available, false otherwise
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns true if available, false otherwise.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/check-alternative-billing-availability-android
    */
   checkAlternativeBillingAvailabilityAndroid: Promise<boolean>;
-  /** Clear pending transactions from the StoreKit payment queue */
+  /**
+   * Clear pending transactions in the queue (sandbox helper).
+   * See: https://www.openiap.dev/docs/apis/ios/clear-transaction-ios
+   */
   clearTransactionIOS: Promise<boolean>;
-  /** Consume a purchase token so it can be repurchased */
+  /**
+   * Consume a consumable purchase so it can be re-bought.
+   * See: https://www.openiap.dev/docs/apis/android/consume-purchase-android
+   */
   consumePurchaseAndroid: Promise<boolean>;
   /**
-   * Create external transaction token for Google Play reporting
-   * Step 3 of alternative billing flow
-   * Must be called AFTER successful payment in your payment system
-   * Token must be reported to Google Play backend within 24 hours
+   * Create a reporting token for an alternative billing flow. Step 3 of the alternative billing flow.
+   * Must be called AFTER successful payment in your payment system.
+   * Token must be reported to Google Play backend within 24 hours.
    *
-   * Returns token string, or null if creation failed
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns token string, or null if creation failed.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/create-alternative-billing-token-android
    */
   createAlternativeBillingTokenAndroid?: Promise<(string | null)>;
   /**
-   * Create reporting details for a billing program
-   * Replaces the deprecated createExternalOfferReportingDetailsAsync API
+   * Create the reporting payload Google requires after a Developer-Provided Billing transaction (Play Billing 8.3.0+).
+   * Replaces the deprecated createExternalOfferReportingDetailsAsync API.
    *
-   * Available in Google Play Billing Library 8.2.0+
-   * Returns external transaction token needed for reporting external transactions
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns external transaction token needed for reporting external transactions.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/create-billing-program-reporting-details-android
    */
   createBillingProgramReportingDetailsAndroid: Promise<BillingProgramReportingDetailsAndroid>;
-  /** Open the native subscription management surface */
+  /**
+   * Open the platform's subscription management UI.
+   * See: https://www.openiap.dev/docs/apis/deep-link-to-subscriptions
+   */
   deepLinkToSubscriptions: Promise<void>;
-  /** Close the platform billing connection */
+  /**
+   * Close the store connection and release resources.
+   * See: https://www.openiap.dev/docs/apis/end-connection
+   */
   endConnection: Promise<boolean>;
-  /** Finish a transaction after validating receipts */
+  /**
+   * Complete a transaction after server-side verification. Required on Android within 3 days.
+   * See: https://www.openiap.dev/docs/apis/finish-transaction
+   */
   finishTransaction: Promise<void>;
-  /** Establish the platform billing connection */
+  /**
+   * Initialize the store connection. Call before any IAP API.
+   * See: https://www.openiap.dev/docs/apis/init-connection
+   */
   initConnection: Promise<boolean>;
   /**
-   * Check if a billing program is available for the current user
-   * Replaces the deprecated isExternalOfferAvailableAsync API
+   * Check whether a billing program (e.g., External Payments) is available for the current user.
+   * Replaces the deprecated isExternalOfferAvailableAsync API.
    *
-   * Available in Google Play Billing Library 8.2.0+
-   * Returns availability result with isAvailable flag
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Available in Google Play Billing Library 8.2.0+.
+   * Returns availability result with isAvailable flag.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/is-billing-program-available-android
    */
   isBillingProgramAvailableAndroid: Promise<BillingProgramAvailabilityResultAndroid>;
   /**
-   * Launch external link flow for external billing programs
-   * Replaces the deprecated showExternalOfferInformationDialog API
+   * Launch an external content/offer link from inside the Billing Programs flow (Play Billing 8.2.0+).
+   * Replaces the deprecated showExternalOfferInformationDialog API.
    *
-   * Available in Google Play Billing Library 8.2.0+
-   * Shows Play Store dialog and optionally launches external URL
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Shows Play Store dialog and optionally launches external URL.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/launch-external-link-android
    */
   launchExternalLinkAndroid: Promise<boolean>;
-  /** Present the App Store code redemption sheet */
+  /**
+   * Show the App Store offer code redemption sheet.
+   * See: https://www.openiap.dev/docs/apis/ios/present-code-redemption-sheet-ios
+   */
   presentCodeRedemptionSheetIOS: Promise<boolean>;
-  /** Present external purchase custom link with StoreKit UI */
+  /**
+   * Present an external purchase link, StoreKit External (iOS 16+).
+   * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-link-ios
+   */
   presentExternalPurchaseLinkIOS: Promise<ExternalPurchaseLinkResultIOS>;
   /**
-   * Present external purchase notice sheet (iOS 17.4+).
-   * Uses ExternalPurchase.presentNoticeSheet() which returns a token when user continues.
+   * Present the external purchase notice sheet (iOS 17.4+).
+   * Uses ExternalPurchase.presentNoticeSheet() which returns a token when the user continues.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchase/presentnoticesheet()
+   * See: https://www.openiap.dev/docs/apis/ios/present-external-purchase-notice-sheet-ios
    */
   presentExternalPurchaseNoticeSheetIOS: Promise<ExternalPurchaseNoticeResultIOS>;
-  /** Initiate a purchase flow; rely on events for final state */
+  /**
+   * Initiate a purchase or subscription flow; rely on events for final state.
+   * See: https://www.openiap.dev/docs/apis/request-purchase
+   */
   requestPurchase?: Promise<(Purchase | Purchase[] | null)>;
   /**
-   * Purchase the promoted product surfaced by the App Store.
+   * Buy the currently promoted product.
    *
    * @deprecated Use promotedProductListenerIOS to receive the productId,
    * then call requestPurchase with that SKU instead. In StoreKit 2,
    * promoted products can be purchased directly via the standard purchase flow.
+   * See: https://www.openiap.dev/docs/apis/ios/request-purchase-on-promoted-product-ios
    * @deprecated Use promotedProductListenerIOS + requestPurchase instead
    */
   requestPurchaseOnPromotedProductIOS: Promise<boolean>;
-  /** Restore completed purchases across platforms */
+  /**
+   * Restore non-consumable and active subscription purchases.
+   * See: https://www.openiap.dev/docs/apis/restore-purchases
+   */
   restorePurchases: Promise<void>;
   /**
-   * Show alternative billing information dialog to user
-   * Step 2 of alternative billing flow
-   * Must be called BEFORE processing payment in your payment system
+   * Display Google's alternative billing information dialog. Step 2 of the alternative billing flow.
+   * Must be called BEFORE processing payment in your payment system.
    *
-   * Returns true if user accepted, false if user canceled
-   * Throws OpenIapError.NotPrepared if billing client not ready
+   * Returns true if user accepted, false if user canceled.
+   * Throws OpenIapError.NotPrepared if billing client not ready.
+   * See: https://www.openiap.dev/docs/apis/android/show-alternative-billing-dialog-android
    */
   showAlternativeBillingDialogAndroid: Promise<boolean>;
   /**
-   * Show ExternalPurchaseCustomLink notice sheet (iOS 18.1+).
-   * Displays the system disclosure notice sheet for custom external purchase links.
+   * Present the disclosure sheet required before linking out via ExternalPurchaseCustomLink (iOS 18.1+).
    * Call this after a deliberate customer interaction before linking out to external purchases.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/shownotice(type:)
+   * See: https://www.openiap.dev/docs/apis/ios/show-external-purchase-custom-link-notice-ios
    */
   showExternalPurchaseCustomLinkNoticeIOS: Promise<ExternalPurchaseCustomLinkNoticeResultIOS>;
-  /** Open subscription management UI and return changed purchases (iOS 15+) */
+  /**
+   * Present the manage-subscriptions sheet and return changed purchases (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/show-manage-subscriptions-ios
+   */
   showManageSubscriptionsIOS: Promise<PurchaseIOS[]>;
-  /** Force a StoreKit sync for transactions (iOS 15+) */
+  /**
+   * Force sync transactions with the App Store (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/sync-ios
+   */
   syncIOS: Promise<boolean>;
   /**
-   * Validate purchase receipts with the configured providers
+   * Deprecated. Validate purchase receipts with the configured providers — use verifyPurchase instead.
+   * See: https://www.openiap.dev/docs/features/validation#verify-purchase
    * @deprecated Use verifyPurchase
    */
   validateReceipt: Promise<VerifyPurchaseResult>;
-  /** Verify purchases with the configured providers */
+  /**
+   * Verify a purchase against your own backend (returns isValid + raw store metadata).
+   * See: https://www.openiap.dev/docs/features/validation#verify-purchase
+   */
   verifyPurchase: Promise<VerifyPurchaseResult>;
-  /** Verify purchases with a specific provider (e.g., IAPKit) */
+  /**
+   * Verify via a managed provider (IAPKit, Apple, Google, Horizon) without standing up your own server.
+   * See: https://www.openiap.dev/docs/features/validation#verify-purchase-with-provider
+   */
   verifyPurchaseWithProvider: Promise<VerifyPurchaseWithProviderResult>;
 }
 
@@ -1234,66 +1286,117 @@ export type PurchaseVerificationProvider = 'iapkit';
 
 export interface Query {
   /**
-   * Check if external purchase notice sheet can be presented (iOS 17.4+)
-   * Uses ExternalPurchase.canPresent
+   * Check eligibility for the external purchase notice sheet (iOS 17.4+).
+   * Uses ExternalPurchase.canPresent.
+   * See: https://www.openiap.dev/docs/apis/ios/can-present-external-purchase-notice-ios
    */
   canPresentExternalPurchaseNoticeIOS: Promise<boolean>;
-  /** Get current StoreKit 2 entitlements (iOS 15+) */
+  /**
+   * Get the user's current entitlement for a product, using StoreKit 2 (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/current-entitlement-ios
+   */
   currentEntitlementIOS?: Promise<(PurchaseIOS | null)>;
-  /** Retrieve products or subscriptions from the store */
+  /**
+   * Fetch products or subscriptions from the store.
+   * See: https://www.openiap.dev/docs/apis/fetch-products
+   */
   fetchProducts: Promise<(ProductOrSubscription[] | Product[] | ProductSubscription[] | null)>;
-  /** Get active subscriptions (filters by subscriptionIds when provided) */
+  /**
+   * Get details of all currently active subscriptions (filters by subscriptionIds when provided).
+   * See: https://www.openiap.dev/docs/apis/get-active-subscriptions
+   */
   getActiveSubscriptions: Promise<ActiveSubscription[]>;
   /**
-   * Get the full StoreKit 2 transaction history as PurchaseIOS values.
+   * List every StoreKit transaction (finished + unfinished) for the current user.
    * Requires the SK2ConsumableTransactionHistory Info.plist key in the host app
    * for finished consumables to be included (iOS 18+).
    * Unlike getAvailablePurchases, always returns the iOS-specific PurchaseIOS shape.
+   * See: https://www.openiap.dev/docs/apis/ios/get-all-transactions-ios
    */
   getAllTransactionsIOS: Promise<PurchaseIOS[]>;
-  /** Fetch the current app transaction (iOS 16+) */
+  /**
+   * Fetch the app transaction (iOS 16+).
+   * See: https://www.openiap.dev/docs/apis/ios/get-app-transaction-ios
+   */
   getAppTransactionIOS?: Promise<(AppTransaction | null)>;
-  /** Get all available purchases for the current user */
+  /**
+   * List active purchases for the current user.
+   * See: https://www.openiap.dev/docs/apis/get-available-purchases
+   */
   getAvailablePurchases: Promise<Purchase[]>;
   /**
-   * Get external purchase token for reporting to Apple (iOS 18.1+).
-   * Use this token with Apple's External Purchase Server API to report transactions.
+   * Fetch a token for Apple's External Purchase Server reporting API (iOS 18.1+).
+   * Use this token to report transactions made through ExternalPurchaseCustomLink.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/token(for:)
+   * See: https://www.openiap.dev/docs/apis/ios/get-external-purchase-custom-link-token-ios
    */
   getExternalPurchaseCustomLinkTokenIOS: Promise<ExternalPurchaseCustomLinkTokenResultIOS>;
-  /** Retrieve all pending transactions in the StoreKit queue */
+  /**
+   * List unfinished StoreKit transactions in the queue.
+   * See: https://www.openiap.dev/docs/apis/ios/get-pending-transactions-ios
+   */
   getPendingTransactionsIOS: Promise<PurchaseIOS[]>;
-  /** Get the currently promoted product (iOS 11+) */
+  /**
+   * Read the App Store-promoted product, if any (iOS 11+).
+   * See: https://www.openiap.dev/docs/apis/ios/get-promoted-product-ios
+   */
   getPromotedProductIOS?: Promise<(ProductIOS | null)>;
-  /** Get base64-encoded receipt data for validation */
+  /**
+   * Get base64-encoded receipt data (legacy validation).
+   * See: https://www.openiap.dev/docs/apis/ios/get-receipt-data-ios
+   */
   getReceiptDataIOS?: Promise<(string | null)>;
-  /** Get the current storefront country code */
+  /**
+   * Return the user's storefront country code.
+   * See: https://www.openiap.dev/docs/apis/get-storefront
+   */
   getStorefront: Promise<string>;
   /**
-   * Get the current App Store storefront country code
+   * Deprecated. Get the current App Store storefront country code — use cross-platform getStorefront instead.
+   * See: https://www.openiap.dev/docs/apis/ios/get-storefront-ios
    * @deprecated Use getStorefront
    */
   getStorefrontIOS: Promise<string>;
-  /** Get the transaction JWS (StoreKit 2) */
+  /**
+   * Return the JWS string for a transaction (StoreKit 2).
+   * See: https://www.openiap.dev/docs/apis/ios/get-transaction-jws-ios
+   */
   getTransactionJwsIOS?: Promise<(string | null)>;
-  /** Check whether the user has active subscriptions */
+  /**
+   * Check whether the user has any active subscription.
+   * See: https://www.openiap.dev/docs/apis/has-active-subscriptions
+   */
   hasActiveSubscriptions: Promise<boolean>;
   /**
-   * Check if app is eligible for ExternalPurchaseCustomLink API (iOS 18.1+).
+   * Check eligibility for the custom-link variant of external purchase (iOS 18.1+).
    * Returns true if the app can use custom external purchase links.
    * Reference: https://developer.apple.com/documentation/storekit/externalpurchasecustomlink/iseligible
+   * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-external-purchase-custom-link-ios
    */
   isEligibleForExternalPurchaseCustomLinkIOS: Promise<boolean>;
-  /** Check introductory offer eligibility for a subscription group */
+  /**
+   * Check intro-offer eligibility for a subscription group.
+   * See: https://www.openiap.dev/docs/apis/ios/is-eligible-for-intro-offer-ios
+   */
   isEligibleForIntroOfferIOS: Promise<boolean>;
-  /** Verify a StoreKit 2 transaction signature */
+  /**
+   * Check whether a transaction's JWS verification passed (StoreKit 2).
+   * See: https://www.openiap.dev/docs/apis/ios/is-transaction-verified-ios
+   */
   isTransactionVerifiedIOS: Promise<boolean>;
-  /** Get the latest transaction for a product using StoreKit 2 */
+  /**
+   * Get the latest verified transaction for a product, using StoreKit 2.
+   * See: https://www.openiap.dev/docs/apis/ios/latest-transaction-ios
+   */
   latestTransactionIOS?: Promise<(PurchaseIOS | null)>;
-  /** Get StoreKit 2 subscription status details (iOS 15+) */
+  /**
+   * Get subscription status objects from StoreKit 2 (iOS 15+).
+   * See: https://www.openiap.dev/docs/apis/ios/subscription-status-ios
+   */
   subscriptionStatusIOS: Promise<SubscriptionStatusIOS[]>;
   /**
-   * Validate a receipt for a specific product
+   * Deprecated. Legacy App Store receipt validation — use verifyPurchase instead.
+   * See: https://www.openiap.dev/docs/apis/ios/validate-receipt-ios
    * @deprecated Use verifyPurchase
    */
   validateReceiptIOS: Promise<VerifyPurchaseResultIOS>;

--- a/scripts/audit-docs.ts
+++ b/scripts/audit-docs.ts
@@ -491,4 +491,8 @@ async function main() {
   process.exit(0);
 }
 
-main();
+main().catch((err) => {
+  console.error('audit-docs: fatal error');
+  console.error(err);
+  process.exit(2);
+});

--- a/scripts/audit-docs.ts
+++ b/scripts/audit-docs.ts
@@ -1,0 +1,494 @@
+#!/usr/bin/env bun
+/**
+ * audit-docs.ts — SSOT consistency check for /docs/apis and /docs/types pages.
+ *
+ * What it does
+ *   1. Walks every `packages/docs/src/pages/docs/apis/**\/*.tsx` and
+ *      `packages/docs/src/pages/docs/types/**\/*.tsx` page.
+ *   2. Loads the generated TypeScript types from
+ *      `libraries/expo-iap/src/types.ts` and indexes every `interface`,
+ *      `type` alias, and `enum` / string-literal union shape.
+ *   3. For each doc page, extracts:
+ *        - `<Link to="/docs/...">` targets
+ *        - `<code>fieldName</code>` mentions inside `<table>` rows or
+ *          `<ul className="api-params">` lists
+ *        - Enum-style `<code>'literal'</code>` mentions
+ *        - `@see {@link …}` URLs
+ *      and cross-checks each against the type index.
+ *   4. Reports drift as a punch-list (file:line — what's wrong).
+ *
+ * Exit code 0 = clean, 1 = at least one drift detected.
+ *
+ * Read knowledge/internal/07-docs-consistency.md for the rules this
+ * script enforces.
+ */
+import { readFileSync, statSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { dirname, join, relative, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(import.meta.dir, '..');
+const DOC_ROOTS = [
+  resolve(REPO_ROOT, 'packages/docs/src/pages/docs/apis'),
+  resolve(REPO_ROOT, 'packages/docs/src/pages/docs/types'),
+];
+const DOC_PAGES_DIR = resolve(REPO_ROOT, 'packages/docs/src/pages');
+const TYPES_FILE = resolve(REPO_ROOT, 'libraries/expo-iap/src/types.ts');
+
+type Drift = {
+  file: string;
+  line: number;
+  rule: string;
+  message: string;
+};
+
+async function walkTsxFiles(root: string): Promise<string[]> {
+  const out: string[] = [];
+  async function recurse(dir: string) {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await recurse(full);
+      } else if (entry.isFile() && entry.name.endsWith('.tsx')) {
+        out.push(full);
+      }
+    }
+  }
+  await recurse(root);
+  return out;
+}
+
+/**
+ * Build an index of every interface / type alias / enum-like union
+ * defined in libraries/expo-iap/src/types.ts.
+ *
+ * The index maps:
+ *   typeName: string  →  { fields: Set<string>, literals: Set<string> }
+ *
+ * Fields = property names declared inside `interface X { ... }` or
+ *          `type X = { ... }`. Optional `?` is stripped.
+ * Literals = string-literal members of a union type
+ *            (`type X = 'a' | 'b' | 'c'`).
+ */
+function buildTypeIndex(): Map<
+  string,
+  { fields: Set<string>; literals: Set<string> }
+> {
+  const src = readFileSync(TYPES_FILE, 'utf8');
+  const index = new Map<
+    string,
+    { fields: Set<string>; literals: Set<string> }
+  >();
+
+  // interface NAME { ... } — capture body via brace matching
+  const interfaceRe = /export\s+interface\s+([A-Za-z_]\w*)\s*(?:extends[^{]+)?\{/g;
+  let m: RegExpExecArray | null;
+  while ((m = interfaceRe.exec(src)) !== null) {
+    const name = m[1];
+    const body = extractBraceBlock(src, m.index + m[0].length - 1);
+    if (!body) continue;
+    const fields = extractInterfaceFields(body);
+    index.set(name, {
+      fields,
+      literals: new Set(),
+    });
+  }
+
+  // type NAME = '...' | '...' | ... — string-literal unions
+  const literalUnionRe =
+    /export\s+type\s+([A-Za-z_]\w*)\s*=\s*((?:'[^']*'\s*\|\s*)*'[^']*')\s*;/g;
+  while ((m = literalUnionRe.exec(src)) !== null) {
+    const name = m[1];
+    const literals = new Set<string>();
+    for (const lit of m[2].matchAll(/'([^']*)'/g)) literals.add(lit[1]);
+    index.set(name, {
+      fields: new Set(),
+      literals,
+    });
+  }
+
+  // type NAME = { ... } — object-shape aliases
+  const objectAliasRe = /export\s+type\s+([A-Za-z_]\w*)\s*=\s*\{/g;
+  while ((m = objectAliasRe.exec(src)) !== null) {
+    const name = m[1];
+    if (index.has(name)) continue;
+    const body = extractBraceBlock(src, m.index + m[0].length - 1);
+    if (!body) continue;
+    index.set(name, {
+      fields: extractInterfaceFields(body),
+      literals: new Set(),
+    });
+  }
+
+  return index;
+}
+
+function extractBraceBlock(src: string, openBraceIdx: number): string | null {
+  if (src[openBraceIdx] !== '{') return null;
+  let depth = 1;
+  let i = openBraceIdx + 1;
+  while (i < src.length && depth > 0) {
+    const ch = src[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') depth -= 1;
+    i += 1;
+  }
+  if (depth !== 0) return null;
+  return src.slice(openBraceIdx + 1, i - 1);
+}
+
+function extractInterfaceFields(body: string): Set<string> {
+  const fields = new Set<string>();
+  // Match `name?:` or `name:` at the start of a line (after whitespace
+  // or `;`). Skip lines starting with `//` (comments).
+  for (const line of body.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('*'))
+      continue;
+    const fieldMatch = trimmed.match(/^([a-z_$][\w$]*)\s*\??\s*:/i);
+    if (fieldMatch) fields.add(fieldMatch[1]);
+  }
+  return fields;
+}
+
+/**
+ * Parse a doc page's content for the things we want to audit.
+ *
+ * Field-name claims are scoped strictly to `<ul className="api-params">`
+ * blocks — those are the only place a doc page formally asserts "this
+ * is a real field on the type". Function names, native API references,
+ * and listener names that appear inside ordinary <code>...</code> spans
+ * elsewhere on the page are NOT validated (too many legitimate
+ * non-field mentions to enumerate cleanly).
+ */
+function parseDocPage(filePath: string) {
+  const src = readFileSync(filePath, 'utf8');
+  const lines = src.split('\n');
+
+  const linkTargets: { line: number; href: string }[] = [];
+  const seeUrls: { line: number; url: string }[] = [];
+  const fieldMentions: { line: number; field: string }[] = [];
+
+  // Track whether we're inside an `<ul className="api-params">` block.
+  // The first `<code>token</code>` of each `<li>` inside such a list is
+  // treated as a field-name claim.
+  let inParamsList = false;
+  let liExpectingField = false;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const lineNo = i + 1;
+
+    // <Link to="/docs/...">
+    for (const m of line.matchAll(/<Link\s+to="(\/docs\/[^"]+)"/g)) {
+      linkTargets.push({ line: lineNo, href: m[1] });
+    }
+    // @see {@link https://www.openiap.dev/...}
+    for (const m of line.matchAll(
+      /@see\s*\{@link\s+(https:\/\/www\.openiap\.dev\/[^\s}]+)\}/g
+    )) {
+      seeUrls.push({ line: lineNo, url: m[1] });
+    }
+
+    if (line.includes('className="api-params"')) inParamsList = true;
+    if (inParamsList) {
+      if (line.includes('</ul>')) {
+        inParamsList = false;
+        liExpectingField = false;
+        continue;
+      }
+      if (/<li>/.test(line)) liExpectingField = true;
+      if (liExpectingField) {
+        const m = line.match(/<code>([^<']+?)<\/code>/);
+        if (m) {
+          const token = m[1].trim();
+          // Allow dotted paths (`request.apple.sku`) and array-bracket
+          // notation. Take the LEAF identifier — that's the field on
+          // some intermediate type.
+          const leaf = token.split(/[.[\s]/).pop() ?? token;
+          if (
+            /^[a-z_$][\w$]*$/.test(leaf) &&
+            leaf.length > 1 &&
+            !RESERVED_WORDS.has(leaf)
+          ) {
+            fieldMentions.push({ line: lineNo, field: leaf });
+          }
+          liExpectingField = false;
+        }
+      }
+    }
+  }
+
+  return { linkTargets, seeUrls, fieldMentions };
+}
+
+const RESERVED_WORDS = new Set([
+  'true',
+  'false',
+  'null',
+  'void',
+  'any',
+  'never',
+  'string',
+  'number',
+  'boolean',
+  'object',
+  'undefined',
+  'this',
+  'self',
+  'super',
+  'async',
+  'await',
+  'yield',
+  'try',
+  'catch',
+  'finally',
+  'throw',
+  'return',
+  'if',
+  'else',
+  'for',
+  'while',
+  'do',
+  'switch',
+  'case',
+  'break',
+  'continue',
+  'const',
+  'let',
+  'var',
+  'function',
+  'class',
+  'extends',
+  'implements',
+  'interface',
+  'type',
+  'enum',
+  'public',
+  'private',
+  'protected',
+  'static',
+  'readonly',
+  'abstract',
+  'as',
+  'is',
+  'in',
+  'of',
+  'new',
+  'delete',
+  'typeof',
+  'instanceof',
+  'import',
+  'export',
+  'from',
+  'default',
+  'package',
+]);
+
+/**
+ * Verify a `/docs/<path>` link resolves to a real .tsx page (or its
+ * containing folder's `index.tsx`).
+ */
+function linkResolves(target: string): boolean {
+  const [pathPart] = target.split('#');
+  // strip leading /docs and trailing slash
+  const slug = pathPart.replace(/^\/docs\/?/, '').replace(/\/$/, '');
+  if (!slug) return statSyncSafe(join(DOC_PAGES_DIR, 'docs/index.tsx'));
+  const candidates = [
+    join(DOC_PAGES_DIR, 'docs', `${slug}.tsx`),
+    join(DOC_PAGES_DIR, 'docs', slug, 'index.tsx'),
+  ];
+  return candidates.some(statSyncSafe);
+}
+
+function statSyncSafe(p: string): boolean {
+  try {
+    statSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const typeIndex = buildTypeIndex();
+  const drifts: Drift[] = [];
+
+  // Build the set of every known field name across every type — used as
+  // a lenient fallback for "is this field plausible?" checks. (We don't
+  // know which type a `<code>foo</code>` mention belongs to without
+  // page-level context, so we accept any field that exists somewhere in
+  // types.ts.)
+  const allFields = new Set<string>();
+  for (const v of typeIndex.values()) {
+    for (const f of v.fields) allFields.add(f);
+  }
+
+  // Common framework + JS / Dart / Kotlin words that appear in code
+  // examples without being IAP fields. Excluded from the fallback.
+  const SAFE_WORDS = new Set([
+    'console',
+    'log',
+    'error',
+    'warn',
+    'instance',
+    'shared',
+    'connected',
+    'await',
+    'use',
+    'effect',
+    'callback',
+    'fn',
+    'cb',
+    'i',
+    'j',
+    'k',
+    'p',
+    'a',
+    'b',
+    'c',
+    'x',
+    'y',
+    'value',
+    'name',
+    'message',
+    'code',
+    'reason',
+    'data',
+    'json',
+    'token',
+    'url',
+    'sku',
+    'id',
+    'type',
+    'platform',
+    'native',
+    'success',
+    'result',
+    'error',
+    'props',
+    'options',
+    'params',
+    'config',
+    'request',
+    'args',
+    'purchase',
+    'product',
+    'subscription',
+    'continued',
+    'reconnect',
+    'cancel',
+    'open',
+    'close',
+    'state',
+    'status',
+    'group',
+    'ok',
+    'os',
+    'isIOS',
+    'isAndroid',
+    'productId',
+    'orderId',
+    'transactionId',
+    'purchaseToken',
+    'currency',
+    'price',
+    'count',
+    'index',
+    'size',
+    'length',
+    'env',
+    'process',
+    'self',
+    'this',
+    'super',
+    'continuation',
+    'deferred',
+    'completion',
+    'handler',
+    'listener',
+    'emitter',
+    'subscriber',
+    'unsubscribe',
+    'remove',
+    'add',
+  ]);
+
+  const allDocPages: string[] = [];
+  for (const root of DOC_ROOTS) {
+    allDocPages.push(...(await walkTsxFiles(root)));
+  }
+  allDocPages.sort();
+
+  for (const file of allDocPages) {
+    const { linkTargets, fieldMentions } = parseDocPage(file);
+
+    // R5 — internal /docs links must resolve.
+    for (const { line, href } of linkTargets) {
+      if (!linkResolves(href)) {
+        drifts.push({
+          file,
+          line,
+          rule: 'R5',
+          message: `<Link to="${href}"> does not resolve to an existing /docs page.`,
+        });
+      }
+    }
+
+    // R3 — field mentions should appear somewhere in the generated types.
+    // We're lenient: if the mentioned word is in SAFE_WORDS or in any
+    // type's field set, OK. Otherwise flag.
+    for (const { line, field } of fieldMentions) {
+      if (SAFE_WORDS.has(field)) continue;
+      if (allFields.has(field)) continue;
+      drifts.push({
+        file,
+        line,
+        rule: 'R3',
+        message: `<code>${field}</code> is not a known field on any generated TypeScript type. Did you rename or invent it?`,
+      });
+    }
+  }
+
+  // R5 (broken /docs links) is a hard failure; R3 (field name not in
+  // generated types) is a warning because top-level scalar function
+  // params (e.g. `sku: string`, `program: BillingProgramAndroid`)
+  // legitimately appear in `<ul className="api-params">` lists without
+  // being a field of any type — the audit can't tell them apart from
+  // genuine drift without knowing each function's signature.
+  const hardFailures = drifts.filter((d) => d.rule !== 'R3');
+  const warnings = drifts.filter((d) => d.rule === 'R3');
+
+  if (hardFailures.length === 0 && warnings.length === 0) {
+    console.log('audit-docs: clean — 0 drift detected');
+    process.exit(0);
+  }
+
+  if (warnings.length > 0) {
+    console.log(`audit-docs: ${warnings.length} warning(s)\n`);
+    for (const d of warnings) {
+      const rel = relative(REPO_ROOT, d.file);
+      console.log(`  [${d.rule}] ${rel}:${d.line}\n    ${d.message}`);
+    }
+    console.log('');
+  }
+
+  if (hardFailures.length > 0) {
+    console.log(`audit-docs: ${hardFailures.length} drift(s) detected\n`);
+    for (const d of hardFailures) {
+      const rel = relative(REPO_ROOT, d.file);
+      console.log(`  [${d.rule}] ${rel}:${d.line}\n    ${d.message}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('audit-docs: no hard failures (warnings above are advisory)');
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add doc comments on every public OpenIAP API across all wrapper SDKs (apple, google, react-native-iap, expo-iap, flutter, kmp, godot) linking to www.openiap.dev/docs/apis/<symbol>; full @param/@returns/@throws/@example for the 5 core funcs (initConnection, fetchProducts, requestPurchase, finishTransaction, getAvailablePurchases). Preserves original Apple StoreKit / @platform / @example content.
- GraphQL schema descriptions get canonical URLs, propagated to every generated Types file via codegen.
- Docs site (~70 API + Type pages) get a one-paragraph iOS/Android behaviour blurb with Apple/Google reference links.
- Mobile/tablet UI fixes: CodeBlock badge attached as tab-bar (no overlap with scrolling code), sidebar drawer below sticky nav (no z-index collision with hamburger), sidebar margin-left clamped so the centering offset doesn't shove it right at 768–1400px.

## Test plan
- [x] `swift build` — packages/apple
- [x] `./gradlew :openiap:compilePlayDebugKotlin` — packages/google
- [x] `./gradlew :library:compileKotlinMetadata` — kmp-iap
- [x] `bun run lint:tsc` — expo-iap
- [x] `yarn typecheck` — react-native-iap (pre-existing example-expo errors unrelated)
- [x] `dart analyze lib` — flutter_inapp_purchase
- [x] `bun run build` — packages/docs (vite + tsc)
- [ ] Visual QA: mobile sidebar opens, drawer items clickable, code block badge stays inside the tab bar at narrow widths
- [ ] Visual QA: tablet 768–1300px viewport — sidebar stays at left edge, content fills the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Massive cross-SDK docs refresh: clearer API semantics, platform-specific behavior notes, event-driven purchase flow guidance (listener-delivered outcomes), timing/acknowledgement rules, deprecation guidance (prefer verifyPurchase), expanded examples, and many OpenIAP/Apple/Google reference links.
* **Style**
  * Docs UI improvements: revamped code-block header/tabs and sidebar/responsive layout for better navigation.
* **Bug Fixes**
  * Adjusted fetchProducts default behavior: omitting type now defaults to in-app products.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->