### PR TITLE
fix(react-native-iap): expose renewal info

### DIFF
--- a/libraries/react-native-iap/ios/RnIapHelper.swift
+++ b/libraries/react-native-iap/ios/RnIapHelper.swift
@@ -334,7 +334,11 @@ enum RnIapHelper {
     }
 
     static func convertRenewalInfo(_ dictionary: [String: Any]) -> NitroSubscriptionRenewalInfo? {
-        guard let autoRenewStatus = boolValue(dictionary["autoRenewStatus"]) else {
+        // OpenIapSerialization.encode(RenewalInfoIOS) emits `willAutoRenew` (see
+        // packages/apple/Sources/Models/Types.swift); guarding on the non-existent
+        // `autoRenewStatus` key dropped the whole renewalInfo, so
+        // subscriptionStatusIOS never exposed autoRenewPreference to JS.
+        guard let autoRenewStatus = boolValue(dictionary["willAutoRenew"]) else {
             return nil
         }
 


### PR DESCRIPTION

## Problem

On iOS, `subscriptionStatusIOS()` always returns statuses whose `renewalInfo` is
`undefined`, so `renewalInfo.autoRenewPreference` can never be read from JS. This makes
it impossible to detect a scheduled plan change (same-group downgrade), which produces
no transaction and no purchase event — the renewal preference is the only signal.

## Cause

A key mismatch in `libraries/react-native-iap/ios/RnIapHelper.swift`:

`convertRenewalInfo` guards on `dictionary["autoRenewStatus"]`, but
`OpenIapSerialization.encode(RenewalInfoIOS)` emits the field as `willAutoRenew`
(`packages/apple/Sources/Models/Types.swift` — `RenewalInfoIOS.willAutoRenew`; there is
no `autoRenewStatus` key). The guard always fails, so the entire `renewalInfo` is
silently dropped before it reaches the Nitro layer.

The sibling converter in the same file, `convertRenewalInfoFromOpenIAP` (used for
purchases / `getActiveSubscriptions`), already reads the correct `willAutoRenew` key —
only the subscription-status path was missed.

## Reproduction (real device, sandbox)

1. Two auto-renewable products in one subscription group.
2. Purchase the higher tier.
3. `requestPurchase` the lower tier and confirm Apple's sheet (a deferred downgrade).
4. Call `subscriptionStatusIOS(sku)`: a status is returned (`state: subscribed`) but
   `renewalInfo` is `undefined` on every call — even though StoreKit's renewal info now
   has `autoRenewPreference` set to the lower-tier product id (verified via
   `getActiveSubscriptions()`, which surfaces it correctly).

## Fix

Read the `willAutoRenew` key in the guard. The Nitro struct field keeps its generated
name (`autoRenewStatus`); only the dictionary key read from the OpenIAP payload changes.
No generated files touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed iOS app not correctly processing subscription auto-renewal status, ensuring renewal information is properly captured and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->