### PR TITLE
hotfix(kit): bundle React with antd to fix vendor chunk cycle crashing kit.openiap.dev

### DIFF
--- a/packages/kit/vite.config.ts
+++ b/packages/kit/vite.config.ts
@@ -69,8 +69,8 @@ export default defineConfig({
     chunkSizeWarningLimit: 1200,
     rollupOptions: {
       output: {
-        manualChunks(id) {
-          if (!id.includes("node_modules")) return;
+        manualChunks(id: string): string | undefined {
+          if (!id.includes("node_modules")) return undefined;
           // Group React core, react-dom, react-router, antd, and
           // antd-adjacent rc-component libs into ONE vendor chunk.
           // Splitting React from its consumers (antd, react-router,
@@ -84,6 +84,7 @@ export default defineConfig({
           ) {
             return "vendor-react";
           }
+          return undefined;
         },
       },
     },

--- a/packages/kit/vite.config.ts
+++ b/packages/kit/vite.config.ts
@@ -70,11 +70,19 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks(id) {
-          if (id.includes("node_modules")) {
-            if (id.includes("react-dom")) return "vendor-react-dom";
-            if (id.includes("react-router")) return "vendor-react-router";
-            if (id.includes("lucide-react")) return "vendor-lucide";
-            if (id.includes("antd")) return "vendor-antd";
+          if (!id.includes("node_modules")) return;
+          // Group React core, react-dom, react-router, antd, and
+          // antd-adjacent rc-component libs into ONE vendor chunk.
+          // Splitting React from its consumers (antd, react-router,
+          // lucide-react) creates cross-chunk cycles that crash with
+          // `Cannot set properties of undefined (setting 'Activity')`
+          // when antd initializes before React's chunk finishes loading.
+          if (
+            /[\\/](react|react-dom|react-router(?:-dom)?|antd|@ant-design|@rc-component|rc-[^/\\]+|lucide-react)[\\/]/.test(
+              id,
+            )
+          ) {
+            return "vendor-react";
           }
         },
       },

--- a/packages/kit/vite.config.ts
+++ b/packages/kit/vite.config.ts
@@ -78,7 +78,7 @@ export default defineConfig({
           // `Cannot set properties of undefined (setting 'Activity')`
           // when antd initializes before React's chunk finishes loading.
           if (
-            /[\\/](react|react-dom|react-router(?:-dom)?|antd|@ant-design|@rc-component|rc-[^/\\]+|lucide-react)[\\/]/.test(
+            /[\\/](react|react-dom|react-is|react-router(?:-dom)?|scheduler|use-sync-external-store|antd|@ant-design|@rc-component|rc-[^/\\]+|lucide-react|@preact[\\/]signals-(?:react|core))[\\/]/.test(
               id,
             )
           ) {


### PR DESCRIPTION
## Summary
kit.openiap.dev is currently down with a blank page and console error \`Uncaught TypeError: Cannot set properties of undefined (setting 'Activity')\` from \`vendor-antd\`.

**Root cause**: \`vite.config.ts\` \`manualChunks\` splits antd into \`vendor-antd\` while React core stays in the main \`index\` chunk. That creates a cross-chunk cycle (antd imports React from index, index imports antd), and ESM resolution can run antd's module initializer before React is bound. antd then tries \`React.Activity = ...\` and crashes — \`React\` is undefined.

The bug exists on every kit deploy back to v41 (rollback didn't help because the broken config has been there since before PR #108). It only became visible now because PR #119 was the first successful monorepo deploy (all main pushes between v41 and v42 failed at the docker COPY step).

**Fix**: group every React-consuming library — \`react\`, \`react-dom\`, \`react-router(-dom)\`, \`antd\`, \`@ant-design/*\`, \`@rc-component/*\`, \`rc-*\`, \`lucide-react\` — into a single \`vendor-react\` chunk. No more cycle.

## Test plan
- [x] Local pre-commit gate (lint + 225 tests + smoke probes) passed.
- [x] Build output verified: now produces a single \`vendor-react-DpDE0__a.js\` (843 KB) chunk.
- [ ] After merge: deploy succeeds, kit.openiap.dev loads without the antd crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized vendor code splitting strategy during the build process for improved bundling efficiency and application loading performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->