### PR TITLE
fix(flutter): repair android gradle fallback build

### DIFF
--- a/.github/workflows/ci-flutter-inapp-purchase.yml
+++ b/.github/workflows/ci-flutter-inapp-purchase.yml
@@ -36,7 +36,7 @@ jobs:
           flutter-version: "3.41.9"
           cache: true
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: "temurin"
           java-version: "17"

--- a/.github/workflows/ci-flutter-inapp-purchase.yml
+++ b/.github/workflows/ci-flutter-inapp-purchase.yml
@@ -36,6 +36,11 @@ jobs:
           flutter-version: "3.41.9"
           cache: true
 
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
       - name: Install dependencies
         run: flutter pub get
 
@@ -44,3 +49,6 @@ jobs:
 
       - name: Test
         run: flutter test
+
+      - name: Android consumer build smoke test
+        run: bash scripts/verify-android-consumer-build.sh

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -29,7 +29,7 @@ jobs:
           flutter-version: "3.41.9"
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: "temurin"
           java-version: "17"

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -28,8 +28,17 @@ jobs:
           channel: "stable"
           flutter-version: "3.41.9"
 
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
       - name: Install dependencies
         run: flutter pub get
+
+      - name: Android consumer build smoke test
+        run: bash scripts/verify-android-consumer-build.sh
 
       - name: Check if pub.dev package already published
         id: check_pub

--- a/.github/workflows/release-flutter.yml
+++ b/.github/workflows/release-flutter.yml
@@ -67,6 +67,10 @@ jobs:
         working-directory: libraries/flutter_inapp_purchase/example
         run: flutter build apk --debug
 
+      - name: Android consumer build smoke test
+        working-directory: libraries/flutter_inapp_purchase
+        run: bash scripts/verify-android-consumer-build.sh
+
   validate-ios:
     if: github.ref == 'refs/heads/main'
     runs-on: macos-15

--- a/libraries/flutter_inapp_purchase/android/build.gradle
+++ b/libraries/flutter_inapp_purchase/android/build.gradle
@@ -82,6 +82,14 @@ buildscript {
         return properties.getProperty(propertyName)
     }
 
