### PR TITLE
fix: stabilize sdk example builds

### DIFF
--- a/libraries/expo-iap/plugin/src/__tests__/withLocalOpenIAP.test.ts
+++ b/libraries/expo-iap/plugin/src/__tests__/withLocalOpenIAP.test.ts
@@ -24,13 +24,32 @@ describe('ensureLocalOpenIapFlavorStrategy', () => {
     expect(result).toContain('missingDimensionStrategy "platform", "play"');
   });
 
+  it('emits Kotlin DSL for Kotlin project build files', () => {
+    const result = ensureLocalOpenIapFlavorStrategy(
+      baseProjectBuildGradle,
+      'horizon',
+      'kotlin',
+    );
+
+    expect(result).toContain('subprojects {');
+    expect(result).toContain(
+      'extensions.configure<com.android.build.gradle.LibraryExtension>("android")',
+    );
+    expect(result).toContain(
+      'missingDimensionStrategy("platform", "horizon")',
+    );
+    expect(result).not.toContain(
+      'missingDimensionStrategy "platform", "horizon"',
+    );
+  });
+
   it('replaces the managed block when the target flavor changes', () => {
     const playResult = ensureLocalOpenIapFlavorStrategy(
       baseProjectBuildGradle,
       'play',
     );
     const horizonResult = ensureLocalOpenIapFlavorStrategy(
-      playResult,
+      `${playResult}\n${playResult}`,
       'horizon',
     );
 
@@ -41,7 +60,9 @@ describe('ensureLocalOpenIapFlavorStrategy', () => {
       'missingDimensionStrategy "platform", "play"',
     );
     expect(
-      horizonResult.match(/local openiap-google flavor selection/g) ?? [],
-    ).toHaveLength(2);
+      horizonResult.match(
+        /Added by expo-iap \(local openiap-google flavor selection\)/g,
+      ) ?? [],
+    ).toHaveLength(1);
   });
 });

--- a/libraries/expo-iap/plugin/src/__tests__/withLocalOpenIAP.test.ts
+++ b/libraries/expo-iap/plugin/src/__tests__/withLocalOpenIAP.test.ts
@@ -1,0 +1,47 @@
+import {ensureLocalOpenIapFlavorStrategy} from '../withLocalOpenIAP';
+
+describe('ensureLocalOpenIapFlavorStrategy', () => {
+  const baseProjectBuildGradle = [
+    '// Top-level build file where you can add configuration options common to all sub-projects/modules.',
+    '',
+    'buildscript {',
+    '  repositories {',
+    '    google()',
+    '    mavenCentral()',
+    '  }',
+    '}',
+    '',
+  ].join('\n');
+
+  it('adds a default platform flavor for Android library subprojects', () => {
+    const result = ensureLocalOpenIapFlavorStrategy(
+      baseProjectBuildGradle,
+      'play',
+    );
+
+    expect(result).toContain('subprojects { subproject ->');
+    expect(result).toContain('subproject.plugins.withId("com.android.library")');
+    expect(result).toContain('missingDimensionStrategy "platform", "play"');
+  });
+
+  it('replaces the managed block when the target flavor changes', () => {
+    const playResult = ensureLocalOpenIapFlavorStrategy(
+      baseProjectBuildGradle,
+      'play',
+    );
+    const horizonResult = ensureLocalOpenIapFlavorStrategy(
+      playResult,
+      'horizon',
+    );
+
+    expect(horizonResult).toContain(
+      'missingDimensionStrategy "platform", "horizon"',
+    );
+    expect(horizonResult).not.toContain(
+      'missingDimensionStrategy "platform", "play"',
+    );
+    expect(
+      horizonResult.match(/local openiap-google flavor selection/g) ?? [],
+    ).toHaveLength(2);
+  });
+});

--- a/libraries/expo-iap/plugin/src/withLocalOpenIAP.ts
+++ b/libraries/expo-iap/plugin/src/withLocalOpenIAP.ts
@@ -3,6 +3,7 @@ import {
   withDangerousMod,
   withSettingsGradle,
   withAppBuildGradle,
+  withProjectBuildGradle,
 } from 'expo/config-plugins';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -85,6 +86,42 @@ const logOnce = (() => {
     }
   };
 })();
