### PR TITLE
fix(apple): accept apple purchase props

### DIFF
--- a/packages/apple/Sources/OpenIapModule.swift
+++ b/packages/apple/Sources/OpenIapModule.swift
@@ -1615,14 +1615,14 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
 
     /// Resolves iOS purchase props from request params.
     /// Returns either RequestPurchaseIosProps or RequestSubscriptionIosProps based on request type.
-    private func resolveIOSPurchaseProps(from params: RequestPurchaseProps) throws -> any IosPropsProtocol {
+    func resolveIOSPurchaseProps(from params: RequestPurchaseProps) throws -> any IosPropsProtocol {
         switch params.request {
         case let .purchase(platforms):
-            if let ios = platforms.ios {
+            if let ios = platforms.apple ?? platforms.ios {
                 return ios
             }
         case let .subscription(platforms):
-            if let ios = platforms.ios {
+            if let ios = platforms.apple ?? platforms.ios {
                 return ios
             }
         }

--- a/packages/apple/Tests/OpenIapTests.swift
+++ b/packages/apple/Tests/OpenIapTests.swift
@@ -453,6 +453,47 @@ final class OpenIapTests: XCTestCase {
         XCTAssertNil(decoded.advancedCommerceData)
     }
 
+    @available(iOS 15.0, macOS 14.0, tvOS 16.0, watchOS 8.0, *)
+    func testResolvePurchasePropsUsesAppleAlias() throws {
+        let props = RequestPurchaseProps(
+            request: .purchase(RequestPurchasePropsByPlatforms(
+                apple: RequestPurchaseIosProps(sku: "dev.hyo.apple"),
+                ios: RequestPurchaseIosProps(sku: "dev.hyo.legacy")
+            ))
+        )
+
+        let resolved = try OpenIapModule.shared.resolveIOSPurchaseProps(from: props)
+
+        XCTAssertEqual(resolved.sku, "dev.hyo.apple")
+    }
+
+    @available(iOS 15.0, macOS 14.0, tvOS 16.0, watchOS 8.0, *)
+    func testResolvePurchasePropsFallsBackToLegacyIosAlias() throws {
+        let props = RequestPurchaseProps(
+            request: .purchase(RequestPurchasePropsByPlatforms(
+                ios: RequestPurchaseIosProps(sku: "dev.hyo.legacy")
+            ))
+        )
+
+        let resolved = try OpenIapModule.shared.resolveIOSPurchaseProps(from: props)
+
+        XCTAssertEqual(resolved.sku, "dev.hyo.legacy")
+    }
+
+    @available(iOS 15.0, macOS 14.0, tvOS 16.0, watchOS 8.0, *)
+    func testResolveSubscriptionPropsUsesAppleAlias() throws {
+        let props = RequestPurchaseProps(
+            request: .subscription(RequestSubscriptionPropsByPlatforms(
+                apple: RequestSubscriptionIosProps(sku: "dev.hyo.sub.apple"),
+                ios: RequestSubscriptionIosProps(sku: "dev.hyo.sub.legacy")
+            ))
+        )
+
+        let resolved = try OpenIapModule.shared.resolveIOSPurchaseProps(from: props)
+
+        XCTAssertEqual(resolved.sku, "dev.hyo.sub.apple")
+    }
+
     func testAdvancedCommerceDataJSONSerialization() throws {
         let props = RequestPurchaseIosProps(
             advancedCommerceData: "promo_code_abc",

--- a/packages/docs/src/generated/version-metadata.json
+++ b/packages/docs/src/generated/version-metadata.json
@@ -6,7 +6,7 @@
   "godotPackageVersion": "2.3.1",
   "kmpPackageVersion": "2.3.1",
   "mauiPackageId": "OpenIap.Maui",
-  "mauiPackageVersion": "1.1.1",
+  "mauiPackageVersion": "1.1.2",
   "googleCompileSdk": "35",
   "googleMinSdk": "23",
   "googlePlayBillingVersion": "8.3.0",


### PR DESCRIPTION
## Summary
- fix iOS native purchase request resolution to accept the canonical `apple` platform key, with legacy `ios` fallback preserved
- add Swift regression tests for purchase/subscription request resolution through `apple` and legacy `ios`
- sync docs version metadata with the MAUI 1.1.2 release bump so audits stay green

## Root cause
MAUI sends iOS purchase props as `requestPurchase.apple`, but the Swift native resolver only checked the deprecated `ios` alias. That prevented iOS from resolving the SKU before StoreKit purchase presentation, while Android continued to work.

## Verification
- `swift test` in `packages/apple`
- `bash packages/apple/scripts/build-xcframework.sh`
- `dotnet build libraries/maui-iap/src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net9.0-ios --nologo`
- `dotnet build libraries/maui-iap/src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net10.0-ios --nologo`
- `dotnet build -f net10.0-ios -p:RuntimeIdentifier=ios-arm64 --nologo` in `libraries/maui-iap/example/OpenIap.Maui.Example`
- installed and launched the fixed net10 iOS example app on iPhone 13 mini via `devicectl`
- `bun audit:parity`
- `bun audit:docs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced iOS purchase request handling to prioritize Apple platform configurations, with automatic fallback to legacy settings when unavailable.

* **Tests**
  * Added test coverage for iOS and subscription purchase request resolution across supported Apple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->