### PR TITLE
fix(kit): drop redundant packages/kit/node_modules COPY breaking deploy

### DIFF
--- a/packages/kit/Dockerfile
+++ b/packages/kit/Dockerfile
@@ -16,14 +16,12 @@ COPY packages/gql/package.json ./packages/gql/
 COPY packages/apple/package.json ./packages/apple/
 COPY packages/google/package.json ./packages/google/
 COPY packages/docs/package.json ./packages/docs/
-RUN bun install --frozen-lockfile --filter @hyodotdev/openiap-kit && \
-    mkdir -p /app/packages/kit/node_modules
+RUN bun install --frozen-lockfile --filter @hyodotdev/openiap-kit
 
 # --- Build the unified app (Vite SPA + compiled Bun server) --------------
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/packages/kit/node_modules ./packages/kit/node_modules
 COPY package.json bun.lock ./
 COPY packages/kit ./packages/kit
 WORKDIR /app/packages/kit

--- a/packages/kit/Dockerfile
+++ b/packages/kit/Dockerfile
@@ -16,7 +16,8 @@ COPY packages/gql/package.json ./packages/gql/
 COPY packages/apple/package.json ./packages/apple/
 COPY packages/google/package.json ./packages/google/
 COPY packages/docs/package.json ./packages/docs/
-RUN bun install --frozen-lockfile --filter @hyodotdev/openiap-kit
+RUN bun install --frozen-lockfile --filter @hyodotdev/openiap-kit && \
+    mkdir -p /app/packages/kit/node_modules
 
 # --- Build the unified app (Vite SPA + compiled Bun server) --------------
 FROM base AS builder


### PR DESCRIPTION
## Summary
- Production deploys for kit have been failing on every \`main\` push since [PR #109](https://github.com/hyodotdev/openiap/pull/109) bumped the kit Dockerfile from \`oven/bun:1.3.0-slim\` → \`1.3.13-slim\`. PR-level CI didn't catch it because the \`Deploy openiap-kit to Fly.io\` job only runs on push-to-main; PRs only run \`verify\`.
- Bun 1.3.13's \`bun install --frozen-lockfile --filter @hyodotdev/openiap-kit\` hoists every workspace dep to \`/app/node_modules\` and never creates \`/app/packages/kit/node_modules\`. The next stage's \`COPY --from=deps /app/packages/kit/node_modules ./packages/kit/node_modules\` then fails with \`failed to calculate checksum ... not found\`.
- Fix: drop that COPY entirely. The per-package \`node_modules\` was always redundant — Bun hoists every workspace dep to \`/app/node_modules\` and the kit build (running from \`/app/packages/kit\`) resolves them via the parent walk-up. Bun 1.3.13 simply made the redundancy actively broken.

Failed run: https://github.com/hyodotdev/openiap/actions/runs/25108419490

## Test plan
- [x] Local pre-commit gate (lint + 225 tests + smoke probes) passed on bceecc4.
- [ ] PR \`verify\` job stays green.
- [ ] After merge: \`Deploy openiap-kit to Fly.io\` succeeds on the next main push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)