+
+const LOCAL_OPENIAP_FLAVOR_BLOCK_START =
+  '// Added by expo-iap (local openiap-google flavor selection)';
+const LOCAL_OPENIAP_FLAVOR_BLOCK_END =
+  '// End expo-iap local openiap-google flavor selection';
+
+export const ensureLocalOpenIapFlavorStrategy = (
+  contents: string,
+  flavor: 'play' | 'horizon',
+): string => {
+  const existingBlockPattern = new RegExp(
+    `\\n?${escapeRegExp(LOCAL_OPENIAP_FLAVOR_BLOCK_START)}[\\s\\S]*?${escapeRegExp(
+      LOCAL_OPENIAP_FLAVOR_BLOCK_END,
+    )}\\n?`,
+    'm',
+  );
+  const cleaned = contents
+    .replace(existingBlockPattern, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
+
+  return `${cleaned}
+
+${LOCAL_OPENIAP_FLAVOR_BLOCK_START}
+subprojects { subproject ->
+  subproject.plugins.withId("com.android.library") {
+    subproject.android {
+      defaultConfig {
+        missingDimensionStrategy "platform", "${flavor}"
+      }
+    }
+  }
+}
+${LOCAL_OPENIAP_FLAVOR_BLOCK_END}
+`;
+};
 
 const withLocalOpenIAP: ConfigPlugin<
   {
@@ -355,6 +392,32 @@ const withLocalOpenIAP: ConfigPlugin<
     }
 
     gradle.contents = contents;
+    return config;
+  });
+
+  // 2b) project build.gradle: Expo autolinked library modules can consume the
+  // local flavored OpenIAP module transitively, so give them the same default.
+  config = withProjectBuildGradle(config, (config) => {
+    const projectRoot = (config.modRequest as any).projectRoot as string;
+    const raw = props?.localPath;
+    const androidInput = typeof raw === 'string' ? undefined : raw?.android;
+    const androidModulePath =
+      resolveAndroidModulePath(androidInput) ||
+      resolveAndroidModulePath(path.resolve(projectRoot, 'openiap-google')) ||
+      null;
+
+    if (!androidModulePath || !fs.existsSync(androidModulePath)) {
+      return config;
+    }
+
+    const flavor = props?.isHorizonEnabled ? 'horizon' : 'play';
+    config.modResults.contents = ensureLocalOpenIapFlavorStrategy(
+      config.modResults.contents,
+      flavor,
+    );
+    logOnce(
+      `🛠️ expo-iap: Added local OpenIAP flavor strategy for ${flavor}`,
+    );
     return config;
   });
 