+    def readRequiredAndroidGradleProperty = { File androidDir, String propertyName ->
+        def value = readGradleProperty(propertyName)
+        if (value == null || value.toString().trim().isEmpty()) {
+            throw new GradleException("flutter_inapp_purchase: missing ${propertyName} in android/gradle.properties")
+        }
+        return value.toString().trim()
+    }
+
     def googlePluginVersion = { String pluginId ->
         File googleRootBuildFile = locateGoogleRootBuildFile(projectDir)
         if (googleRootBuildFile == null) {
@@ -138,7 +146,7 @@ android {
         targetSdkVersion = openIapTargetSdkVersion
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        // Use horizonEnabled to determine platform flavor
+        // Select the local :openiap flavor when developing inside the monorepo.
         def flavor = horizonEnabled ? 'horizon' : 'play'
         missingDimensionStrategy "platform", flavor
     }
@@ -153,18 +161,6 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    flavorDimensions "platform"
-    productFlavors {
-        // Play flavor - Google Play Billing (default)
-        play {
-            dimension "platform"
-            isDefault = true
-        }
-        // Horizon flavor - Meta Horizon Billing
-        horizon {
-            dimension "platform"
-        }
-    }
 }
 
 kotlin {

--- a/libraries/flutter_inapp_purchase/android/build.gradle
+++ b/libraries/flutter_inapp_purchase/android/build.gradle
@@ -72,18 +72,14 @@ buildscript {
         return null
     }
 
-    def readGradleProperty = { String propertyName ->
-        File propertiesFile = new File(projectDir, 'gradle.properties')
+    def readRequiredAndroidGradleProperty = { File androidDir, String propertyName ->
+        File propertiesFile = new File(androidDir, 'gradle.properties')
         if (!propertiesFile.isFile()) {
-            return null
+            throw new GradleException("flutter_inapp_purchase: missing android/gradle.properties")
         }
         Properties properties = new Properties()
         propertiesFile.withInputStream { properties.load(it) }
-        return properties.getProperty(propertyName)
-    }
-
-    def readRequiredAndroidGradleProperty = { File androidDir, String propertyName ->
-        def value = readGradleProperty(propertyName)
+        def value = properties.getProperty(propertyName)
         if (value == null || value.toString().trim().isEmpty()) {
             throw new GradleException("flutter_inapp_purchase: missing ${propertyName} in android/gradle.properties")
         }

--- a/libraries/flutter_inapp_purchase/scripts/verify-android-consumer-build.sh
+++ b/libraries/flutter_inapp_purchase/scripts/verify-android-consumer-build.sh
@@ -14,13 +14,22 @@ trap cleanup EXIT
 package_copy="$tmp_root/flutter_inapp_purchase"
 consumer_app="$tmp_root/openiap_consumer_smoke"
 
-mkdir -p "$package_copy"
+cp -R "$package_root" "$tmp_root/"
+rm -rf \
+  "$package_copy/.build" \
+  "$package_copy/.dart_tool" \
+  "$package_copy/android/.gradle" \
+  "$package_copy/android/build" \
+  "$package_copy/build" \
+  "$package_copy/example/.dart_tool" \
+  "$package_copy/example/android/.gradle" \
+  "$package_copy/example/android/build" \
+  "$package_copy/example/build"
 
-git -C "$repo_root" ls-files libraries/flutter_inapp_purchase | while IFS= read -r source_path; do
-  relative_path="${source_path#libraries/flutter_inapp_purchase/}"
-  mkdir -p "$package_copy/$(dirname "$relative_path")"
-  cp -L "$repo_root/$source_path" "$package_copy/$relative_path"
-done
+if [ -L "$package_copy/openiap-versions.json" ]; then
+  rm "$package_copy/openiap-versions.json"
+  cp "$repo_root/openiap-versions.json" "$package_copy/openiap-versions.json"
+fi
 
 flutter create --platforms=android -t app --project-name openiap_consumer_smoke "$consumer_app"
 
@@ -40,7 +49,7 @@ flutter create --platforms=android -t app --project-name openiap_consumer_smoke 
   if [ -n "$android_sdk_root" ] &&
     [ -d "$android_sdk_root/ndk/27.0.12077973" ] &&
     [ -f android/app/build.gradle.kts ]; then
-    perl -0pi -e 's/ndkVersion = flutter\.ndkVersion/ndkVersion = "27.0.12077973"/' android/app/build.gradle.kts
+    perl -0pi -e 's/ndkVersion\s*=\s*flutter\.ndkVersion/ndkVersion = "27.0.12077973"/' android/app/build.gradle.kts
   fi
 
   flutter build apk --debug

--- a/libraries/flutter_inapp_purchase/scripts/verify-android-consumer-build.sh
+++ b/libraries/flutter_inapp_purchase/scripts/verify-android-consumer-build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+package_root="$(cd "$script_dir/.." && pwd)"
+repo_root="$(git -C "$package_root" rev-parse --show-toplevel)"
+tmp_root="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_root"
+}
+trap cleanup EXIT
+
+package_copy="$tmp_root/flutter_inapp_purchase"
+consumer_app="$tmp_root/openiap_consumer_smoke"
+
+mkdir -p "$package_copy"
+
+git -C "$repo_root" ls-files libraries/flutter_inapp_purchase | while IFS= read -r source_path; do
+  relative_path="${source_path#libraries/flutter_inapp_purchase/}"
+  mkdir -p "$package_copy/$(dirname "$relative_path")"
+  cp -L "$repo_root/$source_path" "$package_copy/$relative_path"
+done
+
+flutter create --platforms=android -t app --project-name openiap_consumer_smoke "$consumer_app"
+
+(
+  cd "$consumer_app"
+  flutter pub add flutter_inapp_purchase --path "$package_copy"
+
+  # Match the bundled example when that NDK is installed; this avoids local
+  # Flutter defaults selecting a partially installed newer NDK.
+  android_sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+  if [ -z "$android_sdk_root" ] && [ -d "$HOME/Library/Android/sdk" ]; then
+    android_sdk_root="$HOME/Library/Android/sdk"
+  elif [ -z "$android_sdk_root" ] && [ -d "$HOME/Android/Sdk" ]; then
+    android_sdk_root="$HOME/Android/Sdk"
+  fi
+
+  if [ -n "$android_sdk_root" ] &&
+    [ -d "$android_sdk_root/ndk/27.0.12077973" ] &&
+    [ -f android/app/build.gradle.kts ]; then
+    perl -0pi -e 's/ndkVersion = flutter\.ndkVersion/ndkVersion = "27.0.12077973"/' android/app/build.gradle.kts
+  fi
+
+  flutter build apk --debug
+)

--- a/libraries/flutter_inapp_purchase/scripts/verify-android-consumer-build.sh
+++ b/libraries/flutter_inapp_purchase/scripts/verify-android-consumer-build.sh
@@ -47,9 +47,12 @@ flutter create --platforms=android -t app --project-name openiap_consumer_smoke 
   fi
 
   if [ -n "$android_sdk_root" ] &&
-    [ -d "$android_sdk_root/ndk/27.0.12077973" ] &&
-    [ -f android/app/build.gradle.kts ]; then
-    perl -0pi -e 's/ndkVersion\s*=\s*flutter\.ndkVersion/ndkVersion = "27.0.12077973"/' android/app/build.gradle.kts
+    [ -d "$android_sdk_root/ndk/27.0.12077973" ]; then
+    if [ -f android/app/build.gradle.kts ]; then
+      perl -0pi -e 's/ndkVersion\s*=\s*flutter\.ndkVersion/ndkVersion = "27.0.12077973"/' android/app/build.gradle.kts
+    elif [ -f android/app/build.gradle ]; then
+      perl -0pi -e 's/ndkVersion\s+flutter\.ndkVersion/ndkVersion "27.0.12077973"/' android/app/build.gradle
+    fi
   fi
 
   flutter build apk --debug

--- a/libraries/flutter_inapp_purchase/scripts/verify-android-consumer-build.sh
+++ b/libraries/flutter_inapp_purchase/scripts/verify-android-consumer-build.sh
@@ -7,7 +7,9 @@ repo_root="$(git -C "$package_root" rev-parse --show-toplevel)"
 tmp_root="$(mktemp -d)"
 
 cleanup() {
-  rm -rf "$tmp_root"
+  if [ -n "${tmp_root:-}" ] && [ -d "$tmp_root" ]; then
+    rm -rf "$tmp_root"
+  fi
 }
 trap cleanup EXIT
 

--- a/libraries/flutter_inapp_purchase/scripts/verify-android-consumer-build.sh
+++ b/libraries/flutter_inapp_purchase/scripts/verify-android-consumer-build.sh
@@ -28,10 +28,8 @@ rm -rf \
   "$package_copy/example/android/build" \
   "$package_copy/example/build"
 
-if [ -L "$package_copy/openiap-versions.json" ]; then
-  rm "$package_copy/openiap-versions.json"
-  cp "$repo_root/openiap-versions.json" "$package_copy/openiap-versions.json"
-fi
+rm -f "$package_copy/openiap-versions.json"
+cp "$repo_root/openiap-versions.json" "$package_copy/openiap-versions.json"
 
 flutter create --platforms=android -t app --project-name openiap_consumer_smoke "$consumer_app"
 
@@ -51,9 +49,9 @@ flutter create --platforms=android -t app --project-name openiap_consumer_smoke 
   if [ -n "$android_sdk_root" ] &&
     [ -d "$android_sdk_root/ndk/27.0.12077973" ]; then
     if [ -f android/app/build.gradle.kts ]; then
-      perl -0pi -e 's/ndkVersion\s*=\s*flutter\.ndkVersion/ndkVersion = "27.0.12077973"/' android/app/build.gradle.kts
+      perl -pi -e 's/ndkVersion\s*=\s*flutter\.ndkVersion/ndkVersion = "27.0.12077973"/' android/app/build.gradle.kts
     elif [ -f android/app/build.gradle ]; then
-      perl -0pi -e 's/ndkVersion\s+flutter\.ndkVersion/ndkVersion "27.0.12077973"/' android/app/build.gradle
+      perl -pi -e 's/ndkVersion\s*=?\s*flutter\.ndkVersion/ndkVersion = "27.0.12077973"/' android/app/build.gradle
     fi
   fi
 

--- a/packages/docs/src/generated/version-metadata.json
+++ b/packages/docs/src/generated/version-metadata.json
@@ -1,7 +1,7 @@
 {
   "_generatedBy": "scripts/sync-versions.sh",
   "expoPackageVersion": "4.3.1",
-  "reactNativePackageVersion": "15.3.1",
+  "reactNativePackageVersion": "15.3.2",
   "flutterPackageVersion": "9.3.1",
   "godotPackageVersion": "2.3.1",
   "kmpPackageVersion": "2.3.1",

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -1738,7 +1738,7 @@ function checkFrameworkDependencyHygiene() {
     "if: steps.check_pub.outputs.exists == 'false'",
   ], 'Flutter publish workflow must support pub.dev release reruns');
   for (const flutterWorkflow of [
-    '.github/workflows/ci-flutter-iap.yml',
+    '.github/workflows/ci-flutter-inapp-purchase.yml',
     '.github/workflows/release-flutter.yml',
     '.github/workflows/publish-flutter.yml',
   ]) {


### PR DESCRIPTION
## Summary

- fixes pub.dev consumer builds by reading Android Gradle fallback properties inside `buildscript {}` scope
- removes Flutter plugin product flavors so regular Android apps do not hit play/horizon variant ambiguity
- adds an Android consumer smoke test that copies the package outside the monorepo, installs it into a fresh Flutter app, and builds a debug APK before PR/release/publish paths can pass

Closes #171

## Test plan

- [x] `bun audit:parity`
- [x] `cd libraries/flutter_inapp_purchase && flutter analyze`
- [x] `cd libraries/flutter_inapp_purchase && flutter test`
- [x] `cd libraries/flutter_inapp_purchase/example && flutter build apk --debug`
- [x] `bash libraries/flutter_inapp_purchase/scripts/verify-android-consumer-build.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Provisioned Java 17 in Flutter CI and publish workflows.
  * Hardened Android build configuration to require key build properties and improve compatibility.
  * Expanded CI audit coverage to include the new Flutter workflow.

* **Tests**
  * Added Android consumer build smoke tests across CI, publish, and release pipelines.
  * Added a local verification script to generate and build a consumer Android app for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->