### PR TITLE
chore(kit): close two CI gaps that let kit.openiap.dev ship broken

### DIFF
--- a/.github/workflows/deploy-kit.yml
+++ b/.github/workflows/deploy-kit.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Vite build
         env:
-          VITE_KIT_CONVEX_URL: https://placeholder.convex.cloud
+          VITE_KIT_CONVEX_URL: https://placeholder-build-1.convex.cloud
         run: bun run build
 
       - name: Bun compile server
@@ -80,7 +80,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            VITE_KIT_CONVEX_URL=https://placeholder.convex.cloud
+            VITE_KIT_CONVEX_URL=https://placeholder-build-1.convex.cloud
 
   deploy:
     name: Deploy openiap-kit to Fly.io

--- a/.github/workflows/deploy-kit.yml
+++ b/.github/workflows/deploy-kit.yml
@@ -56,8 +56,31 @@ jobs:
       - name: Bun compile server
         run: bun run build:server
 
+      - name: Install Playwright chromium
+        # smoke-browser.ts loads the SPA in headless Chromium to catch
+        # runtime bundle crashes that HTTP probes miss (see PR #120).
+        run: bunx playwright install --with-deps chromium
+
       - name: Smoke test compiled server
         run: ./scripts/smoke-server.sh
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker build (PR-level Dockerfile check)
+        # The Deploy job below also builds the Docker image, but only on
+        # push-to-main. Building here on PRs catches Dockerfile/Bun-image
+        # incompatibilities before merge (see PR #119, where bun 1.3.13
+        # changed --filter hoisting and broke the per-package COPY).
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ github.workspace }}
+          file: packages/kit/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VITE_KIT_CONVEX_URL=https://placeholder.convex.cloud
 
   deploy:
     name: Deploy openiap-kit to Fly.io

--- a/packages/kit/scripts/smoke-browser.ts
+++ b/packages/kit/scripts/smoke-browser.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env bun
+// Headless-browser smoke for the kit SPA.
+//
+// Why this exists: smoke-server.sh only HTTP-probes /health, /, /api/v1
+// — those return 200 even when the JS bundle crashes on hydration. PR
+// #120 shipped a manualChunks misconfiguration that left React in the
+// main chunk while antd was split out, creating a cross-chunk cycle
+// that crashed antd at boot ("Cannot set properties of undefined
+// (setting 'Activity')"). The page still served a 200, so HTTP probes
+// missed it. This script loads the SPA in headless Chromium, listens
+// for pageerror + console.error, and asserts the page mounts content.
+
+import { chromium } from "@playwright/test";
+
+const url = process.env.SMOKE_URL ?? "http://localhost:3100/";
+
+async function main(): Promise<void> {
+  const errors: string[] = [];
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    page.on("pageerror", (err) => {
+      errors.push(`pageerror: ${err.message}`);
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        errors.push(`console.error: ${msg.text()}`);
+      }
+    });
+
+    await page.goto(url, { waitUntil: "networkidle", timeout: 30_000 });
+
+    // Verify the SPA actually mounted something non-trivial. An empty
+    // <div id="root"></div> is what every fatal-bundle-crash leaves
+    // behind, and it's what shipped to kit.openiap.dev pre-#120.
+    const rootHtml = await page.locator("#root").innerHTML();
+    if (rootHtml.trim().length === 0) {
+      errors.push("SPA mount target #root is empty — bundle likely crashed");
+    }
+
+    if (errors.length > 0) {
+      console.error("smoke-browser: FAILED");
+      for (const e of errors) console.error(`  - ${e}`);
+      process.exit(1);
+    }
+
+    console.log(`smoke-browser: ${url} mounted cleanly ✓`);
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error("smoke-browser: unexpected error", err);
+  process.exit(1);
+});

--- a/packages/kit/scripts/smoke-browser.ts
+++ b/packages/kit/scripts/smoke-browser.ts
@@ -53,11 +53,20 @@ async function main(): Promise<number> {
     // both — leaving a zombie chromium process and hiding any
     // pageerror/console.error we already collected.
     try {
-      await page.goto(url, { waitUntil: "networkidle", timeout: 30_000 });
+      // `waitUntil: "networkidle"` hangs in apps with persistent
+      // sockets (Convex WebSockets, Sentry beacons). Use
+      // domcontentloaded + an explicit wait for #root to mount
+      // children — that's the actual signal we want, and it surfaces
+      // bundle crashes as a clean TimeoutError.
+      await page.goto(url, {
+        waitUntil: "domcontentloaded",
+        timeout: 30_000,
+      });
+      await page.waitForSelector("#root > *", { timeout: 30_000 });
 
-      // Verify the SPA actually mounted something non-trivial. An empty
-      // <div id="root"></div> is what every fatal-bundle-crash leaves
-      // behind, and it's what shipped to kit.openiap.dev pre-#120.
+      // Defensive: confirm content actually rendered. waitForSelector
+      // already covers this, but keep the explicit emptiness check so
+      // a future change that swaps the assertion still has a tripwire.
       const rootHtml = await page.locator("#root").innerHTML();
       if (rootHtml.trim().length === 0) {
         errors.push("SPA mount target #root is empty — bundle likely crashed");

--- a/packages/kit/scripts/smoke-browser.ts
+++ b/packages/kit/scripts/smoke-browser.ts
@@ -28,7 +28,7 @@ function isIgnored(message: string): boolean {
   return IGNORED_ERROR_PATTERNS.some((re) => re.test(message));
 }
 
-async function main(): Promise<void> {
+async function main(): Promise<number> {
   const errors: string[] = [];
 
   const browser = await chromium.launch({ headless: true });
@@ -47,29 +47,44 @@ async function main(): Promise<void> {
       errors.push(`console.error: ${text}`);
     });
 
-    await page.goto(url, { waitUntil: "networkidle", timeout: 30_000 });
+    // Catch goto/locator failures (timeouts etc.) so the errors array
+    // gets reported AND the finally below still runs to close the
+    // browser. Calling process.exit() inside the try block would skip
+    // both — leaving a zombie chromium process and hiding any
+    // pageerror/console.error we already collected.
+    try {
+      await page.goto(url, { waitUntil: "networkidle", timeout: 30_000 });
 
-    // Verify the SPA actually mounted something non-trivial. An empty
-    // <div id="root"></div> is what every fatal-bundle-crash leaves
-    // behind, and it's what shipped to kit.openiap.dev pre-#120.
-    const rootHtml = await page.locator("#root").innerHTML();
-    if (rootHtml.trim().length === 0) {
-      errors.push("SPA mount target #root is empty — bundle likely crashed");
+      // Verify the SPA actually mounted something non-trivial. An empty
+      // <div id="root"></div> is what every fatal-bundle-crash leaves
+      // behind, and it's what shipped to kit.openiap.dev pre-#120.
+      const rootHtml = await page.locator("#root").innerHTML();
+      if (rootHtml.trim().length === 0) {
+        errors.push("SPA mount target #root is empty — bundle likely crashed");
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push(`navigation failed: ${message}`);
     }
-
-    if (errors.length > 0) {
-      console.error("smoke-browser: FAILED");
-      for (const e of errors) console.error(`  - ${e}`);
-      process.exit(1);
-    }
-
-    console.log(`smoke-browser: ${url} mounted cleanly ✓`);
   } finally {
     await browser.close();
   }
+
+  if (errors.length > 0) {
+    console.error("smoke-browser: FAILED");
+    for (const e of errors) console.error(`  - ${e}`);
+    return 1;
+  }
+
+  console.log(`smoke-browser: ${url} mounted cleanly ✓`);
+  return 0;
 }
 
-main().catch((err) => {
-  console.error("smoke-browser: unexpected error", err);
-  process.exit(1);
-});
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err) => {
+    console.error("smoke-browser: unexpected error", err);
+    process.exitCode = 1;
+  });

--- a/packages/kit/scripts/smoke-browser.ts
+++ b/packages/kit/scripts/smoke-browser.ts
@@ -14,6 +14,20 @@ import { chromium } from "@playwright/test";
 
 const url = process.env.SMOKE_URL ?? "http://localhost:3100/";
 
+// Errors that are expected when the SPA is built against placeholder env
+// (CI smoke and local `bun run smoke:server`). We still want the smoke to
+// fail on bundle-integrity problems — chunk cycles, missing modules,
+// hydration crashes — but a Convex/Sentry config rejection that fires
+// AFTER React has already mounted #root is not a bundle bug.
+const IGNORED_ERROR_PATTERNS: RegExp[] = [
+  /CONVEX FATAL ERROR.*Couldn't parse deployment name/i,
+  /Sentry.*Invalid DSN/i,
+];
+
+function isIgnored(message: string): boolean {
+  return IGNORED_ERROR_PATTERNS.some((re) => re.test(message));
+}
+
 async function main(): Promise<void> {
   const errors: string[] = [];
 
@@ -23,12 +37,14 @@ async function main(): Promise<void> {
     const page = await context.newPage();
 
     page.on("pageerror", (err) => {
+      if (isIgnored(err.message)) return;
       errors.push(`pageerror: ${err.message}`);
     });
     page.on("console", (msg) => {
-      if (msg.type() === "error") {
-        errors.push(`console.error: ${msg.text()}`);
-      }
+      if (msg.type() !== "error") return;
+      const text = msg.text();
+      if (isIgnored(text)) return;
+      errors.push(`console.error: ${text}`);
     });
 
     await page.goto(url, { waitUntil: "networkidle", timeout: 30_000 });

--- a/packages/kit/scripts/smoke-server.sh
+++ b/packages/kit/scripts/smoke-server.sh
@@ -87,4 +87,17 @@ if [[ "$fail" -ne 0 ]]; then
   exit 1
 fi
 
+# HTTP probes pass even when the SPA bundle is broken at runtime
+# (PR #120 shipped a chunk-cycle crash that left a 200 response and a
+# blank page). Run a headless-browser smoke to catch that class of
+# failure. Skipped when SKIP_BROWSER_SMOKE=1 (e.g. dev iteration where
+# Playwright + chromium aren't installed yet).
+if [[ "${SKIP_BROWSER_SMOKE:-0}" != "1" ]]; then
+  if ! SMOKE_URL="http://localhost:${PORT}/" bun run "$ROOT_DIR/scripts/smoke-browser.ts"; then
+    echo "---- server log ----" >&2
+    cat /tmp/openiap-kit-smoke.log >&2 || true
+    exit 1
+  fi
+fi
+
 echo "smoke: all probes passed"

--- a/packages/kit/scripts/smoke-server.sh
+++ b/packages/kit/scripts/smoke-server.sh
@@ -31,7 +31,7 @@ if [[ ! -f "$DIST/index.html" ]]; then
 fi
 
 # Run the binary in the background with placeholder env.
-CONVEX_URL="https://placeholder.convex.cloud" \
+CONVEX_URL="https://placeholder-build-1.convex.cloud" \
 STATIC_ROOT="$DIST" \
 PORT="$PORT" \
 "$BINARY" > /tmp/openiap-kit-smoke.log 2>&1 &


### PR DESCRIPTION
## Summary
This week's outage chain (PR #119 fix-up + PR #120 runtime crash) shipped through green PR CI because the verify job didn't catch either failure mode. Two targeted additions:

### 1. PR-level Docker build (catches Dockerfile bugs before merge)
- Add a `Docker build` step to the `verify` job that builds `packages/kit/Dockerfile` against the workspace context, with GHA layer caching.
- Would have caught PR #109's Bun 1.3.13 `--filter` hoisting incompatibility — currently the Docker image only builds in the `Deploy` job which runs on push-to-main, so the bug only surfaced 5 minutes after merge.

### 2. Headless-browser smoke (catches SPA runtime crashes)
- Add `packages/kit/scripts/smoke-browser.ts`: load the SPA in headless Chromium, listen for `pageerror` + `console.error`, assert `#root` mounts non-empty content.
- Wire it into `smoke-server.sh` after the existing HTTP probes (gated on `SKIP_BROWSER_SMOKE=1` for dev iteration).
- Would have caught PR #120's `manualChunks` cross-chunk cycle ("Cannot set properties of undefined (setting 'Activity')") — HTTP probes returned 200 because the server still served a blank `index.html`, but the bundle crashed at boot in the browser.
- CI installs Chromium via `bunx playwright install --with-deps chromium`; `@playwright/test` was already a dev dep.

## Test plan
- [x] Local pre-commit gate (lint + 225 tests + smoke-server + smoke-browser) passes.
- [x] Verified `smoke-browser.ts` correctly reports `mounted cleanly ✓` against the current bundle.
- [ ] CI verify job stays green; the new Docker build + browser smoke produce sub-2-min added latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Tests**
  * Enhanced PR verification pipeline with headless browser smoke testing to validate application functionality
  * Added Docker image build validation during PR checks to catch incompatibilities before merge
  * Improved error reporting during automated testing

* **Chores**
  * Strengthened CI/CD infrastructure with extended verification steps for better quality assurance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->