### PR TITLE
test(ci): add npm consumer smoke tests

### DIFF
--- a/.github/workflows/ci-expo-iap.yml
+++ b/.github/workflows/ci-expo-iap.yml
@@ -76,3 +76,6 @@ jobs:
 
       - name: Test plugin
         run: bun run test:plugin
+
+      - name: Consumer install smoke test
+        run: bun run verify:consumer-install

--- a/.github/workflows/ci-react-native-iap.yml
+++ b/.github/workflows/ci-react-native-iap.yml
@@ -78,3 +78,6 @@ jobs:
 
       - name: Test
         run: yarn test
+
+      - name: Consumer install smoke test
+        run: yarn verify:consumer-install

--- a/.github/workflows/release-expo.yml
+++ b/.github/workflows/release-expo.yml
@@ -277,6 +277,9 @@ jobs:
             cp --remove-destination "$(readlink openiap-versions.json)" openiap-versions.json
           fi
 
+      - name: Consumer install smoke test
+        run: bun run verify:consumer-install --pack-ignore-scripts
+
       - name: Ensure npm CLI v11.5.1 or later (required for OIDC)
         run: npm install -g npm@11.5.1
 

--- a/.github/workflows/release-react-native.yml
+++ b/.github/workflows/release-react-native.yml
@@ -273,6 +273,9 @@ jobs:
             cp --remove-destination "$(readlink openiap-versions.json)" openiap-versions.json
           fi
 
+      - name: Consumer install smoke test
+        run: node .yarn/releases/yarn-3.6.1.cjs verify:consumer-install --pack-ignore-scripts
+
       - name: Ensure npm CLI v11.5.1 or later (required for OIDC)
         run: npm install -g npm@11.5.1
 

--- a/libraries/expo-iap/package.json
+++ b/libraries/expo-iap/package.json
@@ -16,6 +16,7 @@
     "test": "jest && bun run test:plugin",
     "test:plugin": "cd plugin && bunx jest",
     "test:coverage": "jest --coverage",
+    "verify:consumer-install": "node ../../scripts/verify-npm-consumer-install.mjs --package . --package-name expo-iap --required openiap-versions.json --required build/index.js --required build/index.d.ts --required android/build.gradle --required ios/ExpoIap.podspec --required app.plugin.js --required plugin/build/withIAP.js",
     "prepare": "bun run clean:plugin && bun run clean && expo-module prepare && sh -c 'command -v husky >/dev/null 2>&1 && husky install || { echo \"husky not installed; skipping\"; exit 0; }'",
     "expo-module": "expo-module",
     "open:ios": "xed example/ios",

--- a/libraries/react-native-iap/package.json
+++ b/libraries/react-native-iap/package.json
@@ -63,6 +63,7 @@
     "test:all": "yarn test:library && yarn test:example",
     "test:ci": "jest --maxWorkers=2 --coverage",
     "test:ci:example": "yarn workspace rn-iap-example test --coverage",
+    "verify:consumer-install": "node ../../scripts/verify-npm-consumer-install.mjs --package . --package-name react-native-iap --required openiap-versions.json --required lib/module/index.js --required lib/typescript/src/index.d.ts --required android/build.gradle --required NitroIap.podspec --required app.plugin.js --required nitro.json",
     "prepare:husky": "husky install",
     "precommit": "lint-staged",
     "ci:check": "./scripts/ci-check.sh",

--- a/packages/docs/src/generated/version-metadata.json
+++ b/packages/docs/src/generated/version-metadata.json
@@ -2,7 +2,7 @@
   "_generatedBy": "scripts/sync-versions.sh",
   "expoPackageVersion": "4.3.1",
   "reactNativePackageVersion": "15.3.2",
-  "flutterPackageVersion": "9.3.1",
+  "flutterPackageVersion": "9.3.2",
   "godotPackageVersion": "2.3.1",
   "kmpPackageVersion": "2.3.1",
   "mauiPackageId": "OpenIap.Maui",

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -1729,6 +1729,36 @@ function checkFrameworkDependencyHygiene() {
       'NPM_STATUS=$?',
     ], `${npmReleaseWorkflow} must not drift npm trusted-publishing CLI version`);
   }
