### PR TITLE
feat(kit): expose verified product ids

### DIFF
--- a/packages/kit/CONVENTION.md
+++ b/packages/kit/CONVENTION.md
@@ -115,6 +115,20 @@ If you need a localized dashboard for your users, fork and add an
 i18n layer of your choice. Don't reintroduce one upstream without
 discussion — the simplification is intentional, not an oversight.
 
+## IAPKit docs and messaging
+
+- Default positioning: IAPKit is the managed receipt-validation backend
+  that apps can call directly. Describe a customer's own backend
+  entitlement ledger as an optional advanced integration, not the
+  default path.
+- Keep docs concise and contract-driven. Request/response field claims
+  must follow `server/api/v1/route-input-schemas.ts`,
+  `server/api/v1/route-response-schemas.ts`, and Convex validators;
+  update those sources and docs together.
+- For product verification, never imply a client-provided product id is
+  trustworthy. Use the store-verified `productId` and optional
+  `expectedProductId` match guard.
+
 ## Icons
 
 Always use icon components, never inline `<svg>`:

--- a/packages/kit/convex/purchases/android.test.ts
+++ b/packages/kit/convex/purchases/android.test.ts
@@ -90,6 +90,7 @@ describe("Google Play v2 mappings", () => {
       expect(response).toEqual({
         isValid: true,
         state: HarmonizedPurchaseState.ENTITLED,
+        productId: productPurchaseV2Response.productLineItem[0].productId,
       });
     });
   });
@@ -126,6 +127,7 @@ describe("Google Play v2 mappings", () => {
     expect(response).toEqual({
       isValid: true,
       state: HarmonizedPurchaseState.ENTITLED,
+      productId: "untold_premium",
     });
   });
 
@@ -166,6 +168,7 @@ describe("Google Play v2 mappings", () => {
     expect(response).toEqual({
       isValid: false,
       state: HarmonizedPurchaseState.CONSUMED,
+      productId: "dev.hyo.martie.10bulbs",
     });
   });
 
@@ -202,6 +205,7 @@ describe("Google Play v2 mappings", () => {
     expect(response).toEqual({
       isValid: false,
       state: HarmonizedPurchaseState.EXPIRED,
+      productId: "dev.hyo.martie.premium",
     });
   });
 
@@ -242,6 +246,7 @@ describe("Google Play v2 mappings", () => {
     expect(response).toEqual({
       isValid: true,
       state: HarmonizedPurchaseState.PENDING_ACKNOWLEDGMENT,
+      productId: "dev.hyo.martie.10bulbs",
     });
   });
 
@@ -274,6 +279,7 @@ describe("Google Play v2 mappings", () => {
     expect(response).toEqual({
       isValid: false,
       state: HarmonizedPurchaseState.PENDING,
+      productId: "test.product",
     });
   });
 
@@ -311,6 +317,7 @@ describe("Google Play v2 mappings", () => {
     expect(response).toEqual({
       isValid: false,
       state: HarmonizedPurchaseState.CANCELED,
+      productId: "untold_full",
     });
   });
 
@@ -343,6 +350,7 @@ describe("Google Play v2 mappings", () => {
     expect(response).toEqual({
       isValid: false,
       state: HarmonizedPurchaseState.UNKNOWN,
+      productId: "test.product",
     });
   });
 });

