### PR TITLE
fix(maui): set xcframework install name

### DIFF
--- a/packages/apple/scripts/build-xcframework.sh
+++ b/packages/apple/scripts/build-xcframework.sh
@@ -14,6 +14,7 @@ DERIVED="${BUILD_DIR}/derived"
 ARCHIVES="${BUILD_DIR}/archives"
 OUT="${BUILD_DIR}/OpenIAP.xcframework"
 VERSIONS_FILE="${PACKAGE_DIR}/Sources/openiap-versions.json"
+EXPECTED_INSTALL_NAME="@rpath/OpenIAP.framework/OpenIAP"
 if [[ ! -f "${VERSIONS_FILE}" ]]; then
   VERSIONS_FILE="${PACKAGE_DIR}/../../openiap-versions.json"
 fi
@@ -71,9 +72,45 @@ archive() {
     -derivedDataPath "${DERIVED}" \
     -configuration Release \
     OPENIAP_MARKETING_VERSION="${APPLE_VERSION}" \
+    LD_DYLIB_INSTALL_NAME="${EXPECTED_INSTALL_NAME}" \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
     -quiet
+}
+
+validate_install_names() {
+  local binary
+  local install_name
+  local found=0
+  local failed=0
+
+  while IFS= read -r -d '' binary; do
+    found=1
+    while IFS= read -r install_name; do
+      if [[ -z "${install_name}" ]]; then
+        continue
+      fi
+
+      if [[ "${install_name}" != "${EXPECTED_INSTALL_NAME}" ]]; then
+        echo "error: ${binary} has install name ${install_name}; expected ${EXPECTED_INSTALL_NAME}"
+        failed=1
+      fi
+    done < <(otool -l "${binary}" | awk '/LC_ID_DYLIB/{in_id=1; next} in_id && / name /{print $2; in_id=0}')
+  done < <(
+    find "${OUT}" \
+      \( -path "*/OpenIAP.framework/OpenIAP" -o -path "*/OpenIAP.framework/Versions/*/OpenIAP" \) \
+      -type f \
+      -print0
+  )
+
+  if [[ "${found}" -eq 0 ]]; then
+    echo "error: no OpenIAP.framework binaries found in ${OUT}"
+    exit 1
+  fi
+
+  if [[ "${failed}" -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 archive "generic/platform=iOS"                         "${ARCHIVES}/ios.xcarchive"
@@ -107,5 +144,7 @@ xcodebuild -create-xcframework \
   -framework "${SIM_FW}" \
   -framework "${CAT_FW}" \
   -output "${OUT}"
+
+validate_install_names
 
 echo "==> done: ${OUT}"

--- a/packages/apple/scripts/build-xcframework.sh
+++ b/packages/apple/scripts/build-xcframework.sh
@@ -81,21 +81,29 @@ archive() {
 validate_install_names() {
   local binary
   local install_name
+  local saw_install_name
   local found=0
   local failed=0
 
   while IFS= read -r -d '' binary; do
     found=1
+    saw_install_name=0
     while IFS= read -r install_name; do
       if [[ -z "${install_name}" ]]; then
         continue
       fi
+      saw_install_name=1
 
       if [[ "${install_name}" != "${EXPECTED_INSTALL_NAME}" ]]; then
         echo "error: ${binary} has install name ${install_name}; expected ${EXPECTED_INSTALL_NAME}"
         failed=1
       fi
-    done < <(otool -l "${binary}" | awk '/LC_ID_DYLIB/{in_id=1; next} in_id && / name /{print $2; in_id=0}')
+    done < <(otool -D "${binary}" | grep -v ':$' || true)
+
+    if [[ "${saw_install_name}" -eq 0 ]]; then
+      echo "error: ${binary} has no LC_ID_DYLIB install name entry"
+      failed=1
+    fi
   done < <(
     find "${OUT}" \
       \( -path "*/OpenIAP.framework/OpenIAP" -o -path "*/OpenIAP.framework/Versions/*/OpenIAP" \) \

--- a/packages/apple/wrapper/project.yml
+++ b/packages/apple/wrapper/project.yml
@@ -21,6 +21,7 @@ settings:
     MARKETING_VERSION: "$(OPENIAP_MARKETING_VERSION)"
     CURRENT_PROJECT_VERSION: "1"
     SUPPORTED_PLATFORMS: "iphoneos iphonesimulator macosx"
+    LD_DYLIB_INSTALL_NAME: "@rpath/$(EXECUTABLE_PATH)"
 targets:
   OpenIAP:
     type: framework

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -3103,6 +3103,14 @@ function checkFrameworkDependencyHygiene() {
     'APPLE_VERSION="$(read_openiap_version apple)"',
     'OPENIAP_MARKETING_VERSION="${APPLE_VERSION}"',
   ], 'Apple xcframework marketing version');
+  expectIncludes('packages/apple/scripts/build-xcframework.sh', [
+    'EXPECTED_INSTALL_NAME="@rpath/OpenIAP.framework/OpenIAP"',
+    'LD_DYLIB_INSTALL_NAME="${EXPECTED_INSTALL_NAME}"',
+    'validate_install_names',
+  ], 'Apple xcframework install name');
+  expectIncludes('packages/apple/wrapper/project.yml', [
+    'LD_DYLIB_INSTALL_NAME: "@rpath/$(EXECUTABLE_PATH)"',
+  ], 'Apple wrapper install name');
   expectNotIncludes('packages/apple/scripts/bump-version.sh', [
     'OpenIapVersion.swift fallback',
     'Sources/OpenIapVersion.swift',


### PR DESCRIPTION
## Summary

- Force the OpenIAP xcframework install name to `@rpath/OpenIAP.framework/OpenIAP` during archive builds.
- Validate every iOS, simulator, and Mac Catalyst framework binary after `xcodebuild -create-xcframework` so CI fails if the install name regresses.
- Add the install-name guard to the parity audit.

Closes #186

## Test plan

- `bash packages/apple/scripts/build-xcframework.sh`
- `find packages/apple/.build/xcframework/OpenIAP.xcframework \( -path '*/OpenIAP.framework/OpenIAP' -o -path '*/OpenIAP.framework/Versions/*/OpenIAP' \) -type f -print -exec sh -c 'otool -l "$1" | awk "/LC_ID_DYLIB/{in_id=1; next} in_id && / name /{print \\$2; in_id=0}"' sh {} \;`
- `dotnet build libraries/maui-iap/src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net9.0 --nologo`
- `dotnet build libraries/maui-iap/src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net10.0 --nologo`
- `dotnet build libraries/maui-iap/src/OpenIap.Maui.Bindings.iOS/OpenIap.Maui.Bindings.iOS.csproj -p:TargetFrameworks=net10.0-ios --nologo`
- `dotnet build libraries/maui-iap/src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net10.0-ios --nologo`
- `bun audit:parity`
- `bash -n packages/apple/scripts/build-xcframework.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened Apple framework build validation to ensure dynamic libraries are correctly configured during the build process.
  * Updated build configuration settings for improved Apple framework consistency.
  * Introduced automated validation checks to maintain configuration parity across Apple builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->