### PR TITLE
docs: clean up review trigger comments

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -29,6 +29,17 @@ Complete workflow: branch → commit → push → PR
 
 ## Complete Workflow
 
+### Internal Workflow Guard
+
+If the staged changes only touch internal agent/workflow files, do not push or
+create a PR unless the user explicitly asked to publish, PR, or merge them.
+Internal workflow files include `.claude/commands/`, `.codex/skills/`,
+`AGENTS.md`, `CLAUDE.md`, and agent automation notes.
+
+For those internal-only changes, prefer a local commit or local working-tree
+change and report the files changed. If the user explicitly asks to open or
+merge a PR anyway, add appropriate labels before merging.
+
 ### 1. Check Branch
 
 ```bash

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -84,11 +84,36 @@ The automated reviewers (Copilot + Gemini) need a few minutes to produce feedbac
 
 1. Re-fetch unresolved review threads (`gh api repos/{owner}/{repo}/pulls/$PR_NUMBER/comments`).
 2. If new unresolved threads exist → fix them, push, post `/gemini review` again, and schedule another 8-minute wake-up.
-3. If no new unresolved threads exist → the PR is clean. End the loop and report completion to the user.
+3. If no new unresolved threads exist → the PR is clean. Clean up the temporary review-trigger comments, end the loop, and report completion to the user.
 
 Use the `ScheduleWakeup` tool for the wake-up, passing `/review-pr $PR_NUMBER` back as the prompt so the next firing re-enters this skill with full context. Omit the call to stop the loop once all threads are resolved.
 
 Guard against infinite loops: if a reviewer keeps flagging the same finding after two fix attempts, stop scheduling wake-ups and hand back to the user with a summary of what remains disputed.
+
+### Cleanup Review Trigger Comments
+
+When the polling loop ends with no unresolved review threads, delete the temporary top-level comments created only to trigger bot reviews:
+
+- Author comments whose body is exactly `/gemini review`
+- Author comments whose body is exactly `@coderabbitai review`
+- CodeRabbit top-level "Action performed" replies created by those commands (`CodeRabbit review command invocation`)
+
+Do **not** delete inline review replies, actual reviewer summaries, CodeRabbit walkthrough comments, or any comment containing substantive review feedback. The cleanup is only for command noise left in the PR timeline.
+
+Use the issue comments API because PR conversation comments are issue comments:
+
+```bash
+gh api repos/hyodotdev/openiap/issues/$PR_NUMBER/comments --paginate --jq '
+  .[]
+  | select(
+      .body == "/gemini review"
+      or .body == "@coderabbitai review"
+      or (.user.login == "coderabbitai[bot]" and (.body | contains("CodeRabbit review command invocation")))
+    )
+  | .id' | while read comment_id; do
+  [ -n "$comment_id" ] && gh api -X DELETE "repos/hyodotdev/openiap/issues/comments/$comment_id"
+done
+```
 
 ### Replying to Inline Review Comments
 

--- a/.codex/skills/openiap-workflows/SKILL.md
+++ b/.codex/skills/openiap-workflows/SKILL.md
@@ -42,6 +42,18 @@ natural-language requests, execute the matching workflow:
 When a command file gives a sequence, follow it unless the user's newest
 instruction narrows the scope.
 
+## Internal Workflow Change Guard
+
+Internal agent/workflow-only changes include `.claude/commands/`,
+`.codex/skills/`, `AGENTS.md`, `CLAUDE.md`, and agent automation notes. Do not
+create a branch, push, or open a PR for those changes unless the user explicitly
+asks to publish, PR, or merge them.
+
+If a user asks to update an internal workflow and does not explicitly ask for a
+PR, keep the change local and report the changed files. If a PR is already open
+for an internal workflow because the user explicitly requested it, add
+appropriate labels before merging.
+
 ## Non-Negotiables
 
 - Read relevant knowledge and package convention files before editing package or


### PR DESCRIPTION
## Summary
- Document cleanup of temporary /gemini review and @coderabbitai review trigger comments at the end of the review-pr polling loop
- Use issue comments API and avoid deleting substantive review feedback

## Verification
- pre-commit SDK parity audit passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified `/review-pr` docs to describe automatic cleanup of temporary bot-trigger comments once all review threads are resolved.
  * Added guidance to `/commit` docs to avoid opening PRs for changes limited to internal workflow/agent files unless explicitly requested.
  * Added an "Internal Workflow Change Guard" section to skill instructions to keep workflow-only edits local unless publishing is requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->