+  expectIncludes('scripts/verify-npm-consumer-install.mjs', [
+    'npm',
+    'pack',
+    '--pack-destination',
+    '--ignore-scripts',
+    'openiap-versions.json must be packed as a real file',
+    'consumer install smoke test passed',
+  ], 'npm consumer install smoke helper');
+  for (const [packageJsonPath, packageName] of [
+    ['libraries/expo-iap/package.json', 'expo-iap'],
+    ['libraries/react-native-iap/package.json', 'react-native-iap'],
+  ]) {
+    expectIncludes(packageJsonPath, [
+      '"verify:consumer-install"',
+      'verify-npm-consumer-install.mjs',
+      `--package-name ${packageName}`,
+      '--required openiap-versions.json',
+    ], `${packageJsonPath} must expose npm consumer smoke test`);
+  }
+  for (const [workflowPath, command] of [
+    ['.github/workflows/ci-expo-iap.yml', 'bun run verify:consumer-install'],
+    ['.github/workflows/ci-react-native-iap.yml', 'yarn verify:consumer-install'],
+    ['.github/workflows/release-expo.yml', 'bun run verify:consumer-install --pack-ignore-scripts'],
+    ['.github/workflows/release-react-native.yml', 'verify:consumer-install --pack-ignore-scripts'],
+  ]) {
+    expectIncludes(workflowPath, [
+      'Consumer install smoke test',
+      command,
+    ], `${workflowPath} must run npm consumer smoke test`);
+  }
   expectIncludes('.github/workflows/publish-flutter.yml', [
     'Check if pub.dev package already published',
     'flutter-version: "3.41.9"',

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -313,6 +313,7 @@ if (sourcePackageJson.name !== options.packageName) {
 
 let tempRoot = null;
 let restoreVersionFile = () => {};
+let success = false;
 
 try {
   tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), `${options.packageName.replaceAll('/', '-')}-consumer-`));
@@ -354,16 +355,22 @@ try {
   const installedRoot = packageInstallDir(consumerRoot, options.packageName);
   validateInstalledPackage(installedRoot, options);
   console.log(`${options.packageName} consumer install smoke test passed.`);
+  success = true;
 } finally {
-  let restoreError = null;
+  let cleanupError = null;
   try {
     restoreVersionFile();
   } catch (error) {
-    restoreError = error;
+    cleanupError = error;
     console.error('Failed to restore version file:', error);
   }
   if (tempRoot && !readBooleanEnv('OPENIAP_KEEP_NPM_CONSUMER_SMOKE_TMP')) {
-    fs.rmSync(tempRoot, {recursive: true, force: true});
+    try {
+      fs.rmSync(tempRoot, {recursive: true, force: true});
+    } catch (error) {
+      cleanupError ??= error;
+      console.error('Failed to clean up temp directory:', error);
+    }
   }
-  if (restoreError) throw restoreError;
+  if (success && cleanupError) throw cleanupError;
 }

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -191,7 +191,10 @@ function packageInstallDir(consumerRoot, packageName) {
 
 function collectExportPaths(value, paths = []) {
   if (typeof value === 'string') {
-    if (value.startsWith('./')) paths.push(value.slice(2));
+    if (value.startsWith('./')) {
+      const exportPath = value.slice(2);
+      if (exportPath.length > 0) paths.push(exportPath);
+    }
     return paths;
   }
   if (value && typeof value === 'object') {

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -12,6 +12,16 @@ function readArgValue(argv, index, flag) {
   return value;
 }
 
+function readBooleanEnv(name) {
+  const value = process.env[name];
+  if (typeof value !== 'string' || value.length === 0) return false;
+  return !['0', 'false', 'no', 'off'].includes(value.toLowerCase());
+}
+
+function consumerPackageName(packageName) {
+  return `${packageName.replace(/^@/, '').replaceAll('/', '-')}-consumer-smoke`;
+}
+
 function parseArgs(argv) {
   const options = {
     packagePath: null,
@@ -52,11 +62,12 @@ function run(command, args, cwd) {
     cwd,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    shell: process.platform === 'win32',
   });
   if (result.error) {
     throw new Error(`Failed to execute ${command} ${args.join(' ')}: ${result.error.message}`);
   }
-  const verbose = process.env.OPENIAP_VERBOSE_NPM_CONSUMER_SMOKE;
+  const verbose = readBooleanEnv('OPENIAP_VERBOSE_NPM_CONSUMER_SMOKE');
   if (verbose && result.stdout) process.stdout.write(result.stdout);
   if (verbose && result.stderr) process.stderr.write(result.stderr);
   if (result.status !== 0) {
@@ -252,7 +263,7 @@ try {
   fs.writeFileSync(
     path.join(consumerRoot, 'package.json'),
     `${JSON.stringify({
-      name: `${options.packageName.replaceAll('/', '-')}-consumer-smoke`,
+      name: consumerPackageName(options.packageName),
       private: true,
       type: 'module',
       dependencies: {
@@ -275,7 +286,7 @@ try {
   console.log(`${options.packageName} consumer install smoke test passed.`);
 } finally {
   restoreVersionFile();
-  if (tempRoot && !process.env.OPENIAP_KEEP_NPM_CONSUMER_SMOKE_TMP) {
+  if (tempRoot && !readBooleanEnv('OPENIAP_KEEP_NPM_CONSUMER_SMOKE_TMP')) {
     fs.rmSync(tempRoot, {recursive: true, force: true});
   }
 }

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -63,6 +63,7 @@ function run(command, args, cwd) {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     shell: process.platform === 'win32',
+    maxBuffer: 10 * 1024 * 1024,
   });
   if (result.error) {
     throw new Error(`Failed to execute ${command} ${args.join(' ')}: ${result.error.message}`);
@@ -214,7 +215,7 @@ function validateInstalledPackage(installedRoot, options) {
     }
     const versions = JSON.parse(fs.readFileSync(versionFile, 'utf8'));
     for (const key of ['spec', 'google', 'apple']) {
-      if (typeof versions[key] !== 'string' || versions[key].length === 0) {
+      if (typeof versions[key] !== 'string' || versions[key].trim().length === 0) {
         throw new Error(`openiap-versions.json is missing ${key}`);
       }
     }

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {spawnSync} from 'node:child_process';
+
+function parseArgs(argv) {
+  const options = {
+    packagePath: null,
+    packageName: null,
+    required: [],
+    forbid: [],
+    packIgnoreScripts: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--package') {
+      options.packagePath = argv[++i];
+    } else if (arg === '--package-name') {
+      options.packageName = argv[++i];
+    } else if (arg === '--required') {
+      options.required.push(argv[++i]);
+    } else if (arg === '--forbid') {
+      options.forbid.push(argv[++i]);
+    } else if (arg === '--pack-ignore-scripts') {
+      options.packIgnoreScripts = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.packagePath) throw new Error('Missing --package');
+  if (!options.packageName) throw new Error('Missing --package-name');
+  return options;
+}
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const verbose = process.env.OPENIAP_VERBOSE_NPM_CONSUMER_SMOKE;
+  if (verbose && result.stdout) process.stdout.write(result.stdout);
+  if (verbose && result.stderr) process.stderr.write(result.stderr);
+  if (result.status !== 0) {
+    if (!verbose && result.stdout) process.stdout.write(result.stdout);
+    if (!verbose && result.stderr) process.stderr.write(result.stderr);
+    throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`);
+  }
+  return result.stdout;
+}
+
+function stripAnsi(value) {
+  return value.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+function parseNpmPackJson(stdout) {
+  const clean = stripAnsi(stdout).trim();
+  for (let index = clean.lastIndexOf('['); index >= 0; index = clean.lastIndexOf('[', index - 1)) {
+    try {
+      const parsed = JSON.parse(clean.slice(index));
+      if (Array.isArray(parsed) && parsed[0]?.filename) return parsed[0];
+    } catch {
+      // Keep scanning; package lifecycle scripts can print arbitrary output.
+    }
+  }
+  throw new Error('Unable to parse npm pack --json output');
+}
+
+function assertFile(filePath, label = filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing ${label}`);
+  }
+}
+
+function packageInstallDir(consumerRoot, packageName) {
+  if (packageName.startsWith('@')) {
+    const [scope, name] = packageName.split('/');
+    return path.join(consumerRoot, 'node_modules', scope, name);
+  }
+  return path.join(consumerRoot, 'node_modules', packageName);
+}
+
+function collectExportPaths(value, paths = []) {
+  if (typeof value === 'string') {
+    if (value.startsWith('./')) paths.push(value.slice(2));
+    return paths;
+  }
+  if (value && typeof value === 'object') {
+    for (const nested of Object.values(value)) collectExportPaths(nested, paths);
+  }
+  return paths;
+}
+
+function listFiles(dir) {
+  const result = [];
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...listFiles(fullPath));
+    } else if (entry.isFile()) {
+      result.push(fullPath);
+    }
+  }
+  return result;
+}
+
+function prepareVersionFile(packageRoot) {
+  const versionFile = path.join(packageRoot, 'openiap-versions.json');
+  if (!fs.existsSync(versionFile)) return () => {};
+
+  const stat = fs.lstatSync(versionFile);
+  if (!stat.isSymbolicLink()) return () => {};
+
+  const target = fs.readlinkSync(versionFile);
+  const resolvedTarget = path.resolve(path.dirname(versionFile), target);
+  fs.rmSync(versionFile);
+  fs.copyFileSync(resolvedTarget, versionFile);
+
+  return () => {
+    fs.rmSync(versionFile, {force: true});
+    fs.symlinkSync(target, versionFile);
+  };
+}
+
+function validateInstalledPackage(installedRoot, options) {
+  const packageJsonPath = path.join(installedRoot, 'package.json');
+  assertFile(packageJsonPath, 'installed package.json');
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  if (packageJson.name !== options.packageName) {
+    throw new Error(`Installed package name ${packageJson.name} does not match ${options.packageName}`);
+  }
+
+  for (const field of ['main', 'types']) {
+    if (packageJson[field]) {
+      assertFile(path.join(installedRoot, packageJson[field]), `${field} target ${packageJson[field]}`);
+    }
+  }
+
+  if (packageJson.exports) {
+    const exportPaths = [...new Set(collectExportPaths(packageJson.exports))];
+    for (const exportPath of exportPaths) {
+      assertFile(path.join(installedRoot, exportPath), `export target ${exportPath}`);
+    }
+  }
+
+  for (const requiredPath of options.required) {
+    assertFile(path.join(installedRoot, requiredPath), requiredPath);
+  }
+
+  const versionFile = path.join(installedRoot, 'openiap-versions.json');
+  if (fs.existsSync(versionFile)) {
+    const stat = fs.lstatSync(versionFile);
+    if (stat.isSymbolicLink()) {
+      throw new Error('openiap-versions.json must be packed as a real file, not a symlink');
+    }
+    const versions = JSON.parse(fs.readFileSync(versionFile, 'utf8'));
+    for (const key of ['spec', 'google', 'apple']) {
+      if (typeof versions[key] !== 'string' || versions[key].length === 0) {
+        throw new Error(`openiap-versions.json is missing ${key}`);
+      }
+    }
+  }
+
+  if (options.forbid.length > 0) {
+    for (const filePath of listFiles(installedRoot)) {
+      const buffer = fs.readFileSync(filePath);
+      if (buffer.includes(0)) continue;
+      const text = buffer.toString('utf8');
+      for (const pattern of options.forbid) {
+        if (text.includes(pattern)) {
+          const relativePath = path.relative(installedRoot, filePath);
+          throw new Error(`Packed package must not include ${JSON.stringify(pattern)} in ${relativePath}`);
+        }
+      }
+    }
+  }
+}
+
+const options = parseArgs(process.argv.slice(2));
+const packageRoot = path.resolve(process.cwd(), options.packagePath);
+const sourcePackageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
+if (sourcePackageJson.name !== options.packageName) {
+  throw new Error(`${packageRoot} package name ${sourcePackageJson.name} does not match ${options.packageName}`);
+}
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), `${options.packageName.replaceAll('/', '-')}-consumer-`));
+const restoreVersionFile = prepareVersionFile(packageRoot);
+
+try {
+  const packArgs = ['pack', '--json', '--pack-destination', tempRoot];
+  if (options.packIgnoreScripts) packArgs.push('--ignore-scripts');
+  const packOutput = run('npm', packArgs, packageRoot);
+  const packInfo = parseNpmPackJson(packOutput);
+  const tarballPath = path.isAbsolute(packInfo.filename)
+    ? packInfo.filename
+    : path.join(tempRoot, packInfo.filename);
+  assertFile(tarballPath, 'packed npm tarball');
+
+  const consumerRoot = path.join(tempRoot, 'consumer');
+  fs.mkdirSync(consumerRoot);
+  fs.writeFileSync(
+    path.join(consumerRoot, 'package.json'),
+    `${JSON.stringify({
+      name: `${options.packageName.replaceAll('/', '-')}-consumer-smoke`,
+      private: true,
+      type: 'module',
+      dependencies: {
+        [options.packageName]: `file:${tarballPath}`,
+      },
+    }, null, 2)}\n`,
+  );
+
+  run('npm', [
+    'install',
+    '--ignore-scripts',
+    '--legacy-peer-deps',
+    '--no-audit',
+    '--no-fund',
+    '--no-package-lock',
+  ], consumerRoot);
+
+  const installedRoot = packageInstallDir(consumerRoot, options.packageName);
+  validateInstalledPackage(installedRoot, options);
+  console.log(`${options.packageName} consumer install smoke test passed.`);
+} finally {
+  restoreVersionFile();
+  if (!process.env.OPENIAP_KEEP_NPM_CONSUMER_SMOKE_TMP) {
+    fs.rmSync(tempRoot, {recursive: true, force: true});
+  }
+}

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -22,6 +22,14 @@ function consumerPackageName(packageName) {
   return `${packageName.replace(/^@/, '').replaceAll('/', '-')}-consumer-smoke`;
 }
 
+function readJsonObject(filePath, label) {
+  const value = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} is not a valid JSON object`);
+  }
+  return value;
+}
+
 function parseArgs(argv) {
   const options = {
     packagePath: null,
@@ -185,7 +193,7 @@ function validateInstalledPackage(installedRoot, options) {
   const packageJsonPath = path.join(installedRoot, 'package.json');
   assertFile(packageJsonPath, 'installed package.json');
 
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const packageJson = readJsonObject(packageJsonPath, 'installed package.json');
   if (packageJson.name !== options.packageName) {
     throw new Error(`Installed package name ${packageJson.name} does not match ${options.packageName}`);
   }
@@ -213,7 +221,7 @@ function validateInstalledPackage(installedRoot, options) {
     if (stat.isSymbolicLink()) {
       throw new Error('openiap-versions.json must be packed as a real file, not a symlink');
     }
-    const versions = JSON.parse(fs.readFileSync(versionFile, 'utf8'));
+    const versions = readJsonObject(versionFile, 'openiap-versions.json');
     for (const key of ['spec', 'google', 'apple']) {
       if (typeof versions[key] !== 'string' || versions[key].trim().length === 0) {
         throw new Error(`openiap-versions.json is missing ${key}`);
@@ -238,7 +246,7 @@ function validateInstalledPackage(installedRoot, options) {
 
 const options = parseArgs(process.argv.slice(2));
 const packageRoot = path.resolve(process.cwd(), options.packagePath);
-const sourcePackageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
+const sourcePackageJson = readJsonObject(path.join(packageRoot, 'package.json'), `${packageRoot}/package.json`);
 if (sourcePackageJson.name !== options.packageName) {
   throw new Error(`${packageRoot} package name ${sourcePackageJson.name} does not match ${options.packageName}`);
 }

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -79,10 +79,11 @@ function run(command, args, cwd) {
   const verbose = readBooleanEnv('OPENIAP_VERBOSE_NPM_CONSUMER_SMOKE');
   if (verbose && result.stdout) process.stdout.write(result.stdout);
   if (verbose && result.stderr) process.stderr.write(result.stderr);
-  if (result.status !== 0) {
+  if (result.status !== 0 || result.signal) {
     if (!verbose && result.stdout) process.stdout.write(result.stdout);
     if (!verbose && result.stderr) process.stderr.write(result.stderr);
-    throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`);
+    const reason = result.signal ? `signal ${result.signal}` : `exit code ${result.status}`;
+    throw new Error(`${command} ${args.join(' ')} failed with ${reason}`);
   }
   return result.stdout;
 }
@@ -151,10 +152,12 @@ function prepareVersionFile(packageRoot) {
   const stat = fs.lstatSync(versionFile);
   const isSymlink = stat.isSymbolicLink();
   let target = null;
+  let originalContent = null;
   if (isSymlink) {
     target = fs.readlinkSync(versionFile);
   } else if (stat.isFile()) {
-    const content = fs.readFileSync(versionFile, 'utf8').trim();
+    originalContent = fs.readFileSync(versionFile);
+    const content = originalContent.toString('utf8').trim();
     if (content.startsWith('.') && content.endsWith('.json') && !content.includes('\n')) {
       target = content;
     }
@@ -171,7 +174,7 @@ function prepareVersionFile(packageRoot) {
       if (isSymlink) {
         fs.symlinkSync(target, versionFile);
       } else {
-        fs.writeFileSync(versionFile, target);
+        fs.writeFileSync(versionFile, originalContent);
       }
     } catch {
       // Preserve the original failure; the restore attempt is best-effort.
@@ -184,7 +187,7 @@ function prepareVersionFile(packageRoot) {
     if (isSymlink) {
       fs.symlinkSync(target, versionFile);
     } else {
-      fs.writeFileSync(versionFile, target);
+      fs.writeFileSync(versionFile, originalContent);
     }
   };
 }
@@ -294,8 +297,15 @@ try {
   validateInstalledPackage(installedRoot, options);
   console.log(`${options.packageName} consumer install smoke test passed.`);
 } finally {
-  restoreVersionFile();
+  let restoreError = null;
+  try {
+    restoreVersionFile();
+  } catch (error) {
+    restoreError = error;
+    console.error('Failed to restore version file:', error);
+  }
   if (tempRoot && !readBooleanEnv('OPENIAP_KEEP_NPM_CONSUMER_SMOKE_TMP')) {
     fs.rmSync(tempRoot, {recursive: true, force: true});
   }
+  if (restoreError) throw restoreError;
 }

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -317,6 +317,7 @@ try {
 
   const consumerRoot = path.join(tempRoot, 'consumer');
   fs.mkdirSync(consumerRoot);
+  const relativeTarballPath = path.relative(consumerRoot, tarballPath).split(path.sep).join(path.posix.sep);
   fs.writeFileSync(
     path.join(consumerRoot, 'package.json'),
     `${JSON.stringify({
@@ -324,7 +325,7 @@ try {
       private: true,
       type: 'module',
       dependencies: {
-        [options.packageName]: `file:${tarballPath}`,
+        [options.packageName]: `file:${relativeTarballPath}`,
       },
     }, null, 2)}\n`,
   );

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -92,16 +92,60 @@ function stripAnsi(value) {
   return value.replace(/\u001b\[[0-9;]*m/g, '');
 }
 
+function findJsonArrayRanges(value) {
+  const ranges = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escape = false;
+
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (char === '\\') {
+        escape = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (depth > 0 && char === '"') {
+      inString = true;
+    } else if (char === '[') {
+      if (depth === 0) start = i;
+      depth += 1;
+    } else if (char === ']' && depth > 0) {
+      depth -= 1;
+      if (depth === 0 && start !== -1) {
+        ranges.push([start, i + 1]);
+        start = -1;
+      }
+    }
+  }
+
+  return ranges;
+}
+
 function parseNpmPackJson(stdout) {
   const clean = stripAnsi(stdout).trim();
-  for (let start = clean.indexOf('['); start !== -1; start = clean.indexOf('[', start + 1)) {
-    for (let end = clean.lastIndexOf(']'); end > start; end = clean.lastIndexOf(']', end - 1)) {
-      try {
-        const parsed = JSON.parse(clean.slice(start, end + 1));
-        if (Array.isArray(parsed) && parsed[0]?.filename) return parsed[0];
-      } catch {
-        // Keep scanning; package lifecycle scripts can print arbitrary output.
-      }
+  try {
+    const parsed = JSON.parse(clean);
+    if (Array.isArray(parsed) && parsed[0]?.filename) return parsed[0];
+  } catch {
+    // Keep scanning; package lifecycle scripts can print arbitrary output.
+  }
+
+  const ranges = findJsonArrayRanges(clean);
+  for (let i = ranges.length - 1; i >= 0; i -= 1) {
+    const [start, end] = ranges[i];
+    try {
+      const parsed = JSON.parse(clean.slice(start, end));
+      if (Array.isArray(parsed) && parsed[0]?.filename) return parsed[0];
+    } catch {
+      // Keep scanning; package lifecycle scripts can print arbitrary output.
     }
   }
   throw new Error('Unable to parse npm pack --json output');
@@ -210,6 +254,7 @@ function validateInstalledPackage(installedRoot, options) {
   if (packageJson.exports) {
     const exportPaths = [...new Set(collectExportPaths(packageJson.exports))];
     for (const exportPath of exportPaths) {
+      if (exportPath.includes('*')) continue;
       assertFile(path.join(installedRoot, exportPath), `export target ${exportPath}`);
     }
   }

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -4,6 +4,14 @@ import os from 'node:os';
 import path from 'node:path';
 import {spawnSync} from 'node:child_process';
 
+function readArgValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (typeof value !== 'string' || value.length === 0 || value.startsWith('--')) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
 function parseArgs(argv) {
   const options = {
     packagePath: null,
@@ -16,13 +24,17 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--package') {
-      options.packagePath = argv[++i];
+      options.packagePath = readArgValue(argv, i, arg);
+      i += 1;
     } else if (arg === '--package-name') {
-      options.packageName = argv[++i];
+      options.packageName = readArgValue(argv, i, arg);
+      i += 1;
     } else if (arg === '--required') {
-      options.required.push(argv[++i]);
+      options.required.push(readArgValue(argv, i, arg));
+      i += 1;
     } else if (arg === '--forbid') {
-      options.forbid.push(argv[++i]);
+      options.forbid.push(readArgValue(argv, i, arg));
+      i += 1;
     } else if (arg === '--pack-ignore-scripts') {
       options.packIgnoreScripts = true;
     } else {
@@ -117,9 +129,18 @@ function prepareVersionFile(packageRoot) {
   if (!fs.existsSync(versionFile)) return () => {};
 
   const stat = fs.lstatSync(versionFile);
-  if (!stat.isSymbolicLink()) return () => {};
+  const isSymlink = stat.isSymbolicLink();
+  let target = null;
+  if (isSymlink) {
+    target = fs.readlinkSync(versionFile);
+  } else if (stat.isFile()) {
+    const content = fs.readFileSync(versionFile, 'utf8').trim();
+    if (content.startsWith('.') && content.endsWith('.json') && !content.includes('\n')) {
+      target = content;
+    }
+  }
+  if (!target) return () => {};
 
-  const target = fs.readlinkSync(versionFile);
   const resolvedTarget = path.resolve(path.dirname(versionFile), target);
   try {
     fs.rmSync(versionFile);
@@ -127,7 +148,11 @@ function prepareVersionFile(packageRoot) {
   } catch (error) {
     try {
       fs.rmSync(versionFile, {force: true});
-      fs.symlinkSync(target, versionFile);
+      if (isSymlink) {
+        fs.symlinkSync(target, versionFile);
+      } else {
+        fs.writeFileSync(versionFile, target);
+      }
     } catch {
       // Preserve the original failure; the restore attempt is best-effort.
     }
@@ -136,7 +161,11 @@ function prepareVersionFile(packageRoot) {
 
   return () => {
     fs.rmSync(versionFile, {force: true});
-    fs.symlinkSync(target, versionFile);
+    if (isSymlink) {
+      fs.symlinkSync(target, versionFile);
+    } else {
+      fs.writeFileSync(versionFile, target);
+    }
   };
 }
 
@@ -202,10 +231,13 @@ if (sourcePackageJson.name !== options.packageName) {
   throw new Error(`${packageRoot} package name ${sourcePackageJson.name} does not match ${options.packageName}`);
 }
 
-const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), `${options.packageName.replaceAll('/', '-')}-consumer-`));
-const restoreVersionFile = prepareVersionFile(packageRoot);
+let tempRoot = null;
+let restoreVersionFile = () => {};
 
 try {
+  tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), `${options.packageName.replaceAll('/', '-')}-consumer-`));
+  restoreVersionFile = prepareVersionFile(packageRoot);
+
   const packArgs = ['pack', '--json', '--pack-destination', tempRoot];
   if (options.packIgnoreScripts) packArgs.push('--ignore-scripts');
   const packOutput = run('npm', packArgs, packageRoot);
@@ -243,7 +275,7 @@ try {
   console.log(`${options.packageName} consumer install smoke test passed.`);
 } finally {
   restoreVersionFile();
-  if (!process.env.OPENIAP_KEEP_NPM_CONSUMER_SMOKE_TMP) {
+  if (tempRoot && !process.env.OPENIAP_KEEP_NPM_CONSUMER_SMOKE_TMP) {
     fs.rmSync(tempRoot, {recursive: true, force: true});
   }
 }

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -164,8 +164,20 @@ function parseNpmPackJson(stdout) {
 }
 
 function assertFile(filePath, label = filePath) {
-  if (!fs.existsSync(filePath)) {
-    throw new Error(`Missing ${label}`);
+  let stat;
+  try {
+    stat = fs.lstatSync(filePath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new Error(`Missing ${label}`);
+    }
+    throw error;
+  }
+  if (stat.isSymbolicLink()) {
+    throw new Error(`${label} must be a real file, not a symlink`);
+  }
+  if (!stat.isFile()) {
+    throw new Error(`${label} must be a file`);
   }
 }
 
@@ -276,16 +288,23 @@ function validateInstalledPackage(installedRoot, options) {
   }
 
   const versionFile = path.join(installedRoot, 'openiap-versions.json');
-  if (fs.existsSync(versionFile)) {
+  try {
     const stat = fs.lstatSync(versionFile);
     if (stat.isSymbolicLink()) {
       throw new Error('openiap-versions.json must be packed as a real file, not a symlink');
+    }
+    if (!stat.isFile()) {
+      throw new Error('openiap-versions.json must be a file');
     }
     const versions = readJsonObject(versionFile, 'openiap-versions.json');
     for (const key of ['spec', 'google', 'apple']) {
       if (typeof versions[key] !== 'string' || versions[key].trim().length === 0) {
         throw new Error(`openiap-versions.json is missing ${key}`);
       }
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      throw error;
     }
   }
 
@@ -357,20 +376,19 @@ try {
   console.log(`${options.packageName} consumer install smoke test passed.`);
   success = true;
 } finally {
-  let cleanupError = null;
+  let restoreError = null;
   try {
     restoreVersionFile();
   } catch (error) {
-    cleanupError = error;
+    restoreError = error;
     console.error('Failed to restore version file:', error);
   }
   if (tempRoot && !readBooleanEnv('OPENIAP_KEEP_NPM_CONSUMER_SMOKE_TMP')) {
     try {
       fs.rmSync(tempRoot, {recursive: true, force: true});
     } catch (error) {
-      cleanupError ??= error;
       console.error('Failed to clean up temp directory:', error);
     }
   }
-  if (success && cleanupError) throw cleanupError;
+  if (success && restoreError) throw restoreError;
 }

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -41,6 +41,9 @@ function run(command, args, cwd) {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+  if (result.error) {
+    throw new Error(`Failed to execute ${command} ${args.join(' ')}: ${result.error.message}`);
+  }
   const verbose = process.env.OPENIAP_VERBOSE_NPM_CONSUMER_SMOKE;
   if (verbose && result.stdout) process.stdout.write(result.stdout);
   if (verbose && result.stderr) process.stderr.write(result.stderr);
@@ -58,12 +61,14 @@ function stripAnsi(value) {
 
 function parseNpmPackJson(stdout) {
   const clean = stripAnsi(stdout).trim();
-  for (let index = clean.lastIndexOf('['); index >= 0; index = clean.lastIndexOf('[', index - 1)) {
-    try {
-      const parsed = JSON.parse(clean.slice(index));
-      if (Array.isArray(parsed) && parsed[0]?.filename) return parsed[0];
-    } catch {
-      // Keep scanning; package lifecycle scripts can print arbitrary output.
+  for (let start = clean.indexOf('['); start !== -1; start = clean.indexOf('[', start + 1)) {
+    for (let end = clean.lastIndexOf(']'); end > start; end = clean.lastIndexOf(']', end - 1)) {
+      try {
+        const parsed = JSON.parse(clean.slice(start, end + 1));
+        if (Array.isArray(parsed) && parsed[0]?.filename) return parsed[0];
+      } catch {
+        // Keep scanning; package lifecycle scripts can print arbitrary output.
+      }
     }
   }
   throw new Error('Unable to parse npm pack --json output');
@@ -116,8 +121,18 @@ function prepareVersionFile(packageRoot) {
 
   const target = fs.readlinkSync(versionFile);
   const resolvedTarget = path.resolve(path.dirname(versionFile), target);
-  fs.rmSync(versionFile);
-  fs.copyFileSync(resolvedTarget, versionFile);
+  try {
+    fs.rmSync(versionFile);
+    fs.copyFileSync(resolvedTarget, versionFile);
+  } catch (error) {
+    try {
+      fs.rmSync(versionFile, {force: true});
+      fs.symlinkSync(target, versionFile);
+    } catch {
+      // Preserve the original failure; the restore attempt is best-effort.
+    }
+    throw error;
+  }
 
   return () => {
     fs.rmSync(versionFile, {force: true});

--- a/scripts/verify-npm-consumer-install.mjs
+++ b/scripts/verify-npm-consumer-install.mjs
@@ -92,14 +92,20 @@ function stripAnsi(value) {
   return value.replace(/\u001b\[[0-9;]*m/g, '');
 }
 
-function findJsonArrayRanges(value) {
-  const ranges = [];
+function isJsonArrayCandidate(value, index) {
+  for (let i = index + 1; i < value.length; i += 1) {
+    if (/\s/.test(value[i])) continue;
+    return value[i] === '{';
+  }
+  return false;
+}
+
+function findJsonArrayEnd(value, start) {
   let depth = 0;
-  let start = -1;
   let inString = false;
   let escape = false;
 
-  for (let i = 0; i < value.length; i += 1) {
+  for (let i = start; i < value.length; i += 1) {
     const char = value[i];
     if (inString) {
       if (escape) {
@@ -112,20 +118,26 @@ function findJsonArrayRanges(value) {
       continue;
     }
 
-    if (depth > 0 && char === '"') {
+    if (char === '"') {
       inString = true;
     } else if (char === '[') {
-      if (depth === 0) start = i;
       depth += 1;
     } else if (char === ']' && depth > 0) {
       depth -= 1;
-      if (depth === 0 && start !== -1) {
-        ranges.push([start, i + 1]);
-        start = -1;
-      }
+      if (depth === 0) return i + 1;
     }
   }
 
+  return -1;
+}
+
+function findJsonArrayRanges(value) {
+  const ranges = [];
+  for (let start = value.indexOf('['); start !== -1; start = value.indexOf('[', start + 1)) {
+    if (!isJsonArrayCandidate(value, start)) continue;
+    const end = findJsonArrayEnd(value, start);
+    if (end !== -1) ranges.push([start, end]);
+  }
   return ranges;
 }
 


### PR DESCRIPTION
## Summary

- Add a shared npm pack based consumer install smoke test for published npm package shape.
- Run the smoke test for react-native-iap and expo-iap in CI and before npm publish.
- Extend the parity audit so the CI/release wiring does not drift.

## Context

This follows the flutter_inapp_purchase incident where CI passed while the published artifact could still fail in a fresh consumer app. The RN and Expo packages did not show the same Gradle scoping/flavor failure pattern, but this closes the npm artifact install gap for both packages.

## Test plan

- [x] node --check scripts/verify-npm-consumer-install.mjs
- [x] bun audit:parity
- [x] cd libraries/react-native-iap && yarn lint:tsc
- [x] cd libraries/react-native-iap && yarn test
- [x] cd libraries/react-native-iap && yarn verify:consumer-install
- [x] cd libraries/expo-iap && bun run lint:tsc
- [x] cd libraries/expo-iap && bun run build:plugin
- [x] cd libraries/expo-iap && npx jest
- [x] cd libraries/expo-iap && bun run test:plugin
- [x] cd libraries/expo-iap && bun run verify:consumer-install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added consumer-install smoke tests to CI and release pipelines for both IAP packages.
  * Smoke tests verify packaged libraries can be installed and expose required files, entry points, and platform artifacts.
* **Chores**
  * Added package-level verification scripts and enhanced audit checks to ensure install tests are present and run consistently across workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->