--- a/packages/kit/convex/purchases/android.ts
+++ b/packages/kit/convex/purchases/android.ts
@@ -80,7 +80,7 @@ export const verifyGooglePlayReceiptInternalV1 = action({
 
     const keyData = parseAndValidateServiceAccountKey(fileContent.content);
 
-    let requestData: {
+    const requestData: {
       store: "google";
       purchaseToken: string;
       expectedProductId?: string;
@@ -108,14 +108,6 @@ export const verifyGooglePlayReceiptInternalV1 = action({
           packageName,
           purchaseToken: args.purchaseToken,
         });
-
-      requestData = {
-        store: "google" as const,
-        purchaseToken: args.purchaseToken,
-        ...(args.expectedProductId !== undefined
-          ? { expectedProductId: args.expectedProductId }
-          : {}),
-      };
 
       // Persist the store-verified purchase state; `expectedProductId`
       // mismatch is caller-scoped and should not corrupt purchase logs.

--- a/packages/kit/convex/purchases/android.ts
+++ b/packages/kit/convex/purchases/android.ts
@@ -9,6 +9,7 @@ import { Id } from "../_generated/dataModel";
 import {
   getProjectByApiKey,
   mapToGooglePlayReceiptResponse,
+  applyExpectedProductId,
   GooglePlayReceiptData,
   receiptResponseValidator,
   isValidState,
@@ -42,6 +43,7 @@ export const verifyGooglePlayReceiptInternalV1 = action({
   args: {
     apiKey: v.string(),
     purchaseToken: v.string(),
+    expectedProductId: v.optional(v.string()),
     requestIp: v.optional(v.string()),
   },
   returns: receiptResponseValidator,
@@ -78,9 +80,16 @@ export const verifyGooglePlayReceiptInternalV1 = action({
 
     const keyData = parseAndValidateServiceAccountKey(fileContent.content);
 
-    let requestData = {
+    let requestData: {
+      store: "google";
+      purchaseToken: string;
+      expectedProductId?: string;
+    } = {
       store: "google" as const,
       purchaseToken: args.purchaseToken,
+      ...(args.expectedProductId !== undefined
+        ? { expectedProductId: args.expectedProductId }
+        : {}),
     };
 
     try {
@@ -103,9 +112,18 @@ export const verifyGooglePlayReceiptInternalV1 = action({
       requestData = {
         store: "google" as const,
         purchaseToken: args.purchaseToken,
+        ...(args.expectedProductId !== undefined
+          ? { expectedProductId: args.expectedProductId }
+          : {}),
       };
 
-      const receiptResponse = mapToGooglePlayReceiptResponse(receiptData);
+      // Persist the store-verified purchase state; `expectedProductId`
+      // mismatch is caller-scoped and should not corrupt purchase logs.
+      const storeReceiptResponse = mapToGooglePlayReceiptResponse(receiptData);
+      const receiptResponse = applyExpectedProductId(
+        storeReceiptResponse,
+        args.expectedProductId,
+      );
 
       await ctx.runMutation(internal.purchases.internal.saveReceiptInternal, {
         projectId: project._id,
@@ -114,8 +132,8 @@ export const verifyGooglePlayReceiptInternalV1 = action({
         remoteId: receiptData.purchaseToken,
         requestData,
         remoteResponse,
-        state: receiptResponse.state,
-        isValid: isValidState(receiptResponse.state),
+        state: storeReceiptResponse.state,
+        isValid: isValidState(storeReceiptResponse.state),
         requestIp: args.requestIp,
         verificationDurationMs: Date.now() - verificationStart,
       });
@@ -467,6 +485,7 @@ async function persistFailedGoogleReceipt(
     requestData: {
       store: "google";
       purchaseToken: string;
+      expectedProductId?: string;
     };
     requestIp?: string;
     error: ReceiptVerificationError;

--- a/packages/kit/convex/purchases/horizon.ts
+++ b/packages/kit/convex/purchases/horizon.ts
@@ -157,7 +157,7 @@ export const verifyMetaHorizonReceiptInternalV1 = action({
       verificationDurationMs: Date.now() - verificationStart,
     });
 
-    return { isValid: isValidState(state), state };
+    return { isValid: isValidState(state), state, productId: args.sku };
   },
 });
 

--- a/packages/kit/convex/purchases/ios.test.ts
+++ b/packages/kit/convex/purchases/ios.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mapToAppStoreReceiptResponse } from "./shared";
+import { applyExpectedProductId, mapToAppStoreReceiptResponse } from "./shared";
 import { HarmonizedPurchaseState } from "./purchaseState";
 
 describe("App Store mappings (real data)", () => {
@@ -27,6 +27,7 @@ describe("App Store mappings (real data)", () => {
     expect(receipt).toEqual({
       isValid: true,
       state: HarmonizedPurchaseState.ENTITLED,
+      productId: "untold_full_premium",
     });
   });
 
@@ -54,6 +55,7 @@ describe("App Store mappings (real data)", () => {
     expect(receipt).toEqual({
       isValid: true,
       state: HarmonizedPurchaseState.READY_TO_CONSUME,
+      productId: "dev.hyo.martie.10bulbs",
     });
   });
 
@@ -85,6 +87,7 @@ describe("App Store mappings (real data)", () => {
     expect(receipt).toEqual({
       isValid: true,
       state: HarmonizedPurchaseState.ENTITLED,
+      productId: "dev.hyo.martie.premium",
     });
   });
 
@@ -116,6 +119,7 @@ describe("App Store mappings (real data)", () => {
     expect(receipt).toEqual({
       isValid: false,
       state: HarmonizedPurchaseState.EXPIRED,
+      productId: "dev.hyo.martie.premium",
     });
   });
 
@@ -149,6 +153,24 @@ describe("App Store mappings (real data)", () => {
     expect(receipt).toEqual({
       isValid: false,
       state: HarmonizedPurchaseState.CANCELED,
+      productId: "dev.hyo.martie.premium",
+    });
+  });
+
+  it("marks a valid receipt inauthentic when expectedProductId mismatches", () => {
+    const receipt = applyExpectedProductId(
+      {
+        isValid: true,
+        state: HarmonizedPurchaseState.ENTITLED,
+        productId: "dev.hyo.martie.premium",
+      },
+      "dev.hyo.martie.coins",
+    );
+
+    expect(receipt).toEqual({
+      isValid: false,
+      state: HarmonizedPurchaseState.INAUTHENTIC,
+      productId: "dev.hyo.martie.premium",
     });
   });
 });

--- a/packages/kit/convex/purchases/ios.ts
+++ b/packages/kit/convex/purchases/ios.ts
@@ -18,6 +18,7 @@ import { loadAppleRootCertificates } from "../certificates/apple_root_certificat
 import {
   getProjectByApiKey,
   mapToAppStoreReceiptResponse,
+  applyExpectedProductId,
   AppStoreReceiptData,
   receiptResponseValidator,
   isValidState,
@@ -42,6 +43,7 @@ export const verifyAppStoreReceiptInternalV1 = action({
   args: {
     apiKey: v.string(),
     jws: v.string(),
+    expectedProductId: v.optional(v.string()),
     requestIp: v.optional(v.string()),
   },
   returns: receiptResponseValidator,
@@ -52,9 +54,16 @@ export const verifyAppStoreReceiptInternalV1 = action({
     const decodedPayload = decodeJwsPayload(args.jws);
     const environment = decodedPayload.environment as Environment;
 
-    const requestData = {
+    const requestData: {
+      store: "apple";
+      jws: string;
+      expectedProductId?: string;
+    } = {
       store: "apple" as const,
       jws: args.jws,
+      ...(args.expectedProductId !== undefined
+        ? { expectedProductId: args.expectedProductId }
+        : {}),
     };
 
     if (project.iosBundleId === undefined) {
@@ -110,7 +119,13 @@ export const verifyAppStoreReceiptInternalV1 = action({
       hashJws(args.jws);
 
     const serializedResponse = JSON.stringify(transactionData);
-    const receiptResponse = mapToAppStoreReceiptResponse(transactionData);
+    // Persist the store-verified purchase state; `expectedProductId`
+    // mismatch is caller-scoped and should not corrupt purchase logs.
+    const storeReceiptResponse = mapToAppStoreReceiptResponse(transactionData);
+    const receiptResponse = applyExpectedProductId(
+      storeReceiptResponse,
+      args.expectedProductId,
+    );
 
     await ctx.runMutation(internal.purchases.internal.saveReceiptInternal, {
       projectId: project._id,
@@ -119,8 +134,8 @@ export const verifyAppStoreReceiptInternalV1 = action({
       remoteId,
       requestData,
       remoteResponse: serializedResponse,
-      state: receiptResponse.state,
-      isValid: isValidState(receiptResponse.state),
+      state: storeReceiptResponse.state,
+      isValid: isValidState(storeReceiptResponse.state),
       requestIp: args.requestIp,
       verificationDurationMs: Date.now() - verificationStart,
     });
@@ -407,6 +422,7 @@ async function persistFailedAppStoreReceipt(
     requestData: {
       store: "apple";
       jws: string;
+      expectedProductId?: string;
     };
     requestIp?: string;
     error: unknown;

--- a/packages/kit/convex/purchases/shared.ts
+++ b/packages/kit/convex/purchases/shared.ts
@@ -96,6 +96,7 @@ export const purchaseTypeValidator = v.union(
 export const receiptResponseValidator = v.object({
   isValid: v.boolean(),
   state: harmonizedPurchaseStateValidator,
+  productId: v.optional(v.string()),
 });
 
 export async function getProjectByApiKey(ctx: ActionCtx, apiKey: string) {
@@ -164,6 +165,7 @@ export function mapToAppStoreReceiptResponse(
   return {
     isValid: isValidState(state),
     state,
+    ...(receiptData.productId ? { productId: receiptData.productId } : {}),
   };
 }
 
@@ -175,6 +177,25 @@ export function mapToGooglePlayReceiptResponse(
   return {
     isValid: isValidState(state),
     state,
+    productId: receiptData.productId,
+  };
+}
+
+export function applyExpectedProductId(
+  receiptResponse: ReceiptResponse,
+  expectedProductId?: string,
+): ReceiptResponse {
+  if (
+    expectedProductId === undefined ||
+    receiptResponse.productId === expectedProductId
+  ) {
+    return receiptResponse;
+  }
+
+  return {
+    ...receiptResponse,
+    isValid: false,
+    state: HarmonizedPurchaseState.INAUTHENTIC,
   };
 }
 

--- a/packages/kit/convex/schema.ts
+++ b/packages/kit/convex/schema.ts
@@ -29,10 +29,12 @@ export const purchaseRequestDataValidator = v.union(
   v.object({
     store: v.literal("apple"),
     jws: v.string(),
+    expectedProductId: v.optional(v.string()),
   }),
   v.object({
     store: v.literal("google"),
     purchaseToken: v.string(),
+    expectedProductId: v.optional(v.string()),
   }),
   // Meta Horizon (Quest / VR): the client SDK doesn't return a Google-
   // or Apple-style opaque receipt; instead Meta's Graph API verifies

--- a/packages/kit/server/api/v1/replay-guard.test.ts
+++ b/packages/kit/server/api/v1/replay-guard.test.ts
@@ -27,6 +27,20 @@ describe("hashPayload", () => {
     expect(apple).not.toBe(google);
   });
 
+  test("distinguishes product match guards for the same store token", () => {
+    const left = hashPayload({
+      store: "google",
+      purchaseToken: "same-token",
+      expectedProductId: "premium_monthly",
+    });
+    const right = hashPayload({
+      store: "google",
+      purchaseToken: "same-token",
+      expectedProductId: "coins_100",
+    });
+    expect(left).not.toBe(right);
+  });
+
   test("distinguishes Horizon (userId, sku) pairs with a separator", () => {
     // Without the `\0` separator between userId and sku,
     // ("ab", "c") and ("a", "bc") would hash to the same input.

--- a/packages/kit/server/api/v1/replay-guard.ts
+++ b/packages/kit/server/api/v1/replay-guard.ts
@@ -32,14 +32,12 @@ export interface ReplayBucket {
   tokens: number;
   lastRefillMs: number;
   // Set when the most recent verify call for this (key, payload)
-  // returned `isValid: false` from the upstream store. Subsequent
+  // returned `isValid: false`. Subsequent
   // requests for the exact same payload are short-circuited with
   // `REPEATED_FAILURE` until the cooldown expires — re-asking
-  // Apple / Google / Meta about a receipt they already rejected has
-  // no chance of changing the answer in seconds, and an attacker
-  // replaying a captured-then-revoked receipt should hit a hard wall
-  // instead of being able to rotate timing under the per-request
-  // burst cap to keep burning upstream API quota.
+  // Apple / Google / Meta about a receipt they already rejected, or
+  // retrying the same failed product-match guard, has no chance of
+  // changing the answer in seconds.
   lastFailureMs?: number;
 }
 
@@ -71,8 +69,8 @@ export interface ReplayConsumeResult {
  */
 export function hashPayload(
   body:
-    | { store: "apple"; jws: string }
-    | { store: "google"; purchaseToken: string }
+    | { store: "apple"; jws: string; expectedProductId?: string }
+    | { store: "google"; purchaseToken: string; expectedProductId?: string }
     | { store: "horizon"; userId: string; sku: string },
 ): string {
   const hasher = crypto.createHash("sha256");
@@ -81,9 +79,17 @@ export function hashPayload(
   switch (body.store) {
     case "apple":
       hasher.update(body.jws);
+      if (body.expectedProductId !== undefined) {
+        hasher.update("\0");
+        hasher.update(body.expectedProductId);
+      }
       break;
     case "google":
       hasher.update(body.purchaseToken);
+      if (body.expectedProductId !== undefined) {
+        hasher.update("\0");
+        hasher.update(body.expectedProductId);
+      }
       break;
     case "horizon":
       hasher.update(body.userId);
@@ -281,8 +287,8 @@ export function replayGuardMiddleware(
     // Valid-by-schema by the time this runs — the valibot validator
     // upstream guarantees one of the three discriminated shapes.
     const body = c.req.valid("json" as never) as
-      | { store: "apple"; jws: string }
-      | { store: "google"; purchaseToken: string }
+      | { store: "apple"; jws: string; expectedProductId?: string }
+      | { store: "google"; purchaseToken: string; expectedProductId?: string }
       | { store: "horizon"; userId: string; sku: string };
 
     const bucketKey = `${apiKeyHash}:${hashPayload(body)}`;
@@ -304,7 +310,7 @@ export function replayGuardMiddleware(
           : "DUPLICATE_PAYLOAD";
       const message =
         result.reason === "repeated_failure"
-          ? `This receipt was just rejected as invalid by the upstream store; the same payload won't be re-verified for ${result.retryAfterSec}s. If you believe this is wrong, wait the cooldown then retry — the store provider's verdict for a given receipt almost never changes within seconds.`
+          ? `This receipt payload was just rejected; the same payload won't be re-verified for ${result.retryAfterSec}s. If you believe this is wrong, wait the cooldown then retry — store verdicts and product-match guard results almost never change within seconds.`
           : `Too many verifications for the same payload from this API key. Legitimate clients re-verify a receipt at most a handful of times per minute. Retry after ${result.retryAfterSec}s, or cache the previous result on your side.`;
       return c.json(
         {
@@ -318,11 +324,11 @@ export function replayGuardMiddleware(
       await next();
     } finally {
       // After the handler completes, mark the bucket if the upstream
-      // store rejected the receipt. Lives in `finally` so an exception
+      // verification returned invalid. Lives in `finally` so an exception
       // bubbling out of the handler doesn't skip the marking step —
       // we only mark on the explicit `isValid: false` signal so
-      // configuration / network errors aren't conflated with
-      // genuine receipt rejections.
+      // configuration / network errors aren't conflated with stable
+      // receipt or product-match failures.
       const outcome = c.get("verifyOutcome");
       if (outcome && outcome.isValid === false) {
         markPayloadFailure(store, bucketKey, capacity, clock(), maxStoreSize);

--- a/packages/kit/server/api/v1/route-input-schemas.test.ts
+++ b/packages/kit/server/api/v1/route-input-schemas.test.ts
@@ -15,7 +15,11 @@ const VALID_GOOGLE_TOKEN = "a".repeat(40);
 
 describe("verifyPurchaseInputSchema", () => {
   test("accepts a well-formed Apple payload", () => {
-    const result = parse({ store: "apple", jws: VALID_APPLE_JWS });
+    const result = parse({
+      store: "apple",
+      jws: VALID_APPLE_JWS,
+      expectedProductId: "premium.monthly",
+    });
     expect(result.success).toBe(true);
   });
 
@@ -23,6 +27,7 @@ describe("verifyPurchaseInputSchema", () => {
     const result = parse({
       store: "google",
       purchaseToken: VALID_GOOGLE_TOKEN,
+      expectedProductId: "premium.monthly",
     });
     expect(result.success).toBe(true);
   });
@@ -134,6 +139,30 @@ describe("verifyPurchaseInputSchema", () => {
     expect(
       parse({ store: "google", purchaseToken: "<script>alert(1)</script>" })
         .success,
+    ).toBe(false);
+  });
+
+  test("rejects malformed expectedProductId values", () => {
+    expect(
+      parse({
+        store: "google",
+        purchaseToken: VALID_GOOGLE_TOKEN,
+        expectedProductId: "",
+      }).success,
+    ).toBe(false);
+    expect(
+      parse({
+        store: "google",
+        purchaseToken: VALID_GOOGLE_TOKEN,
+        expectedProductId: "bad product",
+      }).success,
+    ).toBe(false);
+    expect(
+      parse({
+        store: "apple",
+        jws: VALID_APPLE_JWS,
+        expectedProductId: "p".repeat(257),
+      }).success,
     ).toBe(false);
   });
 

--- a/packages/kit/server/api/v1/route-input-schemas.ts
+++ b/packages/kit/server/api/v1/route-input-schemas.ts
@@ -6,12 +6,13 @@ import * as v from "valibot";
 // push the Bun server into an OOM by posting a multi-megabyte string.
 // Apple JWS transactions are typically ~1–2 KB; nested subscription
 // payloads stay well under 10 KB. Google purchase tokens are opaque
-// base64 blobs, historically under ~200 chars. Meta Horizon identifies
-// entitlements by (userId, sku) — both short strings.
+// base64 blobs, historically under ~200 chars. Product identifiers and
+// Meta Horizon's (userId, sku) are short strings.
 export const APPLE_JWS_MAX_LENGTH = 16_000;
 export const GOOGLE_PURCHASE_TOKEN_MAX_LENGTH = 2_000;
 const HORIZON_USER_ID_MAX_LENGTH = 256;
 const HORIZON_SKU_MAX_LENGTH = 256;
+const EXPECTED_PRODUCT_ID_MAX_LENGTH = 256;
 
 // Lower bounds — any real token from the respective store sits well
 // above these. A sub-threshold input is guaranteed garbage (empty
@@ -45,6 +46,25 @@ export const APPLE_JWS_PATTERN =
 const GOOGLE_PURCHASE_TOKEN_PATTERN = /^[A-Za-z0-9._~-]+$/;
 const HORIZON_USER_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 const HORIZON_SKU_PATTERN = /^[A-Za-z0-9._-]+$/;
+const EXPECTED_PRODUCT_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+const expectedProductIdSchema = v.optional(
+  v.pipe(
+    v.string(),
+    v.nonEmpty("expectedProductId must not be empty."),
+    v.maxLength(
+      EXPECTED_PRODUCT_ID_MAX_LENGTH,
+      `expectedProductId must be at most ${EXPECTED_PRODUCT_ID_MAX_LENGTH} characters.`,
+    ),
+    v.regex(
+      EXPECTED_PRODUCT_ID_PATTERN,
+      "expectedProductId must contain only letters, digits, '.', '_' or '-'.",
+    ),
+    v.description(
+      "Optional product id that must match the product id verified by the store.",
+    ),
+  ),
+);
 
 export const verifyPurchaseInputSchema = v.variant("store", [
   v.pipe(
@@ -67,6 +87,7 @@ export const verifyPurchaseInputSchema = v.variant("store", [
         ),
         v.description("The JWS token returned with the purchase response."),
       ),
+      expectedProductId: expectedProductIdSchema,
     }),
     v.title("Apple App Store"),
   ),
@@ -92,6 +113,7 @@ export const verifyPurchaseInputSchema = v.variant("store", [
           "The token provided to the user's device when the subscription was purchased.",
         ),
       ),
+      expectedProductId: expectedProductIdSchema,
     }),
     v.title("Google Play Store"),
   ),

--- a/packages/kit/server/api/v1/route-response-schemas.ts
+++ b/packages/kit/server/api/v1/route-response-schemas.ts
@@ -60,6 +60,14 @@ const unifiedPurchaseStateSchema = v.union(
 const baseReceiptResponseSchema = v.object({
   isValid: v.boolean(),
   state: unifiedPurchaseStateSchema,
+  productId: v.optional(
+    v.pipe(
+      v.string(),
+      v.description(
+        "Product id verified by the upstream store. For Meta Horizon this is the SKU IAPKit checked.",
+      ),
+    ),
+  ),
 });
 
 export const verifyPurchaseSuccessResponseSchema = v.pipe(

--- a/packages/kit/server/api/v1/routes.test.ts
+++ b/packages/kit/server/api/v1/routes.test.ts
@@ -1,21 +1,27 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("hono/bun", () => ({
   getConnInfo: () => ({ remote: { address: "127.0.0.1" } }),
 }));
 
+const convexClientMock = vi.hoisted(() => ({
+  action: vi.fn(),
+  mutation: vi.fn(),
+  query: vi.fn(),
+}));
+
 vi.mock("../../convex", () => ({
-  client: {
-    action: vi.fn(),
-    mutation: vi.fn(),
-    query: vi.fn(),
-  },
+  client: convexClientMock,
   handleConvexError: () => null,
 }));
 
 const { apiRoutes } = await import("./routes");
 
 describe("apiRoutes", () => {
+  beforeEach(() => {
+    convexClientMock.action.mockReset();
+  });
+
   it("serves the generated OpenAPI specification", async () => {
     const response = await apiRoutes.request("/openapi");
 
@@ -29,6 +35,42 @@ describe("apiRoutes", () => {
     expect(body.openapi).toBe("3.1.0");
     expect(body.paths["/purchase/verify"]?.post?.operationId).toBe(
       "verifyPurchase",
+    );
+  });
+
+  it("returns the verified productId from purchase verification", async () => {
+    convexClientMock.action.mockResolvedValueOnce({
+      isValid: true,
+      state: "ENTITLED",
+      productId: "premium.monthly",
+    });
+
+    const response = await apiRoutes.request("/purchase/verify", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer route-test-product",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        store: "google",
+        purchaseToken: "token".repeat(8),
+        expectedProductId: "premium.monthly",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      isValid: true,
+      state: "ENTITLED",
+      productId: "premium.monthly",
+    });
+    expect(convexClientMock.action).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        apiKey: "route-test-product",
+        purchaseToken: "token".repeat(8),
+        expectedProductId: "premium.monthly",
+      }),
     );
   });
 });

--- a/packages/kit/server/api/v1/routes.ts
+++ b/packages/kit/server/api/v1/routes.ts
@@ -213,11 +213,16 @@ const verifyPurchaseRouteDescription = describeRoute({
   description:
     "Verify an in-app purchase.\n\n" +
     "Supported request shapes (discriminated on `store`):\n" +
-    '  • Apple  — `{ store: "apple",   jws }`\n' +
-    '  • Google — `{ store: "google",  purchaseToken }`\n' +
+    '  • Apple  — `{ store: "apple",   jws, expectedProductId? }`\n' +
+    '  • Google — `{ store: "google",  purchaseToken, expectedProductId? }`\n' +
     '  • Horizon — `{ store: "horizon", userId, sku }` (Meta Quest;' +
     " IAPKit holds the App ID + App Secret and composes" +
     " `OC|APP_ID|APP_SECRET` server-side)\n\n" +
+    "`expectedProductId` is optional for Apple / Google. When present, " +
+    "IAPKit compares it against the product id verified by the upstream " +
+    'store and returns `isValid: false`, `state: "INAUTHENTIC"` on ' +
+    "mismatch. Successful responses include `productId` when the store " +
+    "response exposes one; for Horizon this is the checked `sku`.\n\n" +
     "Rate limit: per API key, 600 req/min sustained with a 600-request " +
     "burst — sized to let legitimate global apps verify at app-launch " +
     "scale without tripping. In addition, per-(API key, payload) " +
@@ -230,7 +235,8 @@ const verifyPurchaseRouteDescription = describeRoute({
     "before the rate-limit middleware and do not include those " +
     "headers.\n\n" +
     "Input size caps: request body ≤ 32 KB, `jws` ≤ 16 KB, " +
-    "`purchaseToken` ≤ 2 KB, `userId` ≤ 256 chars, `sku` ≤ 256 chars. " +
+    "`purchaseToken` ≤ 2 KB, `expectedProductId` ≤ 256 chars, " +
+    "`userId` ≤ 256 chars, `sku` ≤ 256 chars. " +
     "Oversized fields return `400 INVALID_INPUT`; oversized request " +
     "bodies return `413 PAYLOAD_TOO_LARGE`. Neither hits the upstream store.",
   security: [{ apiKey: [] }],
@@ -326,8 +332,8 @@ const verifyPurchaseRouteDescription = describeRoute({
 });
 
 type VerifyPurchaseJson =
-  | { store: "apple"; jws: string }
-  | { store: "google"; purchaseToken: string }
+  | { store: "apple"; jws: string; expectedProductId?: string }
+  | { store: "google"; purchaseToken: string; expectedProductId?: string }
   | { store: "horizon"; userId: string; sku: string };
 
 // Tell Hono's Context what `c.req.valid("json")` returns for this
@@ -359,12 +365,13 @@ const verifyPurchaseHandler = async (
           {
             apiKey,
             jws: json.jws,
+            expectedProductId: json.expectedProductId,
             requestIp,
           },
         );
 
         setOutcome({ isValid: apple.isValid, state: apple.state });
-        return c.json({ isValid: apple.isValid, state: apple.state });
+        return c.json(apple);
       }
       case "google": {
         const google = await client.action(
@@ -372,12 +379,13 @@ const verifyPurchaseHandler = async (
           {
             apiKey,
             purchaseToken: json.purchaseToken,
+            expectedProductId: json.expectedProductId,
             requestIp,
           },
         );
 
         setOutcome({ isValid: google.isValid, state: google.state });
-        return c.json({ isValid: google.isValid, state: google.state });
+        return c.json(google);
       }
       case "horizon": {
         // Meta Horizon (Quest): the client doesn't hold a
@@ -396,7 +404,7 @@ const verifyPurchaseHandler = async (
         );
 
         setOutcome({ isValid: horizon.isValid, state: horizon.state });
-        return c.json({ isValid: horizon.isValid, state: horizon.state });
+        return c.json(horizon);
       }
     }
   } catch (error) {

--- a/packages/kit/src/components/GeneratedApiKeyNotice.tsx
+++ b/packages/kit/src/components/GeneratedApiKeyNotice.tsx
@@ -30,7 +30,7 @@ export function GeneratedApiKeyNotice({
   const handleCopy = async (): Promise<void> => {
     const ok = await copyTextToClipboard(apiKey.key);
     if (!ok) {
-      toast.message("Copy failed. Select the key manually.");
+      toast.error("Copy failed. Select the key manually.");
       return;
     }
 

--- a/packages/kit/src/components/GeneratedApiKeyNotice.tsx
+++ b/packages/kit/src/components/GeneratedApiKeyNotice.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Check, Copy, KeyRound, X } from "lucide-react";
 import { toast } from "sonner";
 
@@ -20,6 +20,13 @@ export function GeneratedApiKeyNotice({
 }: GeneratedApiKeyNoticeProps) {
   const [copied, setCopied] = useState(false);
 
+  useEffect(() => {
+    if (!copied) return;
+
+    const timer = window.setTimeout(() => setCopied(false), 1_500);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
   const handleCopy = async (): Promise<void> => {
     const ok = await copyTextToClipboard(apiKey.key);
     if (!ok) {
@@ -29,7 +36,6 @@ export function GeneratedApiKeyNotice({
 
     setCopied(true);
     toast.success("API key copied to clipboard");
-    window.setTimeout(() => setCopied(false), 1_500);
   };
 
   return (

--- a/packages/kit/src/components/GeneratedApiKeyNotice.tsx
+++ b/packages/kit/src/components/GeneratedApiKeyNotice.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { Check, Copy, KeyRound, X } from "lucide-react";
+import { toast } from "sonner";
+
+import { copyTextToClipboard } from "@/lib/clipboard";
+
+export interface GeneratedApiKey {
+  name: string;
+  key: string;
+}
+
+interface GeneratedApiKeyNoticeProps {
+  apiKey: GeneratedApiKey;
+  onDismiss: () => void;
+}
+
+export function GeneratedApiKeyNotice({
+  apiKey,
+  onDismiss,
+}: GeneratedApiKeyNoticeProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async (): Promise<void> => {
+    const ok = await copyTextToClipboard(apiKey.key);
+    if (!ok) {
+      toast.message("Copy failed. Select the key manually.");
+      return;
+    }
+
+    setCopied(true);
+    toast.success("API key copied to clipboard");
+    window.setTimeout(() => setCopied(false), 1_500);
+  };
+
+  return (
+    <div className="mb-6 rounded-lg border border-primary/30 bg-primary/5 p-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="mb-2 flex items-center gap-2">
+            <KeyRound className="h-4 w-4 text-primary" />
+            <h3 className="text-sm font-semibold text-foreground">
+              {apiKey.name}
+            </h3>
+          </div>
+          <p className="mb-3 text-sm text-muted-foreground">
+            {"This full key is shown once. Store it before leaving this page."}
+          </p>
+          <code className="block max-w-full select-all overflow-x-auto rounded-md border border-border bg-background px-3 py-2 font-mono text-xs text-foreground">
+            {apiKey.key}
+          </code>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <button
+            type="button"
+            onClick={() => void handleCopy()}
+            className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted"
+          >
+            {copied ? (
+              <Check className="h-4 w-4 text-green-600" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+            {copied ? "Copied" : "Copy"}
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted"
+            aria-label="Dismiss API key"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/kit/src/lib/clipboard.ts
+++ b/packages/kit/src/lib/clipboard.ts
@@ -1,0 +1,16 @@
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.clipboard ||
+    !navigator.clipboard.writeText
+  ) {
+    return false;
+  }
+
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/kit/src/pages/auth/organization/project/apikeys.tsx
+++ b/packages/kit/src/pages/auth/organization/project/apikeys.tsx
@@ -13,6 +13,10 @@ import {
   XCircle,
 } from "lucide-react";
 import { ButtonPrimary } from "@/components/ButtonPrimary";
+import {
+  GeneratedApiKey,
+  GeneratedApiKeyNotice,
+} from "@/components/GeneratedApiKeyNotice";
 import { PageLoading } from "@/components/LoadingSpinner";
 import { MixpanelEvent, trackEvent } from "@/lib/mixpanel";
 
@@ -26,6 +30,9 @@ export default function ApiKeys() {
   const [keyName, setKeyName] = useState("");
   const [keyDescription, setKeyDescription] = useState("");
   const [isCreating, setIsCreating] = useState(false);
+  const [revealedApiKey, setRevealedApiKey] = useState<GeneratedApiKey | null>(
+    null,
+  );
 
   // Get current project
   const currentOrg = useQuery(
@@ -63,10 +70,8 @@ export default function ApiKeys() {
       });
       trackEvent(MixpanelEvent.ApiKeyCreated);
 
-      // Copy the new key to clipboard
-      void navigator.clipboard.writeText(result.key);
-
-      toast.success("API key created and copied to clipboard");
+      setRevealedApiKey({ name: result.name, key: result.key });
+      toast.success("API key created. Copy it below before leaving this page.");
 
       // Reset form
       setKeyName("");
@@ -107,8 +112,10 @@ export default function ApiKeys() {
 
     try {
       const result = await regenerateApiKey({ keyId });
-      void navigator.clipboard.writeText(result.key);
-      toast.success("API key regenerated and copied to clipboard");
+      setRevealedApiKey({ name: result.name, key: result.key });
+      toast.success(
+        "API key regenerated. Copy it below before leaving this page.",
+      );
     } catch {
       toast.error("Failed to regenerate API key");
     }
@@ -137,6 +144,13 @@ export default function ApiKeys() {
           <Plus className="w-5 h-5" />
         </ButtonPrimary>
       </div>
+
+      {revealedApiKey && (
+        <GeneratedApiKeyNotice
+          apiKey={revealedApiKey}
+          onDismiss={() => setRevealedApiKey(null)}
+        />
+      )}
 
       {/* Create Form */}
       {showCreateForm && (

--- a/packages/kit/src/pages/auth/organization/projects/index.tsx
+++ b/packages/kit/src/pages/auth/organization/projects/index.tsx
@@ -22,6 +22,10 @@ import {
 } from "lucide-react";
 import ProjectCard from "./ProjectCard";
 import { ButtonPrimary } from "@/components/ButtonPrimary";
+import {
+  GeneratedApiKey,
+  GeneratedApiKeyNotice,
+} from "@/components/GeneratedApiKeyNotice";
 import { MixpanelEvent, trackEvent } from "@/lib/mixpanel";
 
 const PLATFORM_OPTIONS = [
@@ -118,6 +122,9 @@ export default function Projects() {
     "",
   );
   const [isCreating, setIsCreating] = useState(false);
+  const [revealedApiKey, setRevealedApiKey] = useState<GeneratedApiKey | null>(
+    null,
+  );
 
   const handleCreateProject = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -125,7 +132,7 @@ export default function Projects() {
 
     setIsCreating(true);
     try {
-      await createProject({
+      const result = await createProject({
         organizationId: currentOrg._id,
         name: newProjectName.trim(),
         slug: newProjectSlug.trim() || undefined,
@@ -139,7 +146,11 @@ export default function Projects() {
       setSlugManuallyEdited(false);
       setSelectedPlatform("");
       setShowCreateForm(false);
-      toast.success("Project created successfully!");
+      setRevealedApiKey({
+        name: "Default Production Key",
+        key: result.apiKey,
+      });
+      toast.success("Project created. Copy the default production key below.");
     } catch {
       toast.error("Failed to create project");
     } finally {
@@ -368,6 +379,13 @@ export default function Projects() {
             </div>
           </form>
         </div>
+      )}
+
+      {revealedApiKey && (
+        <GeneratedApiKeyNotice
+          apiKey={revealedApiKey}
+          onDismiss={() => setRevealedApiKey(null)}
+        />
       )}
 
       {/* Projects Grid */}

--- a/packages/kit/src/pages/docs/sections/api.tsx
+++ b/packages/kit/src/pages/docs/sections/api.tsx
@@ -45,6 +45,12 @@ export default function ApiReferencePage() {
         Missing header → <code>401 MISSING_API_KEY</code>. Wrong scheme or
         malformed key → <code>403 INVALID_API_KEY</code>.
       </p>
+      <p>
+        In the default mobile-direct flow, your app sends this key to IAPKit as
+        the managed validation service. If you proxy calls through your own
+        backend instead, keep the key server-side and call the same endpoint
+        from there.
+      </p>
 
       <h2 className="mt-10 text-2xl font-semibold">
         POST <span className="font-mono">/v1/purchase/verify</span>
@@ -62,7 +68,8 @@ export default function ApiReferencePage() {
       <CodeBlock language="javascript">
         {`{
   "store": "apple",
-  "jws": "eyJhbGciOi..."       // JWS token from StoreKit 2 (≤ 16 KB)
+  "jws": "eyJhbGciOi...",      // JWS token from StoreKit 2 (≤ 16 KB)
+  "expectedProductId": "premium_monthly" // optional match guard
 }`}
       </CodeBlock>
 
@@ -70,7 +77,8 @@ export default function ApiReferencePage() {
       <CodeBlock language="javascript">
         {`{
   "store": "google",
-  "purchaseToken": "ljhjpg..."  // Play purchase token (≤ 2 KB)
+  "purchaseToken": "ljhjpg...", // Play purchase token (≤ 2 KB)
+  "expectedProductId": "premium_monthly" // optional match guard
 }`}
       </CodeBlock>
 
@@ -98,15 +106,24 @@ export default function ApiReferencePage() {
       <CodeBlock title="200 OK" language="json">
         {`{
   "isValid": true,
-  "state": "ENTITLED"
+  "state": "ENTITLED",
+  "productId": "premium_monthly"
 }`}
       </CodeBlock>
 
       <p>
-        Your app can unlock local premium state, or your backend can grant its
-        own entitlement, when <code>isValid === true</code>. The{" "}
-        <code>state</code> field carries the harmonized lifecycle position
-        across all three stores:
+        Your app can unlock premium state when <code>isValid === true</code>.{" "}
+        <code>state</code> carries the harmonized lifecycle position across all
+        three stores, and <code>productId</code> is the product id verified by
+        the upstream store. For Meta Horizon, <code>productId</code> is the SKU
+        IAPKit checked.
+      </p>
+      <p>
+        If your own backend keeps an entitlement ledger, do not trust a
+        client-provided product id. Send <code>expectedProductId</code> with the
+        Apple or Google request. IAPKit compares it against the store-verified{" "}
+        <code>productId</code> and returns <code>isValid: false</code> with{" "}
+        <code>state: "INAUTHENTIC"</code> on mismatch.
       </p>
 
       <div className="my-4 overflow-hidden rounded-lg border border-border">
@@ -217,7 +234,7 @@ export default function ApiReferencePage() {
             <tr>
               <td className="px-3 py-2 font-mono text-xs">200</td>
               <td className="px-3 py-2">
-                <code>{`{ isValid, state }`}</code>
+                <code>{`{ isValid, state, productId? }`}</code>
               </td>
               <td className="px-3 py-2">Verification completed.</td>
             </tr>

--- a/packages/kit/src/pages/docs/sections/introduction.tsx
+++ b/packages/kit/src/pages/docs/sections/introduction.tsx
@@ -12,13 +12,13 @@ export default function IntroductionPage() {
       description="IAPKit is a hosted receipt-validation API for Apple, Google, and Meta Horizon purchases. Managed by OpenIAP."
     >
       <p>
-        <strong>IAPKit</strong>, managed by OpenIAP, is a receipt-validation
-        backend that turns a mobile or VR in-app purchase into a signed,
-        server-verified "did this user actually pay" answer. You send a
-        store-specific receipt to <code>/v1/purchase/verify</code>, IAPKit calls
-        the upstream store with credentials it already holds for your project,
-        and returns a normalized <code>{`{ isValid, state }`}</code>
-        result your app can use.
+        <strong>IAPKit</strong>, managed by OpenIAP, is a hosted
+        receipt-validation service for mobile and VR apps that need server-side
+        store verification without building their own receipt server. Your app
+        sends a store-specific receipt to <code>/v1/purchase/verify</code>,
+        IAPKit calls the upstream store with credentials it already holds for
+        your project, and returns a normalized{" "}
+        <code>{`{ isValid, state, productId }`}</code> result your app can use.
       </p>
 
       <h2 className="mt-10 text-2xl font-semibold">When to reach for IAPKit</h2>
@@ -33,11 +33,11 @@ export default function IntroductionPage() {
         stay inside IAPKit, not on a customer device.
       </p>
       <p>
-        IAPKit centralizes those credentials in one place, exposes one API your
-        app calls with a project API key, and harmonizes the three stores' very
-        different response shapes into a single lifecycle: <code>ENTITLED</code>
-        , <code>PENDING_ACKNOWLEDGMENT</code>, <code>CANCELED</code>, and
-        friends.
+        IAPKit centralizes those credentials in one place, exposes one managed
+        API your app can call directly with a project API key, and harmonizes
+        the three stores' very different response shapes into a single
+        lifecycle: <code>ENTITLED</code>, <code>PENDING_ACKNOWLEDGMENT</code>,{" "}
+        <code>CANCELED</code>, and friends.
       </p>
 
       <h2 className="mt-10 text-2xl font-semibold">Supported stores</h2>
@@ -77,7 +77,8 @@ export default function IntroductionPage() {
       Bearer <apiKey>    ───►     verify action      ───►     App Store / Play /
       { store, ... }                                           Meta Graph API
                                                           ◄── verified receipt
-      { isValid, state } ◄───     harmonized state
+      { isValid, state,
+        productId }      ◄───     harmonized state
 `}</code>
       </pre>
 

--- a/packages/kit/src/pages/docs/sections/operations.tsx
+++ b/packages/kit/src/pages/docs/sections/operations.tsx
@@ -149,6 +149,10 @@ X-RateLimit-Remaining: 599`}
         <li>
           <code>productId</code> ≤ 256 chars (catalog / subscriptions)
         </li>
+        <li>
+          <code>expectedProductId</code> ≤ 256 chars (optional Apple / Google
+          verify match guard)
+        </li>
       </ul>
       <p>
         Oversized fields return <code>400 INVALID_INPUT</code>; oversized

--- a/packages/kit/src/pages/docs/sections/projects.tsx
+++ b/packages/kit/src/pages/docs/sections/projects.tsx
@@ -79,7 +79,10 @@ export default function ProjectsPage() {
       <h2 className="mt-10 text-2xl font-semibold">API keys</h2>
       <p>
         When a project is created, IAPKit issues a default production key named{" "}
-        <em>Default Production Key</em>. You can issue additional keys on the{" "}
+        <em>Default Production Key</em>. It is a real active key for that
+        project, not a placeholder. The full value is shown only when the
+        project is created or when a key is regenerated; after that the
+        dashboard shows only a preview. You can issue additional keys on the{" "}
         <strong>API Keys</strong> tab for rotation, separate app builds, CI, or
         staging callers.
       </p>
@@ -112,6 +115,10 @@ export default function ProjectsPage() {
         <li>
           Hashed before logging — the server only retains the SHA-256 prefix in
           structured logs, never the plaintext.
+        </li>
+        <li>
+          Regenerable if the one-time full value was missed or leaked. The old
+          key stops working immediately after regeneration.
         </li>
         <li>
           Scoped to a single project — one key can't verify another project's

--- a/packages/kit/src/pages/docs/sections/quickstart.tsx
+++ b/packages/kit/src/pages/docs/sections/quickstart.tsx
@@ -82,8 +82,9 @@ export default function QuickstartPage() {
       <h2 className="mt-10 text-2xl font-semibold">4. Issue an API key</h2>
       <p>
         The <strong>API Keys</strong> tab lists the project's keys. A default
-        production key is auto-created; you can rotate it or add separate keys
-        for app builds, CI, and staging.
+        production key is auto-created and shown once when the project is
+        created; you can rotate it or add separate keys for app builds, CI, and
+        staging.
       </p>
       <p>
         Keys are credentials for the same project, not separate entitlement
@@ -109,11 +110,12 @@ export default function QuickstartPage() {
 
       <Callout kind="warning" title="Project keys are production-sensitive">
         <p>
-          The project key is designed for apps that use IAPKit as their managed
-          validation backend. Do not commit it to a public repo or log it.
-          Assume embedded keys can be extracted and use separate keys for each
-          app build or environment so you can rotate one from the dashboard if
-          it leaks or is abused. Keep server-side copies in a secret manager.
+          The project key lets your app call IAPKit's managed validation service
+          directly. Do not commit it to a public repo or log it. Assume embedded
+          keys can be extracted and use separate keys for each app build or
+          environment so you can rotate one from the dashboard if it leaks or is
+          abused. If your own backend calls IAPKit instead of the app calling
+          directly, keep that server-side copy in a secret manager.
         </p>
       </Callout>
 
@@ -131,7 +133,8 @@ export default function QuickstartPage() {
   -H "Content-Type: application/json" \\
   -d '{
     "store": "apple",
-    "jws": "eyJhbGciOi..."
+    "jws": "eyJhbGciOi...",
+    "expectedProductId": "premium_monthly"
   }'`}
       </CodeBlock>
 
@@ -141,7 +144,8 @@ export default function QuickstartPage() {
   -H "Content-Type: application/json" \\
   -d '{
     "store": "google",
-    "purchaseToken": "ljhjpg..."
+    "purchaseToken": "ljhjpg...",
+    "expectedProductId": "premium_monthly"
   }'`}
       </CodeBlock>
 
@@ -160,14 +164,16 @@ export default function QuickstartPage() {
       <CodeBlock title="200 OK" language="json">
         {`{
   "isValid": true,
-  "state": "ENTITLED"
+  "state": "ENTITLED",
+  "productId": "premium_monthly"
 }`}
       </CodeBlock>
 
       <p>
-        <code>isValid</code> is the short-circuit answer you'll grant
-        entitlements on; <code>state</code> is the harmonized lifecycle position
-        if you need more granularity. See the{" "}
+        <code>isValid</code> is the short-circuit answer your app can unlock
+        content on; <code>state</code> is the harmonized lifecycle position if
+        you need more granularity, and <code>productId</code> is the product id
+        verified by the store. See the{" "}
         <Link to="/docs/api" className="text-primary underline">
           API reference
         </Link>{" "}

--- a/packages/kit/src/pages/docs/sections/verification-apple.tsx
+++ b/packages/kit/src/pages/docs/sections/verification-apple.tsx
@@ -178,7 +178,8 @@ if (revocationDate !== undefined) {
       >
         {`{
   "isValid": false,
-  "state": "CANCELED"
+  "state": "CANCELED",
+  "productId": "premium_monthly"
 }`}
       </CodeBlock>
 

--- a/packages/kit/src/pages/docs/sections/verification-google.tsx
+++ b/packages/kit/src/pages/docs/sections/verification-google.tsx
@@ -15,7 +15,7 @@ export default function VerificationGooglePage() {
         authenticates with a Google Cloud service account you create once and
         grant narrow permissions to in Google Play Console. The client only
         forwards the opaque <code>purchaseToken</code> from Play Billing — the
-        server resolves product vs. subscription automatically using v2
+        IAPKit server resolves product vs. subscription automatically using v2
         endpoints.
       </p>
 
@@ -109,7 +109,8 @@ export default function VerificationGooglePage() {
   -H "Content-Type: application/json" \\
   -d '{
     "store": "google",
-    "purchaseToken": "ljhjpg..."
+    "purchaseToken": "ljhjpg...",
+    "expectedProductId": "premium_monthly"
   }'`}
       </CodeBlock>
 
@@ -120,6 +121,14 @@ export default function VerificationGooglePage() {
         <code>purchases.subscriptionsv2.get</code>. Either way your client just
         sends the opaque token — there's no need to tell IAPKit whether it's a
         one-shot or a subscription.
+      </p>
+      <p>
+        Google purchase tokens are opaque, so your app or backend should not try
+        to derive the product id from the token. IAPKit returns the{" "}
+        <code>productId</code> that Google verifies. If you already know which
+        product the user is trying to unlock, send{" "}
+        <code>expectedProductId</code> and IAPKit rejects the verification if
+        Google's product id differs.
       </p>
 
       <h2 className="mt-10 text-2xl font-semibold">Transient retries</h2>

--- a/packages/kit/src/pages/landing.tsx
+++ b/packages/kit/src/pages/landing.tsx
@@ -205,7 +205,7 @@ export default function LandingPage() {
                   <CheckCircle2 className="w-5 h-5 text-primary mt-0.5 flex-shrink-0" />
                   <span>
                     {
-                      "Unlock local content or grant backend access only when IAPKit returns a valid response."
+                      "Unlock app content only when IAPKit returns a valid, store-verified response."
                     }
                   </span>
                 </li>
@@ -235,7 +235,8 @@ export default function LandingPage() {
                   <pre className="text-sm md:text-base w-full min-w-0">
                     <code className="block w-full min-w-0">{`{
   "isValid": true,
-  "state": "ENTITLED"
+  "state": "ENTITLED",
+  "productId": "premium_monthly"
 }`}</code>
                   </pre>
                 </div>


### PR DESCRIPTION
## Summary

- Return store-verified `productId` from purchase verification and add Apple / Google `expectedProductId` matching.
- Show generated API keys once in the dashboard with an explicit Copy button instead of automatic clipboard writes.
- Clarify IAPKit docs and package AI guidance around mobile-direct validation, backend ledgers, and non-spoofable product verification.

## Test plan

- [x] `bun run --filter @hyodotdev/openiap-kit lint:tsc`
- [x] `bun run --filter @hyodotdev/openiap-kit lint:eslint`
- [x] `bun run --filter @hyodotdev/openiap-kit format:check`
- [x] `bun run --filter @hyodotdev/openiap-kit test`
- [x] `bun run audit:docs`
- [x] pre-commit kit smoke gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional expectedProductId for Apple/Google verification; responses may include a store-verified productId.
  * API key creation/regeneration shows a one-time in-page notice with copy and dismiss controls.

* **Behavior**
  * expectedProductId mismatch yields isValid: false and state: "INAUTHENTIC".
  * Verification responses now return the full verification payload (including productId when available).

* **Documentation**
  * Updated API reference, quickstart, verification, operations, and introductory docs to cover the new parameter, response field, and input limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->