### PR TITLE
fix(maui): stabilize ios device launch

### DIFF
--- a/libraries/maui-iap/.vscode/run_ios_device.sh
+++ b/libraries/maui-iap/.vscode/run_ios_device.sh
@@ -6,6 +6,8 @@ LIB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 APP_DIR="$LIB_DIR/example/OpenIap.Maui.Example"
 PROJECT="$APP_DIR/OpenIap.Maui.Example.csproj"
 APP_ID="dev.hyo.martie"
+APP_BUILD_DIR="$APP_DIR/bin/Debug/net9.0-ios/ios-arm64"
+APP_OBJ_DIR="$APP_DIR/obj/Debug/net9.0-ios/ios-arm64"
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -44,15 +46,30 @@ if [ -z "$DEVICE" ]; then
 fi
 
 echo "Using USB iOS device: $DEVICE"
+echo "Cleaning previous iOS device build output..."
+rm -rf "$APP_BUILD_DIR" "$APP_OBJ_DIR"
 
-dotnet build "$PROJECT" \
-  -f net9.0-ios \
-  -p:RuntimeIdentifier=ios-arm64 \
-  -p:_DeviceName="$DEVICE" \
-  -tl:off \
-  -v:minimal
+build_device() {
+  dotnet build "$PROJECT" \
+    -f net9.0-ios \
+    -p:RuntimeIdentifier=ios-arm64 \
+    -p:_DeviceName="$DEVICE" \
+    -tl:off \
+    -v:minimal
+}
 
-APP_BUNDLE="$APP_DIR/bin/Debug/net9.0-ios/ios-arm64/OpenIap.Maui.Example.app"
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/maui-ios-build.XXXXXX")"
+if ! build_device 2>&1 | tee "$BUILD_LOG"; then
+  if grep -Eq 'AssetCatalogSimulatorAgent|MPSNeuralNetwork|actool exited' "$BUILD_LOG"; then
+    echo "Retrying once after transient Xcode asset catalog failure..."
+    rm -rf "$APP_OBJ_DIR/actool"
+    build_device
+  else
+    exit 1
+  fi
+fi
+
+APP_BUNDLE="$APP_BUILD_DIR/OpenIap.Maui.Example.app"
 if [ ! -d "$APP_BUNDLE" ]; then
   echo "iOS app bundle was not produced: $APP_BUNDLE" >&2
   exit 1
@@ -65,6 +82,7 @@ echo "Installing $APP_BUNDLE..."
 ios-deploy \
   --id "$DEVICE" \
   --bundle "$APP_BUNDLE" \
+  --uninstall \
   --nostart \
   --timeout 30
 

--- a/libraries/maui-iap/.vscode/run_ios_device.sh
+++ b/libraries/maui-iap/.vscode/run_ios_device.sh
@@ -59,6 +59,7 @@ build_device() {
 }
 
 BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/maui-ios-build.XXXXXX")"
+trap 'rm -f "$BUILD_LOG"' EXIT
 if ! build_device 2>&1 | tee "$BUILD_LOG"; then
   if grep -Eq 'AssetCatalogSimulatorAgent|MPSNeuralNetwork|actool exited' "$BUILD_LOG"; then
     echo "Retrying once after transient Xcode asset catalog failure..."


### PR DESCRIPTION
## Summary
- clean the iOS device build output before VS Code launch builds so stale renamed assemblies are not bundled
- retry transient Xcode `actool` / CoreSimulator asset catalog failures once
- force ios-deploy reinstall with `--uninstall` to avoid stale bundle file conflicts

## Test plan
- [x] `git diff --check -- libraries/maui-iap/.vscode/run_ios_device.sh`
- [x] `libraries/maui-iap/.vscode/run_ios_device.sh`
- [x] verified the rebuilt iOS device app bundle has no `Hyo.OpenIap.Maui*` files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved iOS device build reliability with automatic retry logic for transient build failures
  * Enhanced build cleanup to remove prior artifacts before each build
  * Strengthened build logging and error handling for better diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->