--- a/libraries/expo-iap/plugin/src/withLocalOpenIAP.ts
+++ b/libraries/expo-iap/plugin/src/withLocalOpenIAP.ts
@@ -17,6 +17,7 @@ import {
  * This is only for local development with openiap-apple library
  */
 type LocalPathOption = string | {ios?: string; android?: string};
+type GradleLanguage = 'groovy' | 'kotlin';
 
 interface AndroidGradlePluginVersions {
   kotlin: string;
@@ -92,25 +93,37 @@ const LOCAL_OPENIAP_FLAVOR_BLOCK_START =
 const LOCAL_OPENIAP_FLAVOR_BLOCK_END =
   '// End expo-iap local openiap-google flavor selection';
 
+const normalizeGradleLanguage = (language?: string): GradleLanguage =>
+  language === 'kotlin' ? 'kotlin' : 'groovy';
+
 export const ensureLocalOpenIapFlavorStrategy = (
   contents: string,
   flavor: 'play' | 'horizon',
+  language: GradleLanguage = 'groovy',
 ): string => {
   const existingBlockPattern = new RegExp(
     `\\n?${escapeRegExp(LOCAL_OPENIAP_FLAVOR_BLOCK_START)}[\\s\\S]*?${escapeRegExp(
       LOCAL_OPENIAP_FLAVOR_BLOCK_END,
     )}\\n?`,
-    'm',
+    'gm',
   );
   const cleaned = contents
     .replace(existingBlockPattern, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trimEnd();
 
-  return `${cleaned}
-
-${LOCAL_OPENIAP_FLAVOR_BLOCK_START}
-subprojects { subproject ->
+  const strategyBlock =
+    language === 'kotlin'
+      ? `subprojects {
+  plugins.withId("com.android.library") {
+    extensions.configure<com.android.build.gradle.LibraryExtension>("android") {
+      defaultConfig {
+        missingDimensionStrategy("platform", "${flavor}")
+      }
+    }
+  }
+}`
+      : `subprojects { subproject ->
   subproject.plugins.withId("com.android.library") {
     subproject.android {
       defaultConfig {
@@ -118,7 +131,12 @@ subprojects { subproject ->
       }
     }
   }
-}
+}`;
+
+  return `${cleaned}
+
+${LOCAL_OPENIAP_FLAVOR_BLOCK_START}
+${strategyBlock}
 ${LOCAL_OPENIAP_FLAVOR_BLOCK_END}
 `;
 };
@@ -240,10 +258,19 @@ const withLocalOpenIAP: ConfigPlugin<
 
     // 1) settings.gradle: include and map projectDir
     const settings = config.modResults;
-    const includeLine = "include ':openiap-google'";
-    const projectDirLine = `project(':openiap-google').projectDir = new File(settingsDir, '${relativeAndroidModulePath}')`;
+    const settingsLanguage = normalizeGradleLanguage(settings.language);
+    const includeLine =
+      settingsLanguage === 'kotlin'
+        ? 'include(":openiap-google")'
+        : "include ':openiap-google'";
+    const projectDirLine =
+      settingsLanguage === 'kotlin'
+        ? `project(":openiap-google").projectDir = File(settingsDir, "${relativeAndroidModulePath}")`
+        : `project(':openiap-google').projectDir = new File(settingsDir, '${relativeAndroidModulePath}')`;
+    const includePattern =
+      /include\s*(?:\(\s*)?["']:openiap-google["']\s*\)?/;
     const projectDirPattern =
-      /^project\(':openiap-google'\)\.projectDir\s*=.*$/gm;
+      /^\s*project\(["']:openiap-google["']\)\.projectDir\s*=.*$/gm;
     let contents = settings.contents ?? '';
 
     // Ensure pluginManagement has plugin mappings required by the included module
@@ -316,7 +343,7 @@ const withLocalOpenIAP: ConfigPlugin<
     };
 
     injectPluginManagement();
-    if (!contents.includes(includeLine)) contents += `\n${includeLine}\n`;
+    if (!includePattern.test(contents)) contents += `\n${includeLine}\n`;
     if (projectDirPattern.test(contents)) {
       contents = contents.replace(projectDirPattern, projectDirLine);
     } else if (!contents.includes(projectDirLine)) {
@@ -342,9 +369,16 @@ const withLocalOpenIAP: ConfigPlugin<
     }
 
     const gradle = config.modResults;
-    const dependencyLine = `    implementation project(':openiap-google')`;
+    const appLanguage = normalizeGradleLanguage(gradle.language);
+    const dependencyLine =
+      appLanguage === 'kotlin'
+        ? `    implementation(project(":openiap-google"))`
+        : `    implementation project(':openiap-google')`;
     const flavor = props?.isHorizonEnabled ? 'horizon' : 'play';
-    const strategyLine = `        missingDimensionStrategy "platform", "${flavor}"`;
+    const strategyLine =
+      appLanguage === 'kotlin'
+        ? `        missingDimensionStrategy("platform", "${flavor}")`
+        : `        missingDimensionStrategy "platform", "${flavor}"`;
 
     let contents = gradle.contents;
 
@@ -414,6 +448,7 @@ const withLocalOpenIAP: ConfigPlugin<
     config.modResults.contents = ensureLocalOpenIapFlavorStrategy(
       config.modResults.contents,
       flavor,
+      normalizeGradleLanguage(config.modResults.language),
     );
     logOnce(
       `🛠️ expo-iap: Added local OpenIAP flavor strategy for ${flavor}`,

--- a/libraries/flutter_inapp_purchase/example/lib/src/screens/purchase_flow_screen.dart
+++ b/libraries/flutter_inapp_purchase/example/lib/src/screens/purchase_flow_screen.dart
@@ -242,8 +242,7 @@ Has token: ${purchase.purchaseToken != null && purchase.purchaseToken!.isNotEmpt
     }
 
     debugPrint('✅ Purchase detected as successful: ${purchase.productId}');
-    debugPrint(
-        'Purchase token: ${_formatTokenValue(purchase.purchaseToken)}');
+    debugPrint('Purchase token: ${_formatTokenValue(purchase.purchaseToken)}');
     debugPrint('ID: ${purchase.id}'); // OpenIAP standard
     debugPrint('Transaction ID: ${transactionId ?? 'N/A'}');
 

--- a/libraries/flutter_inapp_purchase/example/lib/src/screens/subscription_flow_screen.dart
+++ b/libraries/flutter_inapp_purchase/example/lib/src/screens/subscription_flow_screen.dart
@@ -810,7 +810,8 @@ Store: ${iapkitResult.store.value}
       // Use current subscription token if available, otherwise use a test token
       final testToken = _currentActiveSubscription?.purchaseToken ??
           'test_empty_token_${DateTime.now().millisecondsSinceEpoch}';
-      debugPrint('Using test token: ${testToken.isEmpty ? 'empty' : testToken}');
+      debugPrint(
+          'Using test token: ${testToken.isEmpty ? 'empty' : testToken}');
 
       // Test with empty string - but pass validation by using a non-empty token
       final requestProps = RequestPurchaseProps.subs((

--- a/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/AvailablePurchasesScreen.kt
+++ b/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/AvailablePurchasesScreen.kt
@@ -27,10 +27,8 @@ import io.github.hyochan.kmpiap.toPurchaseInput
 import kotlinx.coroutines.*
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalTime::class)
+@OptIn(ExperimentalMaterial3Api::class, kotlin.time.ExperimentalTime::class)
 @Composable
 fun AvailablePurchasesScreen(navController: NavController) {
     val scope = rememberCoroutineScope()
@@ -71,7 +69,8 @@ fun AvailablePurchasesScreen(navController: NavController) {
                             }
                             // For non-auto-renewing, check expiry time
                             purchase.expirationDateIOS?.let { expiryTime ->
-                                val now = Clock.System.now().toEpochMilliseconds()
+                                // kotlinx-datetime 0.6.1 does not expose Clock.System in common source with this Kotlin toolchain.
+                                val now = kotlin.time.Clock.System.now().toEpochMilliseconds()
                                 return@filter expiryTime.toLong() > now  // Only show if not expired
                             }
                             return@filter true  // Show if no expiry info

--- a/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/AvailablePurchasesScreen.kt
+++ b/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/AvailablePurchasesScreen.kt
@@ -27,9 +27,10 @@ import io.github.hyochan.kmpiap.toPurchaseInput
 import kotlinx.coroutines.*
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTime::class)
 @Composable
 fun AvailablePurchasesScreen(navController: NavController) {
     val scope = rememberCoroutineScope()
@@ -70,9 +71,8 @@ fun AvailablePurchasesScreen(navController: NavController) {
                             }
                             // For non-auto-renewing, check expiry time
                             purchase.expirationDateIOS?.let { expiryTime ->
-                                val expiryDate = Instant.fromEpochMilliseconds(expiryTime.toLong())
-                                val now = kotlinx.datetime.Clock.System.now()
-                                return@filter expiryDate > now  // Only show if not expired
+                                val now = Clock.System.now().toEpochMilliseconds()
+                                return@filter expiryTime.toLong() > now  // Only show if not expired
                             }
                             return@filter true  // Show if no expiry info
                         } else {

--- a/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/WebhookTestNotification.kt
+++ b/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/WebhookTestNotification.kt
@@ -2,17 +2,16 @@ package dev.hyo.martie.screens
 
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 
 internal expect suspend fun triggerWebhookTestNotification(
     apiKey: String,
     baseUrl: String = "https://kit.openiap.dev",
 ): Result<Unit>
 
-@OptIn(ExperimentalEncodingApi::class, ExperimentalTime::class)
+@OptIn(ExperimentalEncodingApi::class, kotlin.time.ExperimentalTime::class)
 internal fun buildWebhookTestNotificationPayload(messagePrefix: String): String {
-    val now = Clock.System.now()
+    // kotlinx-datetime 0.6.1 does not expose Clock.System in common source with this Kotlin toolchain.
+    val now = kotlin.time.Clock.System.now()
     val timestamp = now.toEpochMilliseconds()
     val dataJson =
         """{"version":"1.0","packageName":"com.example.app","eventTimeMillis":"$timestamp","testNotification":{"version":"1.0"}}"""

--- a/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/WebhookTestNotification.kt
+++ b/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/WebhookTestNotification.kt
@@ -1,15 +1,16 @@
 package dev.hyo.martie.screens
 
-import kotlinx.datetime.Clock
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 internal expect suspend fun triggerWebhookTestNotification(
     apiKey: String,
     baseUrl: String = "https://kit.openiap.dev",
 ): Result<Unit>
 
-@OptIn(ExperimentalEncodingApi::class)
+@OptIn(ExperimentalEncodingApi::class, ExperimentalTime::class)
 internal fun buildWebhookTestNotificationPayload(messagePrefix: String): String {
     val now = Clock.System.now()
     val timestamp = now.toEpochMilliseconds()

--- a/libraries/kmp-iap/example/composeApp/src/iosMain/kotlin/dev/hyo/martie/screens/WebhookTestNotification.ios.kt
+++ b/libraries/kmp-iap/example/composeApp/src/iosMain/kotlin/dev/hyo/martie/screens/WebhookTestNotification.ios.kt
@@ -36,7 +36,10 @@ internal actual suspend fun triggerWebhookTestNotification(
         return@suspendCancellableCoroutine
     }
 
-    val url = NSURL(string = webhookTestNotificationUrl(baseUrl, apiKey))
+    val url = NSURL.URLWithString(webhookTestNotificationUrl(baseUrl, apiKey)) ?: run {
+        continuation.resume(Result.failure(IllegalStateException("Invalid webhook URL.")))
+        return@suspendCancellableCoroutine
+    }
     val request = NSMutableURLRequest.requestWithURL(url)
     request.setHTTPMethod("POST")
     request.setValue("application/json", forHTTPHeaderField = "Content-Type")
@@ -51,16 +54,17 @@ internal actual suspend fun triggerWebhookTestNotification(
         delegate,
         null,
     )
-    delegate.session = session
     val task = session.dataTaskWithRequest(request)
-    continuation.invokeOnCancellation { task.cancel() }
+    continuation.invokeOnCancellation {
+        task.cancel()
+        session.invalidateAndCancel()
+    }
     task.resume()
 }
 
 private class WebhookTestNotificationDelegate(
     private val continuation: CancellableContinuation<Result<Unit>>,
 ) : NSObject(), NSURLSessionDataDelegateProtocol {
-    var session: NSURLSession? = null
     private var statusCode = 0
     private var didResume = false
 
@@ -76,6 +80,7 @@ private class WebhookTestNotificationDelegate(
         } else {
             completionHandler(NSURLSessionResponseCancel)
             dataTask.cancel()
+            session.invalidateAndCancel()
             resumeOnce(Result.failure(IllegalStateException("Test POST returned $statusCode")))
         }
     }
@@ -85,6 +90,7 @@ private class WebhookTestNotificationDelegate(
         task: NSURLSessionTask,
         didCompleteWithError: NSError?,
     ) {
+        session.finishTasksAndInvalidate()
         if (didCompleteWithError != null) {
             resumeOnce(
                 Result.failure(
@@ -101,7 +107,6 @@ private class WebhookTestNotificationDelegate(
     private fun resumeOnce(result: Result<Unit>) {
         if (didResume) return
         didResume = true
-        session?.finishTasksAndInvalidate()
         continuation.resume(result)
     }
 }

--- a/libraries/kmp-iap/example/composeApp/src/iosMain/kotlin/dev/hyo/martie/screens/WebhookTestNotification.ios.kt
+++ b/libraries/kmp-iap/example/composeApp/src/iosMain/kotlin/dev/hyo/martie/screens/WebhookTestNotification.ios.kt
@@ -1,17 +1,32 @@
 package dev.hyo.martie.screens
 
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.Foundation.NSError
 import platform.Foundation.NSHTTPURLResponse
 import platform.Foundation.NSMutableURLRequest
 import platform.Foundation.NSString
 import platform.Foundation.NSURL
+import platform.Foundation.NSURLResponse
 import platform.Foundation.NSURLSession
+import platform.Foundation.NSURLSessionConfiguration
+import platform.Foundation.NSURLSessionDataDelegateProtocol
+import platform.Foundation.NSURLSessionDataTask
+import platform.Foundation.NSURLSessionResponseAllow
+import platform.Foundation.NSURLSessionResponseCancel
+import platform.Foundation.NSURLSessionResponseDisposition
+import platform.Foundation.NSURLSessionTask
 import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.create
 import platform.Foundation.dataUsingEncoding
+import platform.Foundation.setHTTPBody
 import platform.Foundation.setHTTPMethod
 import platform.Foundation.setValue
+import platform.darwin.NSObject
 import kotlin.coroutines.resume
 
+@OptIn(BetaInteropApi::class)
 internal actual suspend fun triggerWebhookTestNotification(
     apiKey: String,
     baseUrl: String,
@@ -22,34 +37,71 @@ internal actual suspend fun triggerWebhookTestNotification(
     }
 
     val url = NSURL(string = webhookTestNotificationUrl(baseUrl, apiKey))
-    if (url == null) {
-        continuation.resume(Result.failure(IllegalArgumentException("Invalid webhook URL.")))
-        return@suspendCancellableCoroutine
-    }
-
-    val request = NSMutableURLRequest.requestWithURL(url) as NSMutableURLRequest
+    val request = NSMutableURLRequest.requestWithURL(url)
     request.setHTTPMethod("POST")
     request.setValue("application/json", forHTTPHeaderField = "Content-Type")
-    request.HTTPBody = NSString
+    val body = NSString
         .create(string = buildWebhookTestNotificationPayload("kmp-ios"))
         .dataUsingEncoding(NSUTF8StringEncoding)
+    request.setHTTPBody(body)
 
-    val task = NSURLSession.sharedSession.dataTaskWithRequest(request) { _, response, error ->
-        if (error != null) {
-            continuation.resume(
-                Result.failure(
-                    IllegalStateException(error.localizedDescription ?: "Network error"),
-                ),
-            )
-            return@dataTaskWithRequest
-        }
-        val statusCode = (response as? NSHTTPURLResponse)?.statusCode?.toInt() ?: 0
-        if (statusCode in 200..299) {
-            continuation.resume(Result.success(Unit))
-        } else {
-            continuation.resume(Result.failure(IllegalStateException("Test POST returned $statusCode")))
-        }
-    }
+    val delegate = WebhookTestNotificationDelegate(continuation)
+    val session = NSURLSession.sessionWithConfiguration(
+        NSURLSessionConfiguration.defaultSessionConfiguration(),
+        delegate,
+        null,
+    )
+    delegate.session = session
+    val task = session.dataTaskWithRequest(request)
     continuation.invokeOnCancellation { task.cancel() }
     task.resume()
+}
+
+private class WebhookTestNotificationDelegate(
+    private val continuation: CancellableContinuation<Result<Unit>>,
+) : NSObject(), NSURLSessionDataDelegateProtocol {
+    var session: NSURLSession? = null
+    private var statusCode = 0
+    private var didResume = false
+
+    override fun URLSession(
+        session: NSURLSession,
+        dataTask: NSURLSessionDataTask,
+        didReceiveResponse: NSURLResponse,
+        completionHandler: (NSURLSessionResponseDisposition) -> Unit,
+    ) {
+        statusCode = (didReceiveResponse as? NSHTTPURLResponse)?.statusCode?.toInt() ?: 0
+        if (statusCode in 200..299) {
+            completionHandler(NSURLSessionResponseAllow)
+        } else {
+            completionHandler(NSURLSessionResponseCancel)
+            dataTask.cancel()
+            resumeOnce(Result.failure(IllegalStateException("Test POST returned $statusCode")))
+        }
+    }
+
+    override fun URLSession(
+        session: NSURLSession,
+        task: NSURLSessionTask,
+        didCompleteWithError: NSError?,
+    ) {
+        if (didCompleteWithError != null) {
+            resumeOnce(
+                Result.failure(
+                    IllegalStateException(didCompleteWithError.localizedDescription),
+                ),
+            )
+        } else if (statusCode in 200..299) {
+            resumeOnce(Result.success(Unit))
+        } else {
+            resumeOnce(Result.failure(IllegalStateException("Test POST returned $statusCode")))
+        }
+    }
+
+    private fun resumeOnce(result: Result<Unit>) {
+        if (didResume) return
+        didResume = true
+        session?.finishTasksAndInvalidate()
+        continuation.resume(result)
+    }
 }

--- a/packages/docs/src/pages/docs/updates/releases.tsx
+++ b/packages/docs/src/pages/docs/updates/releases.tsx
@@ -101,6 +101,15 @@ function Releases() {
               checks the new Flutter SwiftPM manifests and generated llms root
               symlinks so path drift is caught before release.
             </li>
+            <li>
+              <strong>Expo local release builds</strong> —{' '}
+              <code>expo-iap 4.3.3</code> updates the local OpenIAP config
+              plugin so Expo release builds that link the monorepo&apos;s local{' '}
+              <code>:openiap-google</code> module apply the selected{' '}
+              <code>play</code> or <code>horizon</code> flavor to transitive
+              Android library modules such as <code>:expo</code>, avoiding
+              Gradle variant ambiguity during <code>assembleRelease</code>.
+            </li>
           </ul>
 
           <div
@@ -132,6 +141,24 @@ function Releases() {
                   rel="noopener noreferrer"
                 >
                   pub.dev
+                </a>
+                )
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/expo-iap-4.3.3"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  expo-iap 4.3.3
+                </a>{' '}
+                (
+                <a
+                  href="https://www.npmjs.com/package/expo-iap/v/4.3.3"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  npm
                 </a>
                 )
               </li>


### PR DESCRIPTION
## Summary

- Fix expo-iap local OpenIAP Android release builds by applying the selected local `openiap-google` flavor to transitive Android library consumers.
- Fix KMP example iOS compilation for webhook test notifications and timestamp comparisons.
- Add the planned `expo-iap 4.3.3` release entry to the existing June 23, 2026 release notes section, alongside the Flutter SwiftPM note.

## Validation

- `bun audit:parity`
- `libraries/expo-iap`: `bun run lint:tsc && cd plugin && bunx jest --runInBand`
- `libraries/kmp-iap/example`: `./gradlew :composeApp:compileKotlinIosArm64 :composeApp:assembleDebug`
- `packages/docs`: `bunx prettier --check "src/**/*.{ts,tsx,css}" && bun run lint && bun run typecheck`
- `bun run scripts/audit-docs.ts`
- Android device smoke: RN, Expo, Flutter, KMP, Godot installed and launched on `HT79F1A00473`
- iOS device smoke: RN, Expo, Flutter, KMP, Godot installed and launched on iPhone 13 mini

## Release follow-up after merge

- Run `A. Release: expo-iap` with `version_type=patch`, stable release, expected version `4.3.3`.
- Deploy docs with `npm run deploy` after the Expo npm/GitHub release exists.

## Preview

Text-only release-note update plus build output validation; no preview media is attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved local Android purchase setup so the correct flavor is selected automatically for supported builds.
  * Updated iOS webhook notification handling for more reliable request completion and cancellation.

* **Bug Fixes**
  * Fixed subscription expiry checks in the Kotlin example app to use a more consistent current-time comparison.
  * Adjusted purchase flow logging and handling without changing user-facing behavior.

* **Documentation**
  * Updated release notes to reflect the latest package release and local build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->