### PR TITLE
fix(kit): allow ios bind-user tokens

### DIFF
--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -144,10 +144,11 @@ Authorization headers return before the logger runs.
 
 Receipt-verification request bodies are capped at 32 KB before JSON
 parsing. Product-management writes are capped at 64 KB, subscription
-user-binding writes at 8 KB, and webhook pushes at 256 KB. `jws`
-(Apple) and `purchaseToken` (Google / subscription binding) are bounded
-at 16 KB and 2 KB respectively; `userId`, `sku`, and `productId` are
-bounded at 256 chars where accepted. Oversized fields return
+user-binding writes at 32 KB, and webhook pushes at 256 KB. `jws`
+(Apple) is bounded at 16 KB, and `purchaseToken` is bounded at 2 KB for
+Google tokens or 16 KB when an Apple JWS is passed to subscription
+binding; `userId`, `sku`, and `productId` are bounded at 256 chars where
+accepted. Oversized fields return
 `400 INVALID_INPUT`; oversized request bodies return
 `413 PAYLOAD_TOO_LARGE`. Invalid inputs stop before upstream store calls
 or Convex mutations.

--- a/packages/kit/server/api/v1/route-input-schemas.ts
+++ b/packages/kit/server/api/v1/route-input-schemas.ts
@@ -40,7 +40,8 @@ const HORIZON_USER_ID_MIN_LENGTH = 3;
 // IMPORTANT: these patterns are intentionally lax enough to match
 // every legitimate shape we've seen. Tightening them further has a
 // real false-positive cost; widen only after checking the logs.
-const APPLE_JWS_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+export const APPLE_JWS_PATTERN =
+  /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 const GOOGLE_PURCHASE_TOKEN_PATTERN = /^[A-Za-z0-9._~-]+$/;
 const HORIZON_USER_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 const HORIZON_SKU_PATTERN = /^[A-Za-z0-9._-]+$/;

--- a/packages/kit/server/api/v1/route-input-schemas.ts
+++ b/packages/kit/server/api/v1/route-input-schemas.ts
@@ -8,8 +8,8 @@ import * as v from "valibot";
 // payloads stay well under 10 KB. Google purchase tokens are opaque
 // base64 blobs, historically under ~200 chars. Meta Horizon identifies
 // entitlements by (userId, sku) — both short strings.
-const APPLE_JWS_MAX_LENGTH = 16_000;
-const GOOGLE_PURCHASE_TOKEN_MAX_LENGTH = 2_000;
+export const APPLE_JWS_MAX_LENGTH = 16_000;
+export const GOOGLE_PURCHASE_TOKEN_MAX_LENGTH = 2_000;
 const HORIZON_USER_ID_MAX_LENGTH = 256;
 const HORIZON_SKU_MAX_LENGTH = 256;
 

--- a/packages/kit/server/api/v1/subscriptions.test.ts
+++ b/packages/kit/server/api/v1/subscriptions.test.ts
@@ -262,6 +262,93 @@ describe("subscriptionsRoutes", () => {
     });
   });
 
+  it("normalizes numeric Apple JWS transaction ids to strings", async () => {
+    const app = buildApp();
+    mocks.mutation.mockResolvedValueOnce({ ok: true, bound: true });
+    const jws = compactJws({
+      transactionId: 2000000000000001,
+      bundleId: "dev.hyo.openiap.test",
+    });
+
+    const response = await app.request("/subscriptions/bind-user/key", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        purchaseToken: jws,
+        userId: "user-1",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, bound: true });
+    expect(mocks.mutation).toHaveBeenCalledWith("bindUser", {
+      apiKey: "key",
+      purchaseToken: "2000000000000001",
+      userId: "user-1",
+    });
+  });
+
+  it("rejects short Apple JWS-shaped bind-user purchaseToken without transaction ids", async () => {
+    const app = buildApp();
+    const jws = compactJws({
+      bundleId: "dev.hyo.openiap.test",
+    });
+
+    expect(jws.length).toBeLessThanOrEqual(2_000);
+
+    const response = await app.request("/subscriptions/bind-user/key", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        purchaseToken: jws,
+        userId: "user-1",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      errors: [
+        {
+          code: "INVALID_INPUT",
+          message:
+            "purchaseToken must be a valid Apple JWS containing originalTransactionId or transactionId",
+        },
+      ],
+    });
+    expect(mocks.mutation).not.toHaveBeenCalled();
+  });
+
+  it("rejects long Apple JWS-shaped bind-user purchaseToken without transaction ids", async () => {
+    const app = buildApp();
+    const jws = compactJws({
+      bundleId: "dev.hyo.openiap.test",
+      padding: "x".repeat(2_400),
+    });
+
+    expect(jws.length).toBeGreaterThan(2_000);
+
+    const response = await app.request("/subscriptions/bind-user/key", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        purchaseToken: jws,
+        userId: "user-1",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      errors: [
+        {
+          code: "INVALID_INPUT",
+          message:
+            "purchaseToken must be a valid Apple JWS containing originalTransactionId or transactionId",
+        },
+      ],
+    });
+    expect(mocks.mutation).not.toHaveBeenCalled();
+  });
+
   it("rejects oversized bind-user bodies before calling Convex", async () => {
     const app = buildApp();
     const response = await app.request("/subscriptions/bind-user/key", {

--- a/packages/kit/server/api/v1/subscriptions.test.ts
+++ b/packages/kit/server/api/v1/subscriptions.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 
@@ -36,6 +37,16 @@ function buildApp() {
   const app = new Hono();
   app.route("/subscriptions", subscriptionsRoutes);
   return app;
+}
+
+function compactJws(payload: Record<string, unknown>): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: "ES256", typ: "JWT" })).toString(
+      "base64url",
+    ),
+    Buffer.from(JSON.stringify(payload)).toString("base64url"),
+    Buffer.from("signature").toString("base64url"),
+  ].join(".");
 }
 
 describe("subscriptionsRoutes", () => {
@@ -196,7 +207,7 @@ describe("subscriptionsRoutes", () => {
     expect(mocks.mutation).not.toHaveBeenCalled();
   });
 
-  it("rejects oversized bind-user purchaseToken before calling Convex", async () => {
+  it("rejects oversized non-Apple bind-user purchaseToken before calling Convex", async () => {
     const app = buildApp();
     const response = await app.request("/subscriptions/bind-user/key", {
       method: "POST",
@@ -212,12 +223,43 @@ describe("subscriptionsRoutes", () => {
       errors: [
         {
           code: "INVALID_INPUT",
-          message: "purchaseToken must be ≤ 2000 chars",
+          message:
+            "purchaseToken must be ≤ 2000 chars, or an Apple JWS ≤ 16000 chars",
         },
       ],
     });
     expect(mocks.query).not.toHaveBeenCalled();
     expect(mocks.mutation).not.toHaveBeenCalled();
+  });
+
+  it("normalizes Apple JWS bind-user purchaseToken to originalTransactionId", async () => {
+    const app = buildApp();
+    mocks.mutation.mockResolvedValueOnce({ ok: true, bound: true });
+    const jws = compactJws({
+      transactionId: "2000000000000001",
+      originalTransactionId: "1000000000000001",
+      bundleId: "dev.hyo.openiap.test",
+      padding: "x".repeat(2_400),
+    });
+
+    expect(jws.length).toBeGreaterThan(2_000);
+
+    const response = await app.request("/subscriptions/bind-user/key", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        purchaseToken: jws,
+        userId: "user-1",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, bound: true });
+    expect(mocks.mutation).toHaveBeenCalledWith("bindUser", {
+      apiKey: "key",
+      purchaseToken: "1000000000000001",
+      userId: "user-1",
+    });
   });
 
   it("rejects oversized bind-user bodies before calling Convex", async () => {
@@ -228,7 +270,7 @@ describe("subscriptionsRoutes", () => {
       body: JSON.stringify({
         purchaseToken: "token",
         userId: "user-1",
-        padding: "x".repeat(8 * 1024),
+        padding: "x".repeat(32 * 1024),
       }),
     });
 
@@ -249,7 +291,7 @@ describe("subscriptionsRoutes", () => {
     const app = buildApp();
     const response = await app.request("/subscriptions/bind-user/key", {
       method: "POST",
-      headers: { "content-length": String(8 * 1024 + 1) },
+      headers: { "content-length": String(32 * 1024 + 1) },
     });
 
     expect(response.status).toBe(413);

--- a/packages/kit/server/api/v1/subscriptions.test.ts
+++ b/packages/kit/server/api/v1/subscriptions.test.ts
@@ -318,6 +318,29 @@ describe("subscriptionsRoutes", () => {
     expect(mocks.mutation).not.toHaveBeenCalled();
   });
 
+  it("accepts short dotted Google tokens that are not parseable Apple JWS", async () => {
+    const app = buildApp();
+    mocks.mutation.mockResolvedValueOnce({ ok: true, bound: true });
+    const purchaseToken = "google.token.value";
+
+    const response = await app.request("/subscriptions/bind-user/key", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        purchaseToken,
+        userId: "user-1",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, bound: true });
+    expect(mocks.mutation).toHaveBeenCalledWith("bindUser", {
+      apiKey: "key",
+      purchaseToken,
+      userId: "user-1",
+    });
+  });
+
   it("rejects long Apple JWS-shaped bind-user purchaseToken without transaction ids", async () => {
     const app = buildApp();
     const jws = compactJws({

--- a/packages/kit/server/api/v1/subscriptions.test.ts
+++ b/packages/kit/server/api/v1/subscriptions.test.ts
@@ -40,11 +40,15 @@ function buildApp() {
 }
 
 function compactJws(payload: Record<string, unknown>): string {
+  return compactJwsFromRawPayload(JSON.stringify(payload));
+}
+
+function compactJwsFromRawPayload(payload: string): string {
   return [
     Buffer.from(JSON.stringify({ alg: "ES256", typ: "JWT" })).toString(
       "base64url",
     ),
-    Buffer.from(JSON.stringify(payload)).toString("base64url"),
+    Buffer.from(payload).toString("base64url"),
     Buffer.from("signature").toString("base64url"),
   ].join(".");
 }
@@ -284,6 +288,32 @@ describe("subscriptionsRoutes", () => {
     expect(mocks.mutation).toHaveBeenCalledWith("bindUser", {
       apiKey: "key",
       purchaseToken: "2000000000000001",
+      userId: "user-1",
+    });
+  });
+
+  it("preserves unsafe 64-bit numeric Apple JWS transaction ids", async () => {
+    const app = buildApp();
+    mocks.mutation.mockResolvedValueOnce({ ok: true, bound: true });
+    const transactionId = "9223372036854775807";
+    const jws = compactJwsFromRawPayload(
+      `{"transactionId":${transactionId},"bundleId":"dev.hyo.openiap.test"}`,
+    );
+
+    const response = await app.request("/subscriptions/bind-user/key", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        purchaseToken: jws,
+        userId: "user-1",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, bound: true });
+    expect(mocks.mutation).toHaveBeenCalledWith("bindUser", {
+      apiKey: "key",
+      purchaseToken: transactionId,
       userId: "user-1",
     });
   });

--- a/packages/kit/server/api/v1/subscriptions.ts
+++ b/packages/kit/server/api/v1/subscriptions.ts
@@ -251,6 +251,10 @@ function isValidProductIdLength(productId: string): boolean {
 type BindUserPurchaseTokenResult =
   | { ok: true; purchaseToken: string }
   | { ok: false; message: string };
+type AppleJwsParseResult =
+  | { kind: "valid"; purchaseToken: string }
+  | { kind: "invalid" }
+  | { kind: "notAppleJws" };
 
 function normalizeBindUserPurchaseToken(
   purchaseToken: string,
@@ -260,9 +264,18 @@ function normalizeBindUserPurchaseToken(
       return { ok: false, message: bindUserPurchaseTokenLimitMessage() };
     }
 
-    const applePurchaseToken = extractApplePurchaseTokenFromJws(purchaseToken);
-    if (applePurchaseToken) {
-      return { ok: true, purchaseToken: applePurchaseToken };
+    const appleJws = parseApplePurchaseTokenFromJws(purchaseToken);
+    if (appleJws.kind === "valid") {
+      return { ok: true, purchaseToken: appleJws.purchaseToken };
+    }
+    if (appleJws.kind === "invalid") {
+      return {
+        ok: false,
+        message: INVALID_APPLE_JWS_PURCHASE_TOKEN_MESSAGE,
+      };
+    }
+    if (purchaseToken.length <= GOOGLE_PURCHASE_TOKEN_MAX_LENGTH) {
+      return { ok: true, purchaseToken };
     }
 
     return {
@@ -278,41 +291,44 @@ function normalizeBindUserPurchaseToken(
   return { ok: false, message: bindUserPurchaseTokenLimitMessage() };
 }
 
-function extractApplePurchaseTokenFromJws(jws: string): string | null {
+function parseApplePurchaseTokenFromJws(jws: string): AppleJwsParseResult {
   if (!isCompactJwsShape(jws) || jws.length > APPLE_JWS_MAX_LENGTH) {
-    return null;
+    return { kind: "notAppleJws" };
   }
 
   try {
-    const [, payloadBase64] = jws.split(".");
-    const payload = JSON.parse(
-      Buffer.from(payloadBase64, "base64url").toString("utf-8"),
-    );
+    const [headerBase64, payloadBase64] = jws.split(".");
+    const header = decodeJwsJsonPart(headerBase64);
+    const payload = decodeJwsJsonPart(payloadBase64);
 
-    if (!isJsonObject(payload)) {
-      return null;
+    if (!isJsonObject(header) || !isJsonObject(payload)) {
+      return { kind: "notAppleJws" };
     }
 
     const originalTransactionId = normalizeTransactionId(
       payload.originalTransactionId,
     );
     if (originalTransactionId) {
-      return originalTransactionId;
+      return { kind: "valid", purchaseToken: originalTransactionId };
     }
 
     const transactionId = normalizeTransactionId(payload.transactionId);
     if (transactionId) {
-      return transactionId;
+      return { kind: "valid", purchaseToken: transactionId };
     }
   } catch {
-    return null;
+    return { kind: "notAppleJws" };
   }
 
-  return null;
+  return { kind: "invalid" };
 }
 
 function isCompactJwsShape(value: string): boolean {
   return APPLE_JWS_PATTERN.test(value);
+}
+
+function decodeJwsJsonPart(part: string): unknown {
+  return JSON.parse(Buffer.from(part, "base64url").toString("utf-8"));
 }
 
 function normalizeTransactionId(value: unknown): string | null {

--- a/packages/kit/server/api/v1/subscriptions.ts
+++ b/packages/kit/server/api/v1/subscriptions.ts
@@ -328,7 +328,12 @@ function isCompactJwsShape(value: string): boolean {
 }
 
 function decodeJwsJsonPart(part: string): unknown {
-  return JSON.parse(Buffer.from(part, "base64url").toString("utf-8"));
+  const raw = Buffer.from(part, "base64url").toString("utf-8");
+  const safeRaw = raw.replace(
+    /"((?:originalT|t)ransactionId)"\s*:\s*(\d+)(?=\s*[,}])/g,
+    '"$1":"$2"',
+  );
+  return JSON.parse(safeRaw);
 }
 
 function normalizeTransactionId(value: unknown): string | null {

--- a/packages/kit/server/api/v1/subscriptions.ts
+++ b/packages/kit/server/api/v1/subscriptions.ts
@@ -5,6 +5,7 @@ import { api } from "@/convex";
 import { client, handleConvexError } from "../../convex";
 import { apiKeyValidationError } from "./middleware";
 import {
+  APPLE_JWS_PATTERN,
   APPLE_JWS_MAX_LENGTH,
   GOOGLE_PURCHASE_TOKEN_MAX_LENGTH,
 } from "./route-input-schemas";
@@ -24,7 +25,8 @@ const subscriptions = new Hono();
 const MAX_USER_ID_LENGTH = 256;
 const MAX_PRODUCT_ID_LENGTH = 256;
 const MAX_BIND_USER_BODY_BYTES = 32 * 1024;
-const COMPACT_JWS_PART_PATTERN = /^[A-Za-z0-9_-]+$/;
+const INVALID_APPLE_JWS_PURCHASE_TOKEN_MESSAGE =
+  "purchaseToken must be a valid Apple JWS containing originalTransactionId or transactionId";
 type SubscriptionState =
   | "Active"
   | "InGracePeriod"
@@ -253,24 +255,24 @@ type BindUserPurchaseTokenResult =
 function normalizeBindUserPurchaseToken(
   purchaseToken: string,
 ): BindUserPurchaseTokenResult {
-  const applePurchaseToken = extractApplePurchaseTokenFromJws(purchaseToken);
-  if (applePurchaseToken) {
-    return { ok: true, purchaseToken: applePurchaseToken };
+  if (isCompactJwsShape(purchaseToken)) {
+    if (purchaseToken.length > APPLE_JWS_MAX_LENGTH) {
+      return { ok: false, message: bindUserPurchaseTokenLimitMessage() };
+    }
+
+    const applePurchaseToken = extractApplePurchaseTokenFromJws(purchaseToken);
+    if (applePurchaseToken) {
+      return { ok: true, purchaseToken: applePurchaseToken };
+    }
+
+    return {
+      ok: false,
+      message: INVALID_APPLE_JWS_PURCHASE_TOKEN_MESSAGE,
+    };
   }
 
   if (purchaseToken.length <= GOOGLE_PURCHASE_TOKEN_MAX_LENGTH) {
     return { ok: true, purchaseToken };
-  }
-
-  if (
-    isCompactJwsShape(purchaseToken) &&
-    purchaseToken.length <= APPLE_JWS_MAX_LENGTH
-  ) {
-    return {
-      ok: false,
-      message:
-        "Apple JWS purchaseToken must include originalTransactionId or transactionId",
-    };
   }
 
   return { ok: false, message: bindUserPurchaseTokenLimitMessage() };
@@ -285,13 +287,22 @@ function extractApplePurchaseTokenFromJws(jws: string): string | null {
     const [, payloadBase64] = jws.split(".");
     const payload = JSON.parse(
       Buffer.from(payloadBase64, "base64url").toString("utf-8"),
-    ) as Record<string, unknown>;
+    );
 
-    if (isNonBlankString(payload.originalTransactionId)) {
-      return payload.originalTransactionId;
+    if (!isJsonObject(payload)) {
+      return null;
     }
-    if (isNonBlankString(payload.transactionId)) {
-      return payload.transactionId;
+
+    const originalTransactionId = normalizeTransactionId(
+      payload.originalTransactionId,
+    );
+    if (originalTransactionId) {
+      return originalTransactionId;
+    }
+
+    const transactionId = normalizeTransactionId(payload.transactionId);
+    if (transactionId) {
+      return transactionId;
     }
   } catch {
     return null;
@@ -301,13 +312,20 @@ function extractApplePurchaseTokenFromJws(jws: string): string | null {
 }
 
 function isCompactJwsShape(value: string): boolean {
-  const parts = value.split(".");
-  return (
-    parts.length === 3 &&
-    parts.every(
-      (part) => part.length > 0 && COMPACT_JWS_PART_PATTERN.test(part),
-    )
-  );
+  return APPLE_JWS_PATTERN.test(value);
+}
+
+function normalizeTransactionId(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
 }
 
 function bindUserPurchaseTokenLimitMessage(): string {

--- a/packages/kit/server/api/v1/subscriptions.ts
+++ b/packages/kit/server/api/v1/subscriptions.ts
@@ -1,8 +1,13 @@
+import { Buffer } from "node:buffer";
 import { Hono, type Context, type Next } from "hono";
 
 import { api } from "@/convex";
 import { client, handleConvexError } from "../../convex";
 import { apiKeyValidationError } from "./middleware";
+import {
+  APPLE_JWS_MAX_LENGTH,
+  GOOGLE_PURCHASE_TOKEN_MAX_LENGTH,
+} from "./route-input-schemas";
 import {
   isContentLengthOverLimit,
   JsonBodyTooLargeError,
@@ -18,8 +23,8 @@ import {
 const subscriptions = new Hono();
 const MAX_USER_ID_LENGTH = 256;
 const MAX_PRODUCT_ID_LENGTH = 256;
-const MAX_PURCHASE_TOKEN_LENGTH = 2_000;
-const MAX_BIND_USER_BODY_BYTES = 8 * 1024;
+const MAX_BIND_USER_BODY_BYTES = 32 * 1024;
+const COMPACT_JWS_PART_PATTERN = /^[A-Za-z0-9_-]+$/;
 type SubscriptionState =
   | "Active"
   | "InGracePeriod"
@@ -199,8 +204,11 @@ subscriptions.post("/bind-user/:apiKey", async (c) => {
   ) {
     return invalidInput(c, "purchaseToken and userId are required");
   }
-  if (!isValidPurchaseTokenLength(payload.purchaseToken)) {
-    return invalidInput(c, "purchaseToken must be ≤ 2000 chars");
+  const normalizedPurchaseToken = normalizeBindUserPurchaseToken(
+    payload.purchaseToken,
+  );
+  if (!normalizedPurchaseToken.ok) {
+    return invalidInput(c, normalizedPurchaseToken.message);
   }
   if (!isValidUserIdLength(payload.userId)) {
     return invalidInput(c, "userId must be ≤ 256 chars");
@@ -208,7 +216,7 @@ subscriptions.post("/bind-user/:apiKey", async (c) => {
   try {
     const result = await client.mutation(api.subscriptions.mutation.bindUser, {
       apiKey,
-      purchaseToken: payload.purchaseToken,
+      purchaseToken: normalizedPurchaseToken.purchaseToken,
       userId: payload.userId,
     });
     return c.json(result);
@@ -238,8 +246,72 @@ function isValidProductIdLength(productId: string): boolean {
   return productId.length <= MAX_PRODUCT_ID_LENGTH;
 }
 
-function isValidPurchaseTokenLength(purchaseToken: string): boolean {
-  return purchaseToken.length <= MAX_PURCHASE_TOKEN_LENGTH;
+type BindUserPurchaseTokenResult =
+  | { ok: true; purchaseToken: string }
+  | { ok: false; message: string };
+
+function normalizeBindUserPurchaseToken(
+  purchaseToken: string,
+): BindUserPurchaseTokenResult {
+  const applePurchaseToken = extractApplePurchaseTokenFromJws(purchaseToken);
+  if (applePurchaseToken) {
+    return { ok: true, purchaseToken: applePurchaseToken };
+  }
+
+  if (purchaseToken.length <= GOOGLE_PURCHASE_TOKEN_MAX_LENGTH) {
+    return { ok: true, purchaseToken };
+  }
+
+  if (
+    isCompactJwsShape(purchaseToken) &&
+    purchaseToken.length <= APPLE_JWS_MAX_LENGTH
+  ) {
+    return {
+      ok: false,
+      message:
+        "Apple JWS purchaseToken must include originalTransactionId or transactionId",
+    };
+  }
+
+  return { ok: false, message: bindUserPurchaseTokenLimitMessage() };
+}
+
+function extractApplePurchaseTokenFromJws(jws: string): string | null {
+  if (!isCompactJwsShape(jws) || jws.length > APPLE_JWS_MAX_LENGTH) {
+    return null;
+  }
+
+  try {
+    const [, payloadBase64] = jws.split(".");
+    const payload = JSON.parse(
+      Buffer.from(payloadBase64, "base64url").toString("utf-8"),
+    ) as Record<string, unknown>;
+
+    if (isNonBlankString(payload.originalTransactionId)) {
+      return payload.originalTransactionId;
+    }
+    if (isNonBlankString(payload.transactionId)) {
+      return payload.transactionId;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function isCompactJwsShape(value: string): boolean {
+  const parts = value.split(".");
+  return (
+    parts.length === 3 &&
+    parts.every(
+      (part) => part.length > 0 && COMPACT_JWS_PART_PATTERN.test(part),
+    )
+  );
+}
+
+function bindUserPurchaseTokenLimitMessage(): string {
+  return `purchaseToken must be ≤ ${GOOGLE_PURCHASE_TOKEN_MAX_LENGTH} chars, or an Apple JWS ≤ ${APPLE_JWS_MAX_LENGTH} chars`;
 }
 
 function isSubscriptionState(state: string): state is SubscriptionState {

--- a/packages/kit/src/pages/docs/sections/operations.tsx
+++ b/packages/kit/src/pages/docs/sections/operations.tsx
@@ -131,13 +131,14 @@ X-RateLimit-Remaining: 599`}
       <ul className="my-3 list-disc space-y-1 pl-6">
         <li>receipt verification body ≤ 32 KB before JSON parsing</li>
         <li>product management body ≤ 64 KB before JSON parsing</li>
-        <li>subscription user-binding body ≤ 8 KB before JSON parsing</li>
+        <li>subscription user-binding body ≤ 32 KB before JSON parsing</li>
         <li>webhook push body ≤ 256 KB before JSON parsing</li>
         <li>
           <code>jws</code> ≤ 16 KB (Apple)
         </li>
         <li>
-          <code>purchaseToken</code> ≤ 2 KB (Google / subscription binding)
+          <code>purchaseToken</code> ≤ 2 KB for Google tokens, or ≤ 16 KB when
+          an Apple JWS is passed to subscription binding
         </li>
         <li>
           <code>userId</code> ≤ 256 chars (Horizon)


### PR DESCRIPTION
## Summary

- Normalize Apple StoreKit JWS values sent as `purchaseToken` to `originalTransactionId` before the subscription bind-user mutation.
- Keep the existing Google purchase token limit while allowing Apple JWS-sized bind-user payloads.
- Update Kit docs and README input-size notes for subscription binding.

Closes #163

## Test plan

- [x] `bun run test server/api/v1/subscriptions.test.ts`
- [x] `bun run lint:tsc`
- [x] `bun run lint:eslint`
- [x] `bun run test`
- [x] `bun run format:check`
- [x] `git diff --check`
- [x] pre-commit gate: SDK parity audit, `bun install --frozen-lockfile`, kit lint, prettier check, tests, smoke server
