### PR TITLE
docs: surface IAPKit open-source + source link consistently

### DIFF
--- a/packages/docs/src/pages/docs/apis/index.tsx
+++ b/packages/docs/src/pages/docs/apis/index.tsx
@@ -332,7 +332,15 @@ function APIsIndex() {
               <td>
                 Verify via a managed provider without standing up your own
                 server. The <code>PurchaseVerificationProvider</code> enum
-                currently exposes only IAPKit.
+                currently exposes only IAPKit (open source, MIT — source at{' '}
+                <a
+                  href="https://github.com/hyodotdev/openiap/tree/main/packages/kit"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <code>packages/kit</code>
+                </a>
+                ).
               </td>
             </tr>
             <tr>

--- a/packages/docs/src/pages/docs/apis/index.tsx
+++ b/packages/docs/src/pages/docs/apis/index.tsx
@@ -332,7 +332,7 @@ function APIsIndex() {
               <td>
                 Verify via a managed provider without standing up your own
                 server. The <code>PurchaseVerificationProvider</code> enum
-                currently exposes only IAPKit (open source, MIT — source at{' '}
+                currently exposes only IAPKit (open source under MIT — source at{' '}
                 <a
                   href="https://github.com/hyodotdev/openiap/tree/main/packages/kit"
                   target="_blank"
@@ -340,7 +340,7 @@ function APIsIndex() {
                 >
                   <code>packages/kit</code>
                 </a>
-                ).
+                {`).`}
               </td>
             </tr>
             <tr>

--- a/packages/docs/src/pages/docs/getting-started.tsx
+++ b/packages/docs/src/pages/docs/getting-started.tsx
@@ -456,9 +456,24 @@ await iap.request_purchase(props)`}</CodeBlock>
           </li>
           <li>
             <Link to="/docs/features/validation">Validation</Link> — server-side
-            verification (your own backend or IAPKit — open source, hosted at
-            kit.openiap.dev or self-host from <code>packages/kit</code> under
-            MIT)
+            verification (your own backend or IAPKit — open source under MIT,
+            hosted free at{' '}
+            <a
+              href="https://kit.openiap.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              kit.openiap.dev
+            </a>{' '}
+            or self-host from{' '}
+            <a
+              href="https://github.com/hyodotdev/openiap/tree/main/packages/kit"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <code>packages/kit</code>
+            </a>
+            )
           </li>
           <li>
             <Link to="/docs/apis">API Reference</Link> — every function with

--- a/packages/docs/src/pages/docs/getting-started.tsx
+++ b/packages/docs/src/pages/docs/getting-started.tsx
@@ -473,7 +473,7 @@ await iap.request_purchase(props)`}</CodeBlock>
             >
               <code>packages/kit</code>
             </a>
-            )
+            {`)`}
           </li>
           <li>
             <Link to="/docs/apis">API Reference</Link> — every function with

--- a/packages/docs/src/pages/docs/types/verify-purchase-with-provider-props.tsx
+++ b/packages/docs/src/pages/docs/types/verify-purchase-with-provider-props.tsx
@@ -43,7 +43,7 @@ function VerifyPurchaseWithProviderProps() {
           >
             <code>packages/kit</code>
           </a>
-          ). See{' '}
+          {`).`} See{' '}
           <a
             href="https://www.openiap.dev/docs/features/validation"
             target="_blank"

--- a/packages/docs/src/pages/docs/types/verify-purchase-with-provider-props.tsx
+++ b/packages/docs/src/pages/docs/types/verify-purchase-with-provider-props.tsx
@@ -35,7 +35,15 @@ function VerifyPurchaseWithProviderProps() {
         <p>
           Input to <code>verifyPurchaseWithProvider</code> — pick a managed
           validator. The <code>PurchaseVerificationProvider</code> enum
-          currently exposes only IAPKit. See{' '}
+          currently exposes only IAPKit (open source under MIT — source at{' '}
+          <a
+            href="https://github.com/hyodotdev/openiap/tree/main/packages/kit"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <code>packages/kit</code>
+          </a>
+          ). See{' '}
           <a
             href="https://www.openiap.dev/docs/features/validation"
             target="_blank"


### PR DESCRIPTION
## Summary
\`example.tsx\` and \`features/validation.tsx\` already note that IAPKit is open source (MIT) and link to \`packages/kit\`. Three other references didn't:

- **getting-started.tsx** — said \"open source\" as plain text without a clickable source link
- **apis/index.tsx** — \`verifyPurchaseWithProvider\` row said only \"currently exposes only IAPKit\" with no MIT/source mention
- **types/verify-purchase-with-provider-props.tsx** — same gap on the type page

Aligned all three with the existing pattern: explicit \"open source under MIT\", linkable \`packages/kit\` source, and (where relevant) the hosted \`kit.openiap.dev\` mention.

## Test plan
- [x] Local pre-commit gate (typecheck + prettier) passed.
- [x] Vite build succeeds.
- [ ] Visually verify the three pages render the new wording + clickable source link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation clarity with explicit MIT open-source attribution for the kit.
  * Added clickable links to the hosted instance and GitHub repository for easier access to source code and self-hosting options.
  * Improved cross-references throughout the documentation for better navigation and resource discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->