### PR TITLE
docs(workflows): clarify pr bugfix labels

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -184,7 +184,8 @@ gh pr edit <PR_NUMBER> --add-label "<label1>,<label2>"
 - Changes to `libraries/kmp-iap/` → `kmp-iap`
 - Changes across multiple platforms → `cross-platform`
 - New features → `🎯 feature`
-- Bug fixes → `🐛 bug`
+- PR bug fixes → `🛠 bugfix`
+- Issue bug reports → `🐛 bug`
 - Breaking changes → `⚡️ breaking`
 - Documentation only → `📖 documentation`
 - CI/CD changes → `💨 ci`

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -185,7 +185,6 @@ gh pr edit <PR_NUMBER> --add-label "<label1>,<label2>"
 - Changes across multiple platforms → `cross-platform`
 - New features → `🎯 feature`
 - PR bug fixes → `🛠 bugfix`
-- Issue bug reports → `🐛 bug`
 - Breaking changes → `⚡️ breaking`
 - Documentation only → `📖 documentation`
 - CI/CD changes → `💨 ci`


### PR DESCRIPTION
## Summary
- clarify that PR bug-fix labels should use 🛠 bugfix
- keep 🐛 bug for issue bug reports

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified PR label guidance: "PR bug fixes" should now map to the 🛠 bugfix label (replacing the prior mapping to 🐛 bug) in the commit/PR workflow docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->