### PR TITLE
feat(kit): add reporting currency setting

### DIFF
--- a/packages/kit/convex/projects/mutation.ts
+++ b/packages/kit/convex/projects/mutation.ts
@@ -151,6 +151,17 @@ function normalizeHorizonAppSecret(input: string): string {
   return normalized;
 }
 
+function normalizeReportingCurrency(input: string): string {
+  const normalized = input.trim().toUpperCase();
+  if (!/^[A-Z]{3}$/.test(normalized)) {
+    throw createError(
+      ErrorCode.INVALID_INPUT,
+      "Reporting currency must be a 3-letter ISO 4217 code (e.g. USD, EUR, GBP).",
+    );
+  }
+  return normalized;
+}
+
 // Helper to generate URL-friendly slug
 function generateSlug(name: string): string {
   return name
@@ -225,6 +236,7 @@ export const createProject = mutation({
       name: args.name,
       slug: finalSlug,
       apiKey, // Keep for backward compatibility, will be deprecated
+      reportingCurrency: "USD",
       createdAt: now,
       updatedAt: now,
       ...(args.platform ? { platform: args.platform } : {}),
@@ -275,6 +287,7 @@ export const updateProject = mutation({
     horizonEnabled: v.optional(v.boolean()),
     horizonAppId: v.optional(v.string()),
     horizonAppSecret: v.optional(v.string()),
+    reportingCurrency: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
@@ -329,6 +342,11 @@ export const updateProject = mutation({
     }
     if (args.iosAscKeyId !== undefined) {
       updates.iosAscKeyId = normalizeAppStoreKeyId(args.iosAscKeyId);
+    }
+    if (args.reportingCurrency !== undefined) {
+      updates.reportingCurrency = normalizeReportingCurrency(
+        args.reportingCurrency,
+      );
     }
 
     // Horizon fields: validated only when the feature is being

--- a/packages/kit/convex/projects/mutation.ts
+++ b/packages/kit/convex/projects/mutation.ts
@@ -4,6 +4,10 @@ import { getAuthUserId } from "@convex-dev/auth/server";
 import { deleteProjectWithData } from "./helpers";
 import { generateApiKey } from "../utils/helpers";
 import { createError, ErrorCode } from "../utils/errors";
+import {
+  DEFAULT_REPORTING_CURRENCY,
+  normalizeReportingCurrency,
+} from "../utils/currency";
 
 const projectPlatformValidator = v.union(
   v.literal("react-native"),
@@ -151,17 +155,6 @@ function normalizeHorizonAppSecret(input: string): string {
   return normalized;
 }
 
-function normalizeReportingCurrency(input: string): string {
-  const normalized = input.trim().toUpperCase();
-  if (!/^[A-Z]{3}$/.test(normalized)) {
-    throw createError(
-      ErrorCode.INVALID_INPUT,
-      "Reporting currency must be a 3-letter ISO 4217 code (e.g. USD, EUR, GBP).",
-    );
-  }
-  return normalized;
-}
-
 // Helper to generate URL-friendly slug
 function generateSlug(name: string): string {
   return name
@@ -236,7 +229,7 @@ export const createProject = mutation({
       name: args.name,
       slug: finalSlug,
       apiKey, // Keep for backward compatibility, will be deprecated
-      reportingCurrency: "USD",
+      reportingCurrency: DEFAULT_REPORTING_CURRENCY,
       createdAt: now,
       updatedAt: now,
       ...(args.platform ? { platform: args.platform } : {}),

--- a/packages/kit/convex/schema.ts
+++ b/packages/kit/convex/schema.ts
@@ -221,7 +221,7 @@ const schema = defineSchema({
 
     // Stable presentation currency for dashboard analytics. Raw
     // purchases/subscriptions keep their original store currency;
-    // without explicit FX conversion, reporting totals only include
+    // IAPKit does not do FX conversion; reporting totals only include
     // rows that already match this code.
     reportingCurrency: v.optional(v.string()),
 
@@ -685,9 +685,9 @@ const schema = defineSchema({
   // budget, which silently undercounted projects above that
   // threshold.
   //
-  // Keyed by currency because MRR can't be summed across
-  // currencies without a presentation-layer FX conversion (matches
-  // the same reasoning on `revenueMetricsDaily`).
+  // Keyed by currency because IAPKit deliberately does not sum MRR
+  // across currencies (matches the same reasoning on
+  // `revenueMetricsDaily`).
   //
   // 30-day rolling counters (refunded, canceled) are NOT stored
   // here — those are bounded-size by definition (limited by 30 days
@@ -720,9 +720,8 @@ const schema = defineSchema({
   // by (projectId, day, productId) would either mix incompatible
   // `revenueMicros` totals or have one currency overwrite another,
   // both of which produce wrong dashboard numbers for multi-region
-  // apps. Aggregating across currencies is a presentation-layer
-  // concern (FX conversion happens in the UI, with whatever rates the
-  // operator picks).
+  // apps. IAPKit does not convert or aggregate those currencies; any
+  // accounting-grade conversion belongs outside the dashboard.
   revenueMetricsDaily: defineTable({
     projectId: v.id("projects"),
     day: v.string(), // ISO date (YYYY-MM-DD), UTC

--- a/packages/kit/convex/schema.ts
+++ b/packages/kit/convex/schema.ts
@@ -219,6 +219,12 @@ const schema = defineSchema({
     horizonAppId: v.optional(v.union(v.string(), v.null())),
     horizonAppSecret: v.optional(v.union(v.string(), v.null())),
 
+    // Stable presentation currency for dashboard analytics. Raw
+    // purchases/subscriptions keep their original store currency;
+    // without explicit FX conversion, reporting totals only include
+    // rows that already match this code.
+    reportingCurrency: v.optional(v.string()),
+
     // Per-platform "active product-sync job" lock. Read-and-patched
     // inside `enqueueProductSync` so Convex's optimistic concurrency
     // control collapses two concurrent enqueue mutations onto the

--- a/packages/kit/convex/subscriptions/query.test.ts
+++ b/packages/kit/convex/subscriptions/query.test.ts
@@ -41,4 +41,20 @@ describe("selectReportingMrr", () => {
       ],
     });
   });
+
+  it("falls back to USD for invalid reporting currency input", () => {
+    const result = selectReportingMrr(
+      [
+        { currency: "USD", mrrMicros: 9_990_000 },
+        { currency: "EUR", mrrMicros: 8_500_000 },
+      ],
+      "US",
+    );
+
+    expect(result).toEqual({
+      currency: "USD",
+      mrrMicros: 9_990_000,
+      excludedMrrByCurrency: [{ currency: "EUR", mrrMicros: 8_500_000 }],
+    });
+  });
 });

--- a/packages/kit/convex/subscriptions/query.test.ts
+++ b/packages/kit/convex/subscriptions/query.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { selectReportingMrr } from "./query";
+
+describe("selectReportingMrr", () => {
+  it("uses only the reporting currency for the headline MRR", () => {
+    const result = selectReportingMrr(
+      [
+        { currency: "EUR", mrrMicros: 8_500_000 },
+        { currency: "USD", mrrMicros: 9_990_000 },
+        { currency: "HUF", mrrMicros: 12_000_000 },
+      ],
+      "USD",
+    );
+
+    expect(result).toEqual({
+      currency: "USD",
+      mrrMicros: 9_990_000,
+      excludedMrrByCurrency: [
+        { currency: "EUR", mrrMicros: 8_500_000 },
+        { currency: "HUF", mrrMicros: 12_000_000 },
+      ],
+    });
+  });
+
+  it("returns zero when the reporting currency has no matching MRR", () => {
+    const result = selectReportingMrr(
+      [
+        { currency: "EUR", mrrMicros: 8_500_000 },
+        { currency: "HUF", mrrMicros: 12_000_000 },
+      ],
+      "USD",
+    );
+
+    expect(result).toEqual({
+      currency: "USD",
+      mrrMicros: 0,
+      excludedMrrByCurrency: [
+        { currency: "EUR", mrrMicros: 8_500_000 },
+        { currency: "HUF", mrrMicros: 12_000_000 },
+      ],
+    });
+  });
+});

--- a/packages/kit/convex/subscriptions/query.ts
+++ b/packages/kit/convex/subscriptions/query.ts
@@ -456,7 +456,7 @@ export const metricsSummary = query({
     // headline `mrrMicros` below intentionally uses only the
     // project's reporting currency; other currencies remain visible
     // in `excludedMrrByCurrency` instead of being silently summed
-    // without FX conversion.
+    // by IAPKit.
     const sorted = Array.from(mrrAccumulators.entries()).sort(
       ([a, av], [b, bv]) => (bv !== av ? bv - av : a.localeCompare(b)),
     );

--- a/packages/kit/convex/subscriptions/query.ts
+++ b/packages/kit/convex/subscriptions/query.ts
@@ -73,15 +73,26 @@ async function projectByApiKey(
     .unique();
 }
 
-function reportingCurrencyForProject(project: Doc<"projects">): string {
-  return normalizeReportingCurrencyOrDefault(project.reportingCurrency);
+export interface MrrCurrencyEntry {
+  currency: string;
+  mrrMicros: number;
 }
 
-export type MrrCurrencyEntry = { currency: string; mrrMicros: number };
-
+/**
+ * Selects the headline MRR entry for a project's reporting currency.
+ *
+ * `reportingCurrency` is normalized via `normalizeReportingCurrencyOrDefault`,
+ * so unknown or invalid input falls back to `DEFAULT_REPORTING_CURRENCY`.
+ * If no entry matches the normalized currency, returned `mrrMicros` is `0`.
+ * Returned `excludedMrrByCurrency` contains every non-reporting-currency entry.
+ *
+ * @param entries Per-currency MRR rows already summed for the project.
+ * @param reportingCurrency Project-configured reporting currency, raw or normalized.
+ * @returns The normalized `currency`, selected `mrrMicros`, and excluded rows.
+ */
 export function selectReportingMrr(
   entries: MrrCurrencyEntry[],
-  reportingCurrency: string,
+  reportingCurrency: string | null | undefined,
 ): {
   currency: string;
   mrrMicros: number;
@@ -332,8 +343,6 @@ export const metricsSummary = query({
         excludedMrrByCurrency: [],
       };
     }
-    const reportingCurrency = reportingCurrencyForProject(project);
-
     const now = Date.now();
     const cutoff = now - 30 * 24 * 60 * 60 * 1000;
 
@@ -463,7 +472,10 @@ export const metricsSummary = query({
       currency,
       mrrMicros,
     }));
-    const reportingMrr = selectReportingMrr(mrrByCurrency, reportingCurrency);
+    const reportingMrr = selectReportingMrr(
+      mrrByCurrency,
+      project.reportingCurrency,
+    );
 
     return {
       activeSubs,

--- a/packages/kit/convex/subscriptions/query.ts
+++ b/packages/kit/convex/subscriptions/query.ts
@@ -4,8 +4,10 @@ import type { Doc, Id } from "../_generated/dataModel";
 
 import { monthlyMicrosForSub } from "./monthlyMicros";
 import { selectMostRecentlyUpdatedSubscription } from "./selectLatest";
-
-const DEFAULT_REPORTING_CURRENCY = "USD";
+import {
+  DEFAULT_REPORTING_CURRENCY,
+  normalizeReportingCurrencyOrDefault,
+} from "../utils/currency";
 
 const subscriptionStateValidator = v.union(
   v.literal("Active"),
@@ -72,10 +74,7 @@ async function projectByApiKey(
 }
 
 function reportingCurrencyForProject(project: Doc<"projects">): string {
-  const candidate = project.reportingCurrency?.trim().toUpperCase();
-  return candidate && /^[A-Z]{3}$/.test(candidate)
-    ? candidate
-    : DEFAULT_REPORTING_CURRENCY;
+  return normalizeReportingCurrencyOrDefault(project.reportingCurrency);
 }
 
 export type MrrCurrencyEntry = { currency: string; mrrMicros: number };
@@ -88,15 +87,17 @@ export function selectReportingMrr(
   mrrMicros: number;
   excludedMrrByCurrency: MrrCurrencyEntry[];
 } {
+  const normalizedReportingCurrency =
+    normalizeReportingCurrencyOrDefault(reportingCurrency);
   const reportingEntry = entries.find(
-    (entry) => entry.currency === reportingCurrency,
+    (entry) => entry.currency === normalizedReportingCurrency,
   );
 
   return {
-    currency: reportingCurrency,
+    currency: normalizedReportingCurrency,
     mrrMicros: reportingEntry?.mrrMicros ?? 0,
     excludedMrrByCurrency: entries.filter(
-      (entry) => entry.currency !== reportingCurrency,
+      (entry) => entry.currency !== normalizedReportingCurrency,
     ),
   };
 }

--- a/packages/kit/convex/subscriptions/query.ts
+++ b/packages/kit/convex/subscriptions/query.ts
@@ -88,17 +88,15 @@ export function selectReportingMrr(
   mrrMicros: number;
   excludedMrrByCurrency: MrrCurrencyEntry[];
 } {
-  const normalizedReportingCurrency =
-    reportingCurrency.trim().toUpperCase() || DEFAULT_REPORTING_CURRENCY;
   const reportingEntry = entries.find(
-    (entry) => entry.currency === normalizedReportingCurrency,
+    (entry) => entry.currency === reportingCurrency,
   );
 
   return {
-    currency: normalizedReportingCurrency,
+    currency: reportingCurrency,
     mrrMicros: reportingEntry?.mrrMicros ?? 0,
     excludedMrrByCurrency: entries.filter(
-      (entry) => entry.currency !== normalizedReportingCurrency,
+      (entry) => entry.currency !== reportingCurrency,
     ),
   };
 }

--- a/packages/kit/convex/subscriptions/query.ts
+++ b/packages/kit/convex/subscriptions/query.ts
@@ -5,6 +5,8 @@ import type { Doc, Id } from "../_generated/dataModel";
 import { monthlyMicrosForSub } from "./monthlyMicros";
 import { selectMostRecentlyUpdatedSubscription } from "./selectLatest";
 
+const DEFAULT_REPORTING_CURRENCY = "USD";
+
 const subscriptionStateValidator = v.union(
   v.literal("Active"),
   v.literal("InGracePeriod"),
@@ -67,6 +69,38 @@ async function projectByApiKey(
     .query("projects")
     .withIndex("by_api_key", (q: any) => q.eq("apiKey", apiKey))
     .unique();
+}
+
+function reportingCurrencyForProject(project: Doc<"projects">): string {
+  const candidate = project.reportingCurrency?.trim().toUpperCase();
+  return candidate && /^[A-Z]{3}$/.test(candidate)
+    ? candidate
+    : DEFAULT_REPORTING_CURRENCY;
+}
+
+export type MrrCurrencyEntry = { currency: string; mrrMicros: number };
+
+export function selectReportingMrr(
+  entries: MrrCurrencyEntry[],
+  reportingCurrency: string,
+): {
+  currency: string;
+  mrrMicros: number;
+  excludedMrrByCurrency: MrrCurrencyEntry[];
+} {
+  const normalizedReportingCurrency =
+    reportingCurrency.trim().toUpperCase() || DEFAULT_REPORTING_CURRENCY;
+  const reportingEntry = entries.find(
+    (entry) => entry.currency === normalizedReportingCurrency,
+  );
+
+  return {
+    currency: normalizedReportingCurrency,
+    mrrMicros: reportingEntry?.mrrMicros ?? 0,
+    excludedMrrByCurrency: entries.filter(
+      (entry) => entry.currency !== normalizedReportingCurrency,
+    ),
+  };
 }
 
 // Match onesub's `/onesub/status?userId=` — returns the most-recently-
@@ -265,16 +299,21 @@ export const metricsSummary = query({
     inBillingRetry: v.number(),
     refunded30d: v.number(),
     canceled30d: v.number(),
-    // Headline MRR in the project's most-popular currency, normalized
-    // to monthly. Historical field name kept for backward compat with
-    // dashboard / MCP consumers.
+    // Headline MRR in the project's reporting currency, normalized
+    // to monthly. Historical field name kept for dashboard / MCP
+    // consumers, but the value is no longer a cross-currency or
+    // "most popular currency" total.
     mrrMicros: v.number(),
     currency: v.optional(v.string()),
+    reportingCurrency: v.string(),
     // Full per-currency breakdown so consumers that care about
     // multi-currency aren't left guessing. Each entry's `mrrMicros`
     // is summed only over subscriptions in that currency, normalized
     // to monthly via the product's billingPeriod.
     mrrByCurrency: v.array(
+      v.object({ currency: v.string(), mrrMicros: v.number() }),
+    ),
+    excludedMrrByCurrency: v.array(
       v.object({ currency: v.string(), mrrMicros: v.number() }),
     ),
   }),
@@ -288,10 +327,13 @@ export const metricsSummary = query({
         refunded30d: 0,
         canceled30d: 0,
         mrrMicros: 0,
-        currency: undefined,
+        currency: DEFAULT_REPORTING_CURRENCY,
+        reportingCurrency: DEFAULT_REPORTING_CURRENCY,
         mrrByCurrency: [],
+        excludedMrrByCurrency: [],
       };
     }
+    const reportingCurrency = reportingCurrencyForProject(project);
 
     const now = Date.now();
     const cutoff = now - 30 * 24 * 60 * 60 * 1000;
@@ -410,14 +452,19 @@ export const metricsSummary = query({
       }
     }
 
-    // Pick the most-popular currency (largest accumulator) as the
-    // headline `currency` + `mrrMicros` so dashboards / MCP consumers
-    // that don't yet read the multi-currency breakdown still show a
-    // sensible single value. Stable tie-break via alphabetical sort.
+    // Sort per-currency MRR for deterministic UI rendering. The
+    // headline `mrrMicros` below intentionally uses only the
+    // project's reporting currency; other currencies remain visible
+    // in `excludedMrrByCurrency` instead of being silently summed
+    // without FX conversion.
     const sorted = Array.from(mrrAccumulators.entries()).sort(
       ([a, av], [b, bv]) => (bv !== av ? bv - av : a.localeCompare(b)),
     );
-    const headline = sorted[0];
+    const mrrByCurrency = sorted.map(([currency, mrrMicros]) => ({
+      currency,
+      mrrMicros,
+    }));
+    const reportingMrr = selectReportingMrr(mrrByCurrency, reportingCurrency);
 
     return {
       activeSubs,
@@ -425,12 +472,11 @@ export const metricsSummary = query({
       inBillingRetry,
       refunded30d,
       canceled30d,
-      mrrMicros: headline ? headline[1] : 0,
-      currency: headline ? headline[0] : undefined,
-      mrrByCurrency: sorted.map(([currency, mrrMicros]) => ({
-        currency,
-        mrrMicros,
-      })),
+      mrrMicros: reportingMrr.mrrMicros,
+      currency: reportingMrr.currency,
+      reportingCurrency: reportingMrr.currency,
+      mrrByCurrency,
+      excludedMrrByCurrency: reportingMrr.excludedMrrByCurrency,
     };
   },
 });

--- a/packages/kit/convex/utils/currency.ts
+++ b/packages/kit/convex/utils/currency.ts
@@ -1,0 +1,33 @@
+import { createError, ErrorCode } from "./errors";
+
+export const DEFAULT_REPORTING_CURRENCY = "USD";
+
+const currencyCodePattern = /^[A-Z]{3}$/;
+
+export function isValidCurrencyCode(code: string): boolean {
+  return currencyCodePattern.test(code);
+}
+
+function normalizeCurrencyCandidate(input: string | null | undefined): string {
+  return input?.trim().toUpperCase() ?? "";
+}
+
+export function normalizeReportingCurrencyOrDefault(
+  input: string | null | undefined,
+): string {
+  const normalized = normalizeCurrencyCandidate(input);
+  return isValidCurrencyCode(normalized)
+    ? normalized
+    : DEFAULT_REPORTING_CURRENCY;
+}
+
+export function normalizeReportingCurrency(input: string): string {
+  const normalized = normalizeCurrencyCandidate(input);
+  if (!isValidCurrencyCode(normalized)) {
+    throw createError(
+      ErrorCode.INVALID_INPUT,
+      "Reporting currency must be a 3-letter ISO 4217 code (e.g. USD, EUR, GBP).",
+    );
+  }
+  return normalized;
+}

--- a/packages/kit/src/lib/utils.test.ts
+++ b/packages/kit/src/lib/utils.test.ts
@@ -24,4 +24,8 @@ describe("formatMicros", () => {
   it("keeps compact formatting for chart axes", () => {
     expect(formatMicros(1_200_000_000, { compact: true })).toBe("1.2k");
   });
+
+  it("preserves cents for compact values below ten", () => {
+    expect(formatMicros(500_000, { compact: true })).toBe("0.50");
+  });
 });

--- a/packages/kit/src/lib/utils.test.ts
+++ b/packages/kit/src/lib/utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { formatMicros, normalizeCurrencyCode } from "./utils";
+import {
+  DEFAULT_REPORTING_CURRENCY,
+  formatMicros,
+  normalizeCurrencyCode,
+} from "./utils";
 
 describe("normalizeCurrencyCode", () => {
   it("trims and uppercases valid ISO currency codes", () => {
@@ -9,6 +13,15 @@ describe("normalizeCurrencyCode", () => {
 
   it("falls back when the currency code is invalid", () => {
     expect(normalizeCurrencyCode("usdollar", "EUR")).toBe("EUR");
+  });
+
+  it("falls back to DEFAULT_REPORTING_CURRENCY for nullish input", () => {
+    expect(normalizeCurrencyCode(null)).toBe(DEFAULT_REPORTING_CURRENCY);
+    expect(normalizeCurrencyCode(undefined)).toBe(DEFAULT_REPORTING_CURRENCY);
+  });
+
+  it("uses the explicit fallback for undefined input", () => {
+    expect(normalizeCurrencyCode(undefined, "GBP")).toBe("GBP");
   });
 });
 

--- a/packages/kit/src/lib/utils.test.ts
+++ b/packages/kit/src/lib/utils.test.ts
@@ -38,6 +38,11 @@ describe("formatMicros", () => {
     expect(formatMicros(1_200_000_000, { compact: true })).toBe("1.2k");
   });
 
+  it("formats compact values between ten and one thousand without decimals", () => {
+    expect(formatMicros(10_500_000, { compact: true })).toBe("11");
+    expect(formatMicros(999_400_000, { compact: true })).toBe("999");
+  });
+
   it("preserves cents for compact values below ten", () => {
     expect(formatMicros(500_000, { compact: true })).toBe("0.50");
   });

--- a/packages/kit/src/lib/utils.test.ts
+++ b/packages/kit/src/lib/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { formatMicros, normalizeCurrencyCode } from "./utils";
+
+describe("normalizeCurrencyCode", () => {
+  it("trims and uppercases valid ISO currency codes", () => {
+    expect(normalizeCurrencyCode(" usd ")).toBe("USD");
+  });
+
+  it("falls back when the currency code is invalid", () => {
+    expect(normalizeCurrencyCode("usdollar", "EUR")).toBe("EUR");
+  });
+});
+
+describe("formatMicros", () => {
+  it("formats zero as a currency amount in non-compact mode", () => {
+    expect(formatMicros(0, { currency: "USD" })).toBe("USD 0.00");
+  });
+
+  it("can hide zero values when a metric is empty", () => {
+    expect(formatMicros(0, { currency: "USD", emptyWhenZero: true })).toBe("—");
+  });
+
+  it("keeps compact formatting for chart axes", () => {
+    expect(formatMicros(1_200_000_000, { compact: true })).toBe("1.2k");
+  });
+});

--- a/packages/kit/src/lib/utils.ts
+++ b/packages/kit/src/lib/utils.ts
@@ -20,17 +20,19 @@ export function normalizeCurrencyCode(
   return fallback;
 }
 
+export interface FormatMicrosOptions {
+  currency?: string | null;
+  compact?: boolean;
+  emptyWhenZero?: boolean;
+}
+
 export function formatMicros(
   micros: number,
   {
     currency,
     compact = false,
     emptyWhenZero = false,
-  }: {
-    currency?: string | null;
-    compact?: boolean;
-    emptyWhenZero?: boolean;
-  } = {},
+  }: FormatMicrosOptions = {},
 ): string {
   if (!micros) {
     if (emptyWhenZero) return "—";

--- a/packages/kit/src/lib/utils.ts
+++ b/packages/kit/src/lib/utils.ts
@@ -7,7 +7,7 @@ export function cn(...inputs: ClassValue[]) {
 
 export const DEFAULT_REPORTING_CURRENCY = "USD";
 
-const currencyCodePattern = /^[A-Z]{3}$/;
+export const currencyCodePattern = /^[A-Z]{3}$/;
 
 export function normalizeCurrencyCode(
   input: string | null | undefined,

--- a/packages/kit/src/lib/utils.ts
+++ b/packages/kit/src/lib/utils.ts
@@ -41,6 +41,7 @@ export function formatMicros(
   const value = micros / 1_000_000;
   if (compact) {
     if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+    if (value < 10) return value.toFixed(2);
     return value.toFixed(0);
   }
 

--- a/packages/kit/src/lib/utils.ts
+++ b/packages/kit/src/lib/utils.ts
@@ -4,3 +4,45 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const DEFAULT_REPORTING_CURRENCY = "USD";
+
+const currencyCodePattern = /^[A-Z]{3}$/;
+
+export function normalizeCurrencyCode(
+  input: string | null | undefined,
+  fallback = DEFAULT_REPORTING_CURRENCY,
+): string {
+  const normalized = input?.trim().toUpperCase() ?? "";
+  if (currencyCodePattern.test(normalized)) {
+    return normalized;
+  }
+  return fallback;
+}
+
+export function formatMicros(
+  micros: number,
+  {
+    currency,
+    compact = false,
+    emptyWhenZero = false,
+  }: {
+    currency?: string | null;
+    compact?: boolean;
+    emptyWhenZero?: boolean;
+  } = {},
+): string {
+  if (!micros) {
+    if (emptyWhenZero) return "—";
+    if (compact) return "0";
+    return `${currency ?? ""} 0.00`.trim();
+  }
+
+  const value = micros / 1_000_000;
+  if (compact) {
+    if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+    return value.toFixed(0);
+  }
+
+  return `${currency ?? ""} ${value.toFixed(2)}`.trim();
+}

--- a/packages/kit/src/pages/auth/organization/project/analytics.tsx
+++ b/packages/kit/src/pages/auth/organization/project/analytics.tsx
@@ -311,29 +311,38 @@ export default function ProjectAnalytics() {
     [lifecycleDaily, periodId],
   );
 
+  const revenueByBucket = useMemo(
+    () => new Map(revenueSeries.map((row) => [row.dayKey, row.revenueMicros])),
+    [revenueSeries],
+  );
+  const reportingRevenueByBucket = useMemo(
+    () =>
+      new Map(
+        reportingRevenueSeries.map((row) => [row.dayKey, row.revenueMicros]),
+      ),
+    [reportingRevenueSeries],
+  );
+
   // Final chart series merges the lifecycle counters (cross-currency)
-  // with the revenue total (currency-pinned) per bucket. Same
-  // bucket-period axis on both sides means we can join positionally
-  // since `bucketByPeriod` produces deterministic output for a
-  // given `periodId` / `range`.
+  // with the revenue total (currency-pinned) by bucket key.
   const series = useMemo(
     () =>
-      lifecycleSeries.map((row, i) => ({
+      lifecycleSeries.map((row) => ({
         ...row,
-        revenueMicros: revenueSeries[i]?.revenueMicros ?? 0,
+        revenueMicros: revenueByBucket.get(row.dayKey) ?? 0,
       })),
-    [lifecycleSeries, revenueSeries],
+    [lifecycleSeries, revenueByBucket],
   );
 
   const totals = useMemo(
     () =>
       lifecycleSeries.reduce(
-        (acc, row, i) => {
+        (acc, row) => {
           acc.newSubs += row.newSubs;
           acc.renewals += row.renewals;
           acc.cancellations += row.cancellations;
           acc.refunds += row.refunds;
-          acc.revenueMicros += reportingRevenueSeries[i]?.revenueMicros ?? 0;
+          acc.revenueMicros += reportingRevenueByBucket.get(row.dayKey) ?? 0;
           acc.activeSubsLast = row.activeSubs;
           return acc;
         },
@@ -346,7 +355,7 @@ export default function ProjectAnalytics() {
           activeSubsLast: 0,
         },
       ),
-    [lifecycleSeries, reportingRevenueSeries],
+    [lifecycleSeries, reportingRevenueByBucket],
   );
 
   // Churn = (cancellations + refunds) / activeSubs at end of window.
@@ -968,7 +977,7 @@ function aggregateByDay(
 function bucketByPeriod(
   daily: Array<DailyRow & { dayKey: string }>,
   period: PeriodId,
-): Array<DailyRow & { label: string; churnPct: number }> {
+): Array<DailyRow & { dayKey: string; label: string; churnPct: number }> {
   if (period === "daily") {
     return daily.map((row) => ({
       ...row,

--- a/packages/kit/src/pages/auth/organization/project/analytics.tsx
+++ b/packages/kit/src/pages/auth/organization/project/analytics.tsx
@@ -536,7 +536,7 @@ export default function ProjectAnalytics() {
           Revenue totals are pinned to {currency}.{" "}
           {excludedCurrencies.join(", ")}{" "}
           {excludedCurrencies.length === 1 ? "is" : "are"} excluded from this
-          total because FX conversion is not enabled.
+          total because IAPKit does not convert currencies.
         </div>
       )}
 

--- a/packages/kit/src/pages/auth/organization/project/analytics.tsx
+++ b/packages/kit/src/pages/auth/organization/project/analytics.tsx
@@ -205,14 +205,20 @@ export default function ProjectAnalytics() {
   // Empty-project case (no rollup rows yet) still resolves to the
   // project reporting currency so the UI does not drift based on
   // whichever store event arrives first.
-  const currency = selectedCurrency ?? reportingCurrency;
   const currencyOptions = useMemo(
     () => Array.from(new Set([reportingCurrency, ...metricsCurrencies])).sort(),
     [reportingCurrency, metricsCurrencies],
   );
-  const excludedCurrencies = useMemo(
-    () => metricsCurrencies.filter((candidate) => candidate !== currency),
-    [metricsCurrencies, currency],
+  const currency = useMemo(() => {
+    if (selectedCurrency && currencyOptions.includes(selectedCurrency)) {
+      return selectedCurrency;
+    }
+    return reportingCurrency;
+  }, [selectedCurrency, currencyOptions, reportingCurrency]);
+  const excludedReportingCurrencies = useMemo(
+    () =>
+      metricsCurrencies.filter((candidate) => candidate !== reportingCurrency),
+    [metricsCurrencies, reportingCurrency],
   );
 
   // Client-side filtering. Range is also a client filter now (we
@@ -230,8 +236,9 @@ export default function ProjectAnalytics() {
   // visually to zero on the first day.
   //
   // Two parallel pipelines:
-  //   - `revenueRows`: pinned to `currency` because `revenueMicros`
-  //     can't be summed across currencies without an FX rate.
+  //   - `revenueRows`: pinned to the selected chart currency.
+  //   - `reportingRevenueRows`: pinned to the project reporting
+  //     currency for headline totals.
   //   - `lifecycleRows`: NOT pinned to currency. activeSubs / new /
   //     renewals / cancellations / refunds are counts, not money,
   //     and aggregating them across currencies gives the correct
@@ -255,6 +262,18 @@ export default function ProjectAnalytics() {
       }),
     [metricsDays, currency, selectedProduct, platformFilter],
   );
+  const reportingRevenueRows = useMemo(
+    () =>
+      metricsDays.filter((row) => {
+        if (row.currency !== reportingCurrency) return false;
+        if (selectedProduct && row.productId !== selectedProduct) return false;
+        if (platformFilter !== "all" && row.platform !== platformFilter) {
+          return false;
+        }
+        return true;
+      }),
+    [metricsDays, reportingCurrency, selectedProduct, platformFilter],
+  );
   const lifecycleRows = useMemo(
     () =>
       metricsDays.filter((row) => {
@@ -271,6 +290,10 @@ export default function ProjectAnalytics() {
     () => aggregateByDay(revenueRows, range.days, fromDay),
     [revenueRows, range.days, fromDay],
   );
+  const reportingRevenueDaily = useMemo(
+    () => aggregateByDay(reportingRevenueRows, range.days, fromDay),
+    [reportingRevenueRows, range.days, fromDay],
+  );
   const lifecycleDaily = useMemo(
     () => aggregateByDay(lifecycleRows, range.days, fromDay),
     [lifecycleRows, range.days, fromDay],
@@ -278,6 +301,10 @@ export default function ProjectAnalytics() {
   const revenueSeries = useMemo(
     () => bucketByPeriod(revenueDaily, periodId),
     [revenueDaily, periodId],
+  );
+  const reportingRevenueSeries = useMemo(
+    () => bucketByPeriod(reportingRevenueDaily, periodId),
+    [reportingRevenueDaily, periodId],
   );
   const lifecycleSeries = useMemo(
     () => bucketByPeriod(lifecycleDaily, periodId),
@@ -300,13 +327,13 @@ export default function ProjectAnalytics() {
 
   const totals = useMemo(
     () =>
-      series.reduce(
-        (acc, row) => {
+      lifecycleSeries.reduce(
+        (acc, row, i) => {
           acc.newSubs += row.newSubs;
           acc.renewals += row.renewals;
           acc.cancellations += row.cancellations;
           acc.refunds += row.refunds;
-          acc.revenueMicros += row.revenueMicros;
+          acc.revenueMicros += reportingRevenueSeries[i]?.revenueMicros ?? 0;
           acc.activeSubsLast = row.activeSubs;
           return acc;
         },
@@ -319,7 +346,7 @@ export default function ProjectAnalytics() {
           activeSubsLast: 0,
         },
       ),
-    [series],
+    [lifecycleSeries, reportingRevenueSeries],
   );
 
   // Churn = (cancellations + refunds) / activeSubs at end of window.
@@ -343,7 +370,7 @@ export default function ProjectAnalytics() {
     });
     const revenueBaseRows = metricsDays.filter((row) => {
       if (row.day < fromDay) return false;
-      if (currency && row.currency !== currency) return false;
+      if (row.currency !== reportingCurrency) return false;
       if (selectedProduct && row.productId !== selectedProduct) return false;
       return true;
     });
@@ -361,7 +388,7 @@ export default function ProjectAnalytics() {
       });
     }
     return byFilter;
-  }, [metricsDays, fromDay, currency, selectedProduct]);
+  }, [metricsDays, fromDay, reportingCurrency, selectedProduct]);
 
   if (metrics === undefined) {
     return <PageLoading />;
@@ -470,7 +497,9 @@ export default function ProjectAnalytics() {
               <div className="relative">
                 <p className="text-sm text-muted-foreground">{card.label}</p>
                 <p className="text-3xl font-semibold mt-2 tabular-nums">
-                  {formatMicros(cardTotals.revenueMicros, { currency })}
+                  {formatMicros(cardTotals.revenueMicros, {
+                    currency: reportingCurrency,
+                  })}
                 </p>
                 <p className="text-xs text-muted-foreground mt-1">
                   {cardTotals.activeSubs} active · {cardTotals.newSubs} new
@@ -515,7 +544,7 @@ export default function ProjectAnalytics() {
                 currencies without an FX rate, so the chart must
                 always be pinned to exactly one. The project
                 reporting currency is the default; other currencies
-                are visible here but excluded from current totals. */}
+                are visible here for chart exploration only. */}
             <Select
               value={currency || undefined}
               onChange={(v) => setSelectedCurrency(v ?? null)}
@@ -529,12 +558,14 @@ export default function ProjectAnalytics() {
         )}
       </div>
 
-      {excludedCurrencies.length > 0 && (
+      {excludedReportingCurrencies.length > 0 && (
         <div className="border border-border bg-muted/20 rounded-lg p-4 text-sm text-muted-foreground">
-          Revenue totals are pinned to {currency}.{" "}
-          {excludedCurrencies.join(", ")}{" "}
-          {excludedCurrencies.length === 1 ? "is" : "are"} excluded from this
-          total because IAPKit does not convert currencies.
+          Headline revenue totals are pinned to {reportingCurrency}.{" "}
+          {currency !== reportingCurrency &&
+            `The revenue chart is showing ${currency}. `}
+          {excludedReportingCurrencies.join(", ")}{" "}
+          {excludedReportingCurrencies.length === 1 ? "is" : "are"} excluded
+          from headline totals because IAPKit does not convert currencies.
         </div>
       )}
 
@@ -542,7 +573,9 @@ export default function ProjectAnalytics() {
         <SummaryCard
           icon={TrendingUp}
           label="Revenue"
-          value={formatMicros(totals.revenueMicros, { currency })}
+          value={formatMicros(totals.revenueMicros, {
+            currency: reportingCurrency,
+          })}
         />
         <SummaryCard
           icon={Users}

--- a/packages/kit/src/pages/auth/organization/project/analytics.tsx
+++ b/packages/kit/src/pages/auth/organization/project/analytics.tsx
@@ -36,6 +36,7 @@ type Platform = "IOS" | "Android";
 type PlatformFilter = "all" | Platform;
 
 const DAY_MS = 86_400_000;
+const DEFAULT_REPORTING_CURRENCY = "USD";
 
 // Stable empty defaults. The kickoff render before `useQuery`
 // returns has `metrics === undefined`; we still need to invoke
@@ -190,26 +191,31 @@ export default function ProjectAnalytics() {
   // bail to `<PageLoading />` after the hooks have been registered.
   const metricsDays = metrics?.days ?? EMPTY_DAYS;
   const metricsCurrencies = metrics?.currencies ?? EMPTY_STRINGS;
+  const reportingCurrency =
+    project.reportingCurrency ?? DEFAULT_REPORTING_CURRENCY;
 
   // Multi-currency projects: we always pin to a single currency for
   // chart rendering because revenueMicros can't be summed across
   // currencies without an FX rate. `selectedCurrency` resolves to
-  // the explicit user choice, falling back to the first available
+  // the explicit user choice, falling back to the project reporting
   // currency. The currency selector below is REQUIRED (not
   // clearable) when multiple currencies exist so a user can never
   // end up in the broken "no currency selected, sum across all"
   // state — otherwise the totals would mix USD + EUR + JPY into a
   // single number labeled with one currency code.
   //
-  // Empty-project case (no rollup rows yet) leaves both
-  // `selectedCurrency` and `metricsCurrencies[0]` undefined; we
-  // resolve to "" deliberately and let the `EmptyState` below take
-  // over rendering — the chart subtree is gated on
-  // `metricsDays.length > 0` so a "" currency never reaches the
-  // axis labels.
-  const currency =
-    selectedCurrency ??
-    (metricsCurrencies.length > 0 ? metricsCurrencies[0] : "");
+  // Empty-project case (no rollup rows yet) still resolves to the
+  // project reporting currency so the UI does not drift based on
+  // whichever store event arrives first.
+  const currency = selectedCurrency ?? reportingCurrency;
+  const currencyOptions = useMemo(
+    () => Array.from(new Set([reportingCurrency, ...metricsCurrencies])).sort(),
+    [reportingCurrency, metricsCurrencies],
+  );
+  const excludedCurrencies = useMemo(
+    () => metricsCurrencies.filter((candidate) => candidate !== currency),
+    [metricsCurrencies, currency],
+  );
 
   // Client-side filtering. Range is also a client filter now (we
   // fetched the max range above), so flipping range chiclets stays
@@ -504,24 +510,35 @@ export default function ProjectAnalytics() {
             />
           </div>
         )}
-        {metrics.currencies.length > 1 && (
+        {currencyOptions.length > 1 && (
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground">Currency:</span>
             {/* No allowClear: revenue can't be summed across
                 currencies without an FX rate, so the chart must
-                always be pinned to exactly one. We surface the
-                first available currency as the default rather
-                than letting the user end up in a "no currency,
-                sum across" state where amounts would be wrong. */}
+                always be pinned to exactly one. The project
+                reporting currency is the default; other currencies
+                are visible here but excluded from current totals. */}
             <Select
               value={currency || undefined}
               onChange={(v) => setSelectedCurrency(v ?? null)}
               className="min-w-[100px]"
-              options={metrics.currencies.map((c) => ({ value: c, label: c }))}
+              options={currencyOptions.map((c) => ({
+                value: c,
+                label: c === reportingCurrency ? `${c} (reporting)` : c,
+              }))}
             />
           </div>
         )}
       </div>
+
+      {excludedCurrencies.length > 0 && (
+        <div className="border border-border bg-muted/20 rounded-lg p-4 text-sm text-muted-foreground">
+          Revenue totals are pinned to {currency}.{" "}
+          {excludedCurrencies.join(", ")}{" "}
+          {excludedCurrencies.length === 1 ? "is" : "are"} excluded from this
+          total because FX conversion is not enabled.
+        </div>
+      )}
 
       <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
         <SummaryCard

--- a/packages/kit/src/pages/auth/organization/project/analytics.tsx
+++ b/packages/kit/src/pages/auth/organization/project/analytics.tsx
@@ -28,7 +28,7 @@ import {
 import type { Doc } from "@/convex";
 import { api } from "@/convex";
 import { PageLoading } from "@/components/LoadingSpinner";
-import { cn } from "@/lib/utils";
+import { cn, formatMicros, normalizeCurrencyCode } from "@/lib/utils";
 
 type ProjectContext = { project: Doc<"projects"> };
 
@@ -36,7 +36,6 @@ type Platform = "IOS" | "Android";
 type PlatformFilter = "all" | Platform;
 
 const DAY_MS = 86_400_000;
-const DEFAULT_REPORTING_CURRENCY = "USD";
 
 // Stable empty defaults. The kickoff render before `useQuery`
 // returns has `metrics === undefined`; we still need to invoke
@@ -191,8 +190,7 @@ export default function ProjectAnalytics() {
   // bail to `<PageLoading />` after the hooks have been registered.
   const metricsDays = metrics?.days ?? EMPTY_DAYS;
   const metricsCurrencies = metrics?.currencies ?? EMPTY_STRINGS;
-  const reportingCurrency =
-    project.reportingCurrency ?? DEFAULT_REPORTING_CURRENCY;
+  const reportingCurrency = normalizeCurrencyCode(project.reportingCurrency);
 
   // Multi-currency projects: we always pin to a single currency for
   // chart rendering because revenueMicros can't be summed across
@@ -472,7 +470,7 @@ export default function ProjectAnalytics() {
               <div className="relative">
                 <p className="text-sm text-muted-foreground">{card.label}</p>
                 <p className="text-3xl font-semibold mt-2 tabular-nums">
-                  {formatMicros(cardTotals.revenueMicros, currency)}
+                  {formatMicros(cardTotals.revenueMicros, { currency })}
                 </p>
                 <p className="text-xs text-muted-foreground mt-1">
                   {cardTotals.activeSubs} active · {cardTotals.newSubs} new
@@ -544,7 +542,7 @@ export default function ProjectAnalytics() {
         <SummaryCard
           icon={TrendingUp}
           label="Revenue"
-          value={formatMicros(totals.revenueMicros, currency)}
+          value={formatMicros(totals.revenueMicros, { currency })}
         />
         <SummaryCard
           icon={Users}
@@ -590,10 +588,14 @@ export default function ProjectAnalytics() {
                 <YAxis
                   tick={{ fontSize: 11 }}
                   stroke="var(--muted-foreground)"
-                  tickFormatter={(v) => formatMicros(v, currency, true)}
+                  tickFormatter={(v) =>
+                    formatMicros(v, { currency, compact: true })
+                  }
                 />
                 <Tooltip
-                  formatter={(value: number) => formatMicros(value, currency)}
+                  formatter={(value: number) =>
+                    formatMicros(value, { currency })
+                  }
                   contentStyle={tooltipStyle}
                 />
                 <Bar
@@ -1091,18 +1093,4 @@ function revenueForPlatform(
 
 function utcDayKey(ts: number): string {
   return new Date(ts).toISOString().slice(0, 10);
-}
-
-function formatMicros(
-  micros: number,
-  currency: string,
-  compact = false,
-): string {
-  if (!micros) return compact ? "0" : `${currency} 0`.trim();
-  const value = micros / 1_000_000;
-  if (compact) {
-    if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
-    return value.toFixed(0);
-  }
-  return `${currency} ${value.toFixed(2)}`.trim();
 }

--- a/packages/kit/src/pages/auth/organization/project/analytics.tsx
+++ b/packages/kit/src/pages/auth/organization/project/analytics.tsx
@@ -220,6 +220,11 @@ export default function ProjectAnalytics() {
       metricsCurrencies.filter((candidate) => candidate !== reportingCurrency),
     [metricsCurrencies, reportingCurrency],
   );
+  const calloutExcludedCurrencies = useMemo(
+    () =>
+      excludedReportingCurrencies.filter((candidate) => candidate !== currency),
+    [excludedReportingCurrencies, currency],
+  );
 
   // Client-side filtering. Range is also a client filter now (we
   // fetched the max range above), so flipping range chiclets stays
@@ -555,7 +560,7 @@ export default function ProjectAnalytics() {
                 reporting currency is the default; other currencies
                 are visible here for chart exploration only. */}
             <Select
-              value={currency || undefined}
+              value={currency}
               onChange={(v) => setSelectedCurrency(v ?? null)}
               className="min-w-[100px]"
               options={currencyOptions.map((c) => ({
@@ -569,12 +574,15 @@ export default function ProjectAnalytics() {
 
       {excludedReportingCurrencies.length > 0 && (
         <div className="border border-border bg-muted/20 rounded-lg p-4 text-sm text-muted-foreground">
-          Headline revenue totals are pinned to {reportingCurrency}.{" "}
+          Headline revenue totals only include {reportingCurrency}.{" "}
           {currency !== reportingCurrency &&
             `The revenue chart is showing ${currency}. `}
-          {excludedReportingCurrencies.join(", ")}{" "}
-          {excludedReportingCurrencies.length === 1 ? "is" : "are"} excluded
-          from headline totals because IAPKit does not convert currencies.
+          {calloutExcludedCurrencies.length > 0
+            ? `${calloutExcludedCurrencies.join(", ")} ${
+                calloutExcludedCurrencies.length === 1 ? "is" : "are"
+              } also kept separate. `
+            : "Other currency slices are kept separate. "}
+          IAPKit does not convert currencies.
         </div>
       )}
 
@@ -614,7 +622,7 @@ export default function ProjectAnalytics() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           <ChartCard
             title="Revenue"
-            subtitle={`Initial purchases + renewals${currency ? ` · ${currency}` : ""}`}
+            subtitle={`Initial purchases + renewals · ${currency}`}
           >
             <ResponsiveContainer width="100%" height={240}>
               <BarChart

--- a/packages/kit/src/pages/auth/organization/project/settings.tsx
+++ b/packages/kit/src/pages/auth/organization/project/settings.tsx
@@ -340,6 +340,7 @@ export default function ProjectSettings() {
   const isReportingCurrencyValid = currencyCodePattern.test(
     trimmedReportingCurrency,
   );
+  const reportingCurrencyErrorId = "reporting-currency-error";
   const reportingCurrencyHasChanges =
     trimmedReportingCurrency !== originalReportingCurrency;
   const disableSaveReportingCurrency =
@@ -726,9 +727,15 @@ export default function ProjectSettings() {
               maxLength={3}
               spellCheck={false}
               aria-invalid={!isReportingCurrencyValid}
+              aria-describedby={
+                !isReportingCurrencyValid ? reportingCurrencyErrorId : undefined
+              }
             />
             {!isReportingCurrencyValid && (
-              <p className="text-sm text-destructive mt-1">
+              <p
+                id={reportingCurrencyErrorId}
+                className="text-sm text-destructive mt-1"
+              >
                 Enter a 3-letter ISO 4217 code.
               </p>
             )}

--- a/packages/kit/src/pages/auth/organization/project/settings.tsx
+++ b/packages/kit/src/pages/auth/organization/project/settings.tsx
@@ -19,6 +19,7 @@ import {
 import { GuideModal } from "../../../../components/GuideModal";
 import { PageLoading } from "@/components/LoadingSpinner";
 import { ButtonPrimary } from "@/components/ButtonPrimary";
+import { DEFAULT_REPORTING_CURRENCY, currencyCodePattern } from "@/lib/utils";
 
 const androidPackagePattern =
   /^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/;
@@ -26,8 +27,6 @@ const iosBundlePattern = /^[A-Za-z][A-Za-z0-9-]*(\.[A-Za-z0-9-]+)+$/;
 const appStoreIssuerPattern =
   /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 const appStoreKeyPattern = /^[A-Z0-9]{10}$/;
-const currencyCodePattern = /^[A-Z]{3}$/;
-const DEFAULT_REPORTING_CURRENCY = "USD";
 
 interface ProjectData {
   _id: Id<"projects">;

--- a/packages/kit/src/pages/auth/organization/project/settings.tsx
+++ b/packages/kit/src/pages/auth/organization/project/settings.tsx
@@ -708,8 +708,8 @@ export default function ProjectSettings() {
         </div>
         <p className="text-sm text-muted-foreground mb-4">
           Main MRR and revenue totals only include rows already stored in this
-          currency. Other currencies stay visible separately until explicit FX
-          conversion is added.
+          currency. IAPKit keeps other currencies visible separately and does
+          not convert them.
         </p>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
           <div className="sm:w-40">

--- a/packages/kit/src/pages/auth/organization/project/settings.tsx
+++ b/packages/kit/src/pages/auth/organization/project/settings.tsx
@@ -14,6 +14,7 @@ import {
   Trash2,
   HelpCircle,
   Download,
+  CircleDollarSign,
 } from "lucide-react";
 import { GuideModal } from "../../../../components/GuideModal";
 import { PageLoading } from "@/components/LoadingSpinner";
@@ -25,6 +26,8 @@ const iosBundlePattern = /^[A-Za-z][A-Za-z0-9-]*(\.[A-Za-z0-9-]+)+$/;
 const appStoreIssuerPattern =
   /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 const appStoreKeyPattern = /^[A-Z0-9]{10}$/;
+const currencyCodePattern = /^[A-Z]{3}$/;
+const DEFAULT_REPORTING_CURRENCY = "USD";
 
 interface ProjectData {
   _id: Id<"projects">;
@@ -39,6 +42,7 @@ interface ProjectData {
   iosAppStoreIssuerId?: string;
   iosAppStoreKeyId?: string;
   iosAscKeyId?: string;
+  reportingCurrency?: string;
   horizonEnabled?: boolean;
   horizonAppId?: string | null;
   // The Meta App Secret is never returned by
@@ -94,6 +98,9 @@ export default function ProjectSettings() {
   // `convex/products/asc.ts` (asc.ts falls back to
   // `iosAppStoreIssuerId` when `iosAscIssuerId` is unset).
   const [iosAscKeyId, setIosAscKeyId] = useState(project?.iosAscKeyId ?? "");
+  const [reportingCurrency, setReportingCurrency] = useState(
+    project?.reportingCurrency ?? DEFAULT_REPORTING_CURRENCY,
+  );
   // Meta Horizon — gated by a checkbox inside the Android card.
   // The enabled flag is the single source of truth: toggling off
   // clears the credential fields on save so stale secrets can't
@@ -111,6 +118,7 @@ export default function ProjectSettings() {
   const [isReplacingHorizonAppSecret, setIsReplacingHorizonAppSecret] =
     useState(false);
   const [savingMetadata, setSavingMetadata] = useState(false);
+  const [savingReportingCurrency, setSavingReportingCurrency] = useState(false);
   const [savingHorizon, setSavingHorizon] = useState(false);
 
   // Convex mutations for file upload
@@ -157,6 +165,8 @@ export default function ProjectSettings() {
   const originalIosIssuerId = project?.iosAppStoreIssuerId ?? "";
   const originalIosKeyId = project?.iosAppStoreKeyId ?? "";
   const originalIosAscKeyId = project?.iosAscKeyId ?? "";
+  const originalReportingCurrency =
+    project?.reportingCurrency ?? DEFAULT_REPORTING_CURRENCY;
   const originalHorizonEnabled = Boolean(project?.horizonEnabled);
   const originalHorizonAppId = project?.horizonAppId ?? "";
   const hasHorizonAppSecretConfigured = Boolean(project?.hasHorizonAppSecret);
@@ -171,6 +181,7 @@ export default function ProjectSettings() {
     setIosAppStoreIssuerId(originalIosIssuerId);
     setIosAppStoreKeyId(originalIosKeyId);
     setIosAscKeyId(originalIosAscKeyId);
+    setReportingCurrency(originalReportingCurrency);
     setHorizonEnabled(originalHorizonEnabled);
     setHorizonAppId(originalHorizonAppId);
     // Secret is write-only; we never receive the existing value, so
@@ -186,6 +197,7 @@ export default function ProjectSettings() {
     originalIosIssuerId,
     originalIosKeyId,
     originalIosAscKeyId,
+    originalReportingCurrency,
     originalHorizonEnabled,
     originalHorizonAppId,
     hasHorizonAppSecretConfigured,
@@ -197,6 +209,7 @@ export default function ProjectSettings() {
   const trimmedIosIssuerId = iosAppStoreIssuerId.trim();
   const trimmedIosKeyId = iosAppStoreKeyId.trim().toUpperCase();
   const trimmedIosAscKeyId = iosAscKeyId.trim().toUpperCase();
+  const trimmedReportingCurrency = reportingCurrency.trim().toUpperCase();
   const trimmedHorizonAppId = horizonAppId.trim();
   const trimmedHorizonAppSecret = horizonAppSecret.trim();
 
@@ -325,6 +338,15 @@ export default function ProjectSettings() {
     !isIosCredentialPairValid ||
     !isIosAscKeyIdValid ||
     savingMetadata;
+  const isReportingCurrencyValid = currencyCodePattern.test(
+    trimmedReportingCurrency,
+  );
+  const reportingCurrencyHasChanges =
+    trimmedReportingCurrency !== originalReportingCurrency;
+  const disableSaveReportingCurrency =
+    !reportingCurrencyHasChanges ||
+    !isReportingCurrencyValid ||
+    savingReportingCurrency;
 
   // Horizon (inside the Android card) has its own save flow rather
   // than piggybacking on the identifiers form above — the form lives
@@ -452,6 +474,29 @@ export default function ProjectSettings() {
       toast.error(error.message || "Failed to save Horizon configuration.");
     } finally {
       setSavingHorizon(false);
+    }
+  };
+
+  const handleReportingCurrencySubmit = async (
+    event: FormEvent<HTMLFormElement>,
+  ) => {
+    event.preventDefault();
+    if (!project || disableSaveReportingCurrency) {
+      return;
+    }
+
+    setSavingReportingCurrency(true);
+    try {
+      await updateProject({
+        projectId: project._id,
+        reportingCurrency: trimmedReportingCurrency,
+      });
+      toast.success("Reporting currency saved.");
+    } catch (error: any) {
+      console.error("Reporting currency update error:", error);
+      toast.error(error.message || "Failed to save reporting currency.");
+    } finally {
+      setSavingReportingCurrency(false);
     }
   };
 
@@ -650,6 +695,56 @@ export default function ProjectSettings() {
           <span className="font-mono text-foreground">{project._id}</span>
         </p>
       </div>
+
+      <form
+        onSubmit={(event) => {
+          void handleReportingCurrencySubmit(event);
+        }}
+        className="bg-card rounded-lg border border-border p-6 mb-6"
+      >
+        <div className="flex items-center gap-2 mb-2">
+          <CircleDollarSign className="w-5 h-5" />
+          <h3 className="font-semibold text-lg">Reporting currency</h3>
+        </div>
+        <p className="text-sm text-muted-foreground mb-4">
+          Main MRR and revenue totals only include rows already stored in this
+          currency. Other currencies stay visible separately until explicit FX
+          conversion is added.
+        </p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+          <div className="sm:w-40">
+            <label className="block text-sm font-medium mb-2">
+              Currency code
+            </label>
+            <input
+              type="text"
+              value={reportingCurrency}
+              onChange={(event) =>
+                setReportingCurrency(event.target.value.toUpperCase())
+              }
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm uppercase tracking-normal focus:outline-none focus:ring-2 focus:ring-primary"
+              placeholder="USD"
+              maxLength={3}
+              spellCheck={false}
+              aria-invalid={!isReportingCurrencyValid}
+            />
+            {!isReportingCurrencyValid && (
+              <p className="text-sm text-destructive mt-1">
+                Enter a 3-letter ISO 4217 code.
+              </p>
+            )}
+          </div>
+          <div className="flex-1 sm:pt-7">
+            <ButtonPrimary
+              type="submit"
+              size="sm"
+              disabled={disableSaveReportingCurrency}
+            >
+              {savingReportingCurrency ? "Saving..." : "Save currency"}
+            </ButtonPrimary>
+          </div>
+        </div>
+      </form>
 
       {/* Supported platforms — gates which configuration cards render
           below. Identifiers + credentials live INSIDE each platform's

--- a/packages/kit/src/pages/auth/organization/project/subscriptions.tsx
+++ b/packages/kit/src/pages/auth/organization/project/subscriptions.tsx
@@ -110,8 +110,7 @@ export default function ProjectSubscriptions() {
               </p>
               <p className="text-sm text-muted-foreground mb-3">
                 The main MRR card only includes {reportingCurrency}. Other
-                currencies are not converted or summed without explicit FX
-                conversion.
+                currencies are shown separately and are not converted or summed.
               </p>
               <div className="flex flex-wrap gap-2">
                 {metrics.mrrByCurrency.map((entry) => (

--- a/packages/kit/src/pages/auth/organization/project/subscriptions.tsx
+++ b/packages/kit/src/pages/auth/organization/project/subscriptions.tsx
@@ -18,6 +18,8 @@ import { Badge } from "../../../../components/Badge";
 
 type ProjectContext = { project: Doc<"projects"> };
 
+const DEFAULT_REPORTING_CURRENCY = "USD";
+
 const STATE_FILTERS = [
   { id: "all", label: "All" },
   { id: "Active", label: "Active" },
@@ -46,8 +48,16 @@ export default function ProjectSubscriptions() {
 
   const formattedMrr = useMemo(() => {
     if (!metrics) return "—";
-    return formatMicros(metrics.mrrMicros, metrics.currency);
+    return formatMicros(
+      metrics.mrrMicros,
+      metrics.reportingCurrency ?? metrics.currency,
+      metrics.mrrByCurrency.length === 0,
+    );
   }, [metrics]);
+  const reportingCurrency =
+    metrics?.reportingCurrency ??
+    project.reportingCurrency ??
+    DEFAULT_REPORTING_CURRENCY;
 
   if (subscriptions === undefined || metrics === undefined) {
     return <PageLoading />;
@@ -83,8 +93,45 @@ export default function ProjectSubscriptions() {
           label="Billing retry"
           value={metrics.inBillingRetry}
         />
-        <MetricCard icon={Calendar} label="MRR" value={formattedMrr} />
+        <MetricCard
+          icon={Calendar}
+          label={`MRR (${reportingCurrency})`}
+          value={formattedMrr}
+        />
       </div>
+
+      {metrics.excludedMrrByCurrency.length > 0 && (
+        <div className="border border-border rounded-lg bg-card p-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="w-4 h-4 text-amber-500 mt-0.5 shrink-0" />
+            <div className="flex-1">
+              <p className="text-sm font-medium mb-2">
+                MRR excludes non-reporting currencies
+              </p>
+              <p className="text-sm text-muted-foreground mb-3">
+                The main MRR card only includes {reportingCurrency}. Other
+                currencies are not converted or summed without explicit FX
+                conversion.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {metrics.mrrByCurrency.map((entry) => (
+                  <span
+                    key={entry.currency}
+                    className={`rounded-md border px-2.5 py-1 text-xs tabular-nums ${
+                      entry.currency === reportingCurrency
+                        ? "border-primary/40 bg-primary/10 text-foreground"
+                        : "border-border bg-muted/30 text-muted-foreground"
+                    }`}
+                  >
+                    {formatMicros(entry.mrrMicros, entry.currency)}
+                    {entry.currency === reportingCurrency ? " included" : ""}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="grid grid-cols-3 gap-3">
         <MetricCard
@@ -206,8 +253,12 @@ function formatDate(epoch: number): string {
   return new Date(epoch).toISOString().slice(0, 16).replace("T", " ");
 }
 
-function formatMicros(micros: number, currency?: string): string {
-  if (!micros) return "—";
+function formatMicros(
+  micros: number,
+  currency?: string,
+  emptyWhenZero = true,
+): string {
+  if (!micros && emptyWhenZero) return "—";
   const value = micros / 1_000_000;
   return `${currency ?? ""} ${value.toFixed(2)}`.trim();
 }

--- a/packages/kit/src/pages/auth/organization/project/subscriptions.tsx
+++ b/packages/kit/src/pages/auth/organization/project/subscriptions.tsx
@@ -15,10 +15,13 @@ import type { Doc } from "@/convex";
 import { api } from "@/convex";
 import { PageLoading } from "@/components/LoadingSpinner";
 import { Badge } from "../../../../components/Badge";
+import {
+  DEFAULT_REPORTING_CURRENCY,
+  formatMicros,
+  normalizeCurrencyCode,
+} from "@/lib/utils";
 
 type ProjectContext = { project: Doc<"projects"> };
-
-const DEFAULT_REPORTING_CURRENCY = "USD";
 
 const STATE_FILTERS = [
   { id: "all", label: "All" },
@@ -46,18 +49,17 @@ export default function ProjectSubscriptions() {
     limit: 200,
   });
 
+  const reportingCurrency = normalizeCurrencyCode(
+    metrics?.reportingCurrency ?? project.reportingCurrency,
+    DEFAULT_REPORTING_CURRENCY,
+  );
   const formattedMrr = useMemo(() => {
     if (!metrics) return "—";
-    return formatMicros(
-      metrics.mrrMicros,
-      metrics.reportingCurrency ?? metrics.currency,
-      metrics.mrrByCurrency.length === 0,
-    );
-  }, [metrics]);
-  const reportingCurrency =
-    metrics?.reportingCurrency ??
-    project.reportingCurrency ??
-    DEFAULT_REPORTING_CURRENCY;
+    return formatMicros(metrics.mrrMicros, {
+      currency: reportingCurrency,
+      emptyWhenZero: metrics.mrrByCurrency.length === 0,
+    });
+  }, [metrics, reportingCurrency]);
 
   if (subscriptions === undefined || metrics === undefined) {
     return <PageLoading />;
@@ -122,7 +124,9 @@ export default function ProjectSubscriptions() {
                         : "border-border bg-muted/30 text-muted-foreground"
                     }`}
                   >
-                    {formatMicros(entry.mrrMicros, entry.currency)}
+                    {formatMicros(entry.mrrMicros, {
+                      currency: entry.currency,
+                    })}
                     {entry.currency === reportingCurrency ? " included" : ""}
                   </span>
                 ))}
@@ -250,14 +254,4 @@ function StateBadge({ state }: { state: string }) {
 
 function formatDate(epoch: number): string {
   return new Date(epoch).toISOString().slice(0, 16).replace("T", " ");
-}
-
-function formatMicros(
-  micros: number,
-  currency?: string,
-  emptyWhenZero = true,
-): string {
-  if (!micros && emptyWhenZero) return "—";
-  const value = micros / 1_000_000;
-  return `${currency ?? ""} ${value.toFixed(2)}`.trim();
 }

--- a/packages/kit/src/pages/docs/sections/analytics.tsx
+++ b/packages/kit/src/pages/docs/sections/analytics.tsx
@@ -125,12 +125,12 @@ export default function AnalyticsPage() {
       <p>
         Rollup rows are keyed by currency: the same SKU sold in USD and EUR on
         the same day produces two rows. The dashboard never sums revenue across
-        currencies without FX conversion. Each project has a reporting currency
-        setting used for the main MRR and revenue views; rows in other
-        currencies stay visible as separate currency slices and are excluded
-        from the reporting-currency total. Full FX conversion is intentionally
-        separate work because analytics conversion needs a documented rate
-        source, update cadence, effective date, and rounding policy.
+        currencies. Each project has a reporting currency setting used for the
+        main MRR and revenue views; rows in other currencies stay visible as
+        separate currency slices and are excluded from the reporting-currency
+        total. IAPKit does not do FX conversion or payout reconciliation; use
+        your store financial reports or accounting system for currency
+        conversion.
       </p>
 
       <h2 className="mt-10 text-2xl font-semibold">Churn definition</h2>

--- a/packages/kit/src/pages/docs/sections/analytics.tsx
+++ b/packages/kit/src/pages/docs/sections/analytics.tsx
@@ -125,10 +125,12 @@ export default function AnalyticsPage() {
       <p>
         Rollup rows are keyed by currency: the same SKU sold in USD and EUR on
         the same day produces two rows. The dashboard never sums revenue across
-        currencies (no built-in FX conversion). When a project has multiple
-        currencies, the Analytics tab surfaces a currency selector; each chart
-        renders for one currency at a time. If you need a unified revenue view,
-        apply your own FX rates downstream.
+        currencies without FX conversion. Each project has a reporting currency
+        setting used for the main MRR and revenue views; rows in other
+        currencies stay visible as separate currency slices and are excluded
+        from the reporting-currency total. Full FX conversion is intentionally
+        separate work because analytics conversion needs a documented rate
+        source, update cadence, effective date, and rounding policy.
       </p>
 
       <h2 className="mt-10 text-2xl font-semibold">Churn definition</h2>


### PR DESCRIPTION
## Summary

- add a project-level reporting currency setting for IAPKit projects
- pin MRR and Analytics revenue totals to the reporting currency without cross-currency summing
- show non-reporting currencies as excluded/per-currency breakdowns and document that IAPKit does not do FX conversion or payout reconciliation

Closes #135

## Test plan

- [x] `bun run --filter @hyodotdev/openiap-kit lint`
- [x] `bun run --filter @hyodotdev/openiap-kit format:check`
- [x] `bun run --filter @hyodotdev/openiap-kit test`
- [x] `bun run --filter @hyodotdev/openiap-kit smoke:server`
- [x] `bun audit:docs` (advisory warnings only; no hard failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reporting currency support for projects—users can now set a default currency for headline metrics, with other currencies listed separately for transparency.
  * Dashboard MRR and analytics now display using the project's reporting currency, with excluded currencies clearly visible.
  * Added reporting currency configuration option in Project Settings.

* **Documentation**
  * Updated analytics documentation to clarify currency handling and reporting currency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->