### PR TITLE
fix(sdk): preserve fetch products all results

### DIFF
--- a/libraries/expo-iap/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
+++ b/libraries/expo-iap/android/src/main/java/expo/modules/iap/ExpoIapModule.kt
@@ -3,6 +3,7 @@ package expo.modules.iap
 import android.content.Context
 import dev.hyo.openiap.AndroidSubscriptionOfferInput
 import dev.hyo.openiap.DeepLinkOptions
+import dev.hyo.openiap.FetchProductsResultAll
 import dev.hyo.openiap.FetchProductsResultProducts
 import dev.hyo.openiap.FetchProductsResultSubscriptions
 import dev.hyo.openiap.InitConnectionConfig
@@ -183,9 +184,9 @@ class ExpoIapModule : Module() {
                         val result = openIap.fetchProducts(request)
                         val payload =
                             when (result) {
+                                is FetchProductsResultAll -> result.value.orEmpty().map { it.toJson() }
                                 is FetchProductsResultProducts -> result.value.orEmpty().map { it.toJson() }
                                 is FetchProductsResultSubscriptions -> result.value.orEmpty().map { it.toJson() }
-                                else -> emptyList<Map<String, Any?>>()
                             }
                         ExpoIapLog.result("fetchProducts", payload)
                         promise.resolve(payload)

--- a/libraries/expo-iap/ios/onside/OnsideIapModule.swift
+++ b/libraries/expo-iap/ios/onside/OnsideIapModule.swift
@@ -310,6 +310,11 @@ public final class ExpoIapOnsideModule: Module {
                     }
                 }
             }
+            if alsoPublish {
+                payload.forEach {
+                    sendEvent(OnsideEvent.purchaseUpdated.rawValue, $0)
+                }
+            }
             ExpoIapLog.result("getAvailableItemsOnside", value: payload)
             return payload
         }
@@ -430,7 +435,7 @@ public final class ExpoIapOnsideModule: Module {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
         formatter.currencyCode = product.price.currencyCode
-        let priceNumber = NSDecimalNumber(value: product.price.value)
+        let priceNumber = NSDecimalNumber(decimal: Decimal(product.price.value))
         let formattedPrice = formatter.string(from: priceNumber) ?? "\(product.price.value)"
         dictionary["displayPrice"] = formattedPrice
         dictionary["currency"] = product.price.currencyCode
@@ -494,7 +499,7 @@ public final class ExpoIapOnsideModule: Module {
         let priceFormatter = NumberFormatter()
         priceFormatter.numberStyle = .currency
         priceFormatter.currencyCode = product.price.currencyCode
-        let priceNumber = NSDecimalNumber(value: product.price.value)
+        let priceNumber = NSDecimalNumber(decimal: Decimal(product.price.value))
         let formattedPrice = priceFormatter.string(from: priceNumber) ?? "\(product.price.value)"
         let jsonObject: [String: Any] = [
             "id": product.productIdentifier,

--- a/libraries/expo-iap/ios/onside/OnsideIapModule.swift
+++ b/libraries/expo-iap/ios/onside/OnsideIapModule.swift
@@ -50,6 +50,7 @@ public final class ExpoIapOnsideModule: Module {
     private let transactionObserver = OnsideTransactionObserverBridge()
     private let productFetcher = OnsideProductFetcher()
     private var productCache: [String: OnsideProduct] = [:]
+    private var transactionDateCache: [String: Date] = [:]
 
     nonisolated public func definition() -> ModuleDefinition {
         Name("ExpoIapOnside")
@@ -246,7 +247,9 @@ public final class ExpoIapOnsideModule: Module {
                 throw OnsideBridgeError.transactionNotFound(txId ?? productId ?? "")
             }
 
-            await Onside.defaultPaymentQueue().finishTransaction(transaction)
+            await MainActor.run {
+                Onside.defaultPaymentQueue().finishTransaction(transaction)
+            }
             ExpoIapLog.result("finishTransactionOnside", value: true)
             return true
         }
@@ -385,6 +388,7 @@ public final class ExpoIapOnsideModule: Module {
         let cont = restoreContinuation
         restoreContinuation = nil
         cont?.resume(returning: false)
+        transactionDateCache.removeAll()
     }
 
     private func handle(transaction: OnsidePaymentTransaction) {
@@ -450,7 +454,7 @@ public final class ExpoIapOnsideModule: Module {
         dictionary["quantity"] = 1
         dictionary["isAutoRenewing"] = false
         dictionary["purchaseState"] = mapPurchaseState(transaction.transactionState)
-        let txDate = Date()
+        let txDate = date(for: transaction)
         dictionary["transactionDate"] = Int(txDate.timeIntervalSince1970 * 1000)
         dictionary["currencyCodeIOS"] = product.price.currencyCode
         let currencyFormatter = NumberFormatter()
@@ -465,6 +469,24 @@ public final class ExpoIapOnsideModule: Module {
             dictionary["reasonIOS"] = error.localizedDescription
         }
         return sanitize(dictionary)
+    }
+
+    private func date(for transaction: OnsidePaymentTransaction) -> Date {
+        guard let key = transaction.transactionIdentifier ?? transaction.originalTransactionIdentifier,
+              !key.isEmpty
+        else {
+            return Date()
+        }
+
+        if let cachedDate = transactionDateCache[key] {
+            return cachedDate
+        }
+
+        // OnsideKit currently exposes no purchase date on the transaction, so
+        // keep the first observed timestamp stable for repeated serializations.
+        let observedDate = Date()
+        transactionDateCache[key] = observedDate
+        return observedDate
     }
 
     // Build a JSON string from known product fields (no Encodable conformance required)

--- a/libraries/expo-iap/ios/onside/OnsideIapModule.swift
+++ b/libraries/expo-iap/ios/onside/OnsideIapModule.swift
@@ -301,7 +301,7 @@ public final class ExpoIapOnsideModule: Module {
             )
             try await ensureObserverRegistered()
             let payload: [[String: Any]] = try await MainActor.run {
-                try Onside.defaultPaymentQueue().transactions.compactMap { transaction -> [String: Any]? in
+                let items = try Onside.defaultPaymentQueue().transactions.compactMap { transaction -> [String: Any]? in
                     switch transaction.transactionState {
                     case .purchased, .restored:
                         return try serialize(transaction: transaction)
@@ -309,11 +309,12 @@ public final class ExpoIapOnsideModule: Module {
                         return nil
                     }
                 }
-            }
-            if alsoPublish {
-                payload.forEach {
-                    sendEvent(OnsideEvent.purchaseUpdated.rawValue, $0)
+                if alsoPublish {
+                    items.forEach {
+                        sendEvent(OnsideEvent.purchaseUpdated.rawValue, $0)
+                    }
                 }
+                return items
             }
             ExpoIapLog.result("getAvailableItemsOnside", value: payload)
             return payload
@@ -435,7 +436,7 @@ public final class ExpoIapOnsideModule: Module {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
         formatter.currencyCode = product.price.currencyCode
-        let priceNumber = NSDecimalNumber(decimal: Decimal(product.price.value))
+        let priceNumber = NSDecimalNumber(string: String(product.price.value))
         let formattedPrice = formatter.string(from: priceNumber) ?? "\(product.price.value)"
         dictionary["displayPrice"] = formattedPrice
         dictionary["currency"] = product.price.currencyCode
@@ -499,7 +500,7 @@ public final class ExpoIapOnsideModule: Module {
         let priceFormatter = NumberFormatter()
         priceFormatter.numberStyle = .currency
         priceFormatter.currencyCode = product.price.currencyCode
-        let priceNumber = NSDecimalNumber(decimal: Decimal(product.price.value))
+        let priceNumber = NSDecimalNumber(string: String(product.price.value))
         let formattedPrice = priceFormatter.string(from: priceNumber) ?? "\(product.price.value)"
         let jsonObject: [String: Any] = [
             "id": product.productIdentifier,

--- a/libraries/expo-iap/ios/onside/OnsideIapModule.swift
+++ b/libraries/expo-iap/ios/onside/OnsideIapModule.swift
@@ -113,7 +113,7 @@ public final class ExpoIapOnsideModule: Module {
 
                 // Check if Onside Store is installed
                 if let onsideURL = URL(string: "onside://"),
-                UIApplication.shared.canOpenURL(onsideURL) {
+                await MainActor.run(body: { UIApplication.shared.canOpenURL(onsideURL) }) {
                     #if DEBUG
                     print("[ExpoIapOnsideModule] ✅ Onside Store app is installed")
                     #endif
@@ -225,16 +225,15 @@ public final class ExpoIapOnsideModule: Module {
             let productId = purchasePayload["productId"] as? String
             let txId = purchasePayload["transactionId"] as? String
 
-            let queue = await Onside.defaultPaymentQueue()
-
             let transaction: OnsidePaymentTransaction? = await MainActor.run {
+                let transactions = Onside.defaultPaymentQueue().transactions
                 if let txId, !txId.isEmpty {
-                    return queue.transactions.first(where: { $0.transactionIdentifier == txId })
+                    return transactions.first(where: { $0.transactionIdentifier == txId })
                 }
 
                 // 2) fallback: if txId is not available yet — search by productId (less reliable!)
                 if let productId, !productId.isEmpty {
-                    return queue.transactions.first(where: {
+                    return transactions.first(where: {
                         $0.payment.product.productIdentifier == productId
                         && ($0.transactionState == .purchased || $0.transactionState == .restored)
                     })
@@ -247,7 +246,7 @@ public final class ExpoIapOnsideModule: Module {
                 throw OnsideBridgeError.transactionNotFound(txId ?? productId ?? "")
             }
 
-            await queue.finishTransaction(transaction)
+            await Onside.defaultPaymentQueue().finishTransaction(transaction)
             ExpoIapLog.result("finishTransactionOnside", value: true)
             return true
         }
@@ -298,13 +297,14 @@ public final class ExpoIapOnsideModule: Module {
                 ]
             )
             try await ensureObserverRegistered()
-            let queue = await Onside.defaultPaymentQueue()
-            let payload = try queue.transactions.compactMap { transaction -> [String: Any]? in
-                switch transaction.transactionState {
-                case .purchased, .restored:
-                    return try serialize(transaction: transaction)
-                default:
-                    return nil
+            let payload: [[String: Any]] = try await MainActor.run {
+                try Onside.defaultPaymentQueue().transactions.compactMap { transaction -> [String: Any]? in
+                    switch transaction.transactionState {
+                    case .purchased, .restored:
+                        return try serialize(transaction: transaction)
+                    default:
+                        return nil
+                    }
                 }
             }
             ExpoIapLog.result("getAvailableItemsOnside", value: payload)
@@ -323,7 +323,7 @@ public final class ExpoIapOnsideModule: Module {
     private func getOnsideStorefront() async throws -> String {
         ExpoIapLog.payload("getStorefrontOnside", payload: nil)
         try await ensureObserverRegistered()
-        let storefront = await Onside.defaultPaymentQueue().storefront?.countryCode ?? ""
+        let storefront = Onside.defaultPaymentQueue().storefront?.countryCode ?? ""
         ExpoIapLog.result("getStorefrontOnside", value: storefront)
         return storefront
     }
@@ -425,11 +425,11 @@ public final class ExpoIapOnsideModule: Module {
         dictionary["displayNameIOS"] = product.localizedTitle
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
-        formatter.currencyCode = product.price.currencyCode ?? ""
-        let priceNumber = NSDecimalNumber(decimal: product.price.value)
+        formatter.currencyCode = product.price.currencyCode
+        let priceNumber = NSDecimalNumber(value: product.price.value)
         let formattedPrice = formatter.string(from: priceNumber) ?? "\(product.price.value)"
         dictionary["displayPrice"] = formattedPrice
-        dictionary["currency"] = product.price.currencyCode ?? ""
+        dictionary["currency"] = product.price.currencyCode
         dictionary["price"] = priceNumber
         dictionary["type"] = "in-app"
         dictionary["typeIOS"] = "non-consumable"
@@ -450,15 +450,15 @@ public final class ExpoIapOnsideModule: Module {
         dictionary["quantity"] = 1
         dictionary["isAutoRenewing"] = false
         dictionary["purchaseState"] = mapPurchaseState(transaction.transactionState)
-        let txDate = transaction.transactionDate ?? Date()
+        let txDate = Date()
         dictionary["transactionDate"] = Int(txDate.timeIntervalSince1970 * 1000)
-        dictionary["currencyCodeIOS"] = product.price.currencyCode ?? ""
+        dictionary["currencyCodeIOS"] = product.price.currencyCode
         let currencyFormatter = NumberFormatter()
         currencyFormatter.numberStyle = .currency
-        currencyFormatter.currencyCode = product.price.currencyCode ?? ""
+        currencyFormatter.currencyCode = product.price.currencyCode
         dictionary["currencySymbolIOS"] = currencyFormatter.currencySymbol ?? ""
 
-        dictionary["storefrontCountryCodeIOS"] = transaction.storefront.countryCode ?? ""
+        dictionary["storefrontCountryCodeIOS"] = transaction.storefront.countryCode
         dictionary["purchaseToken"] = nil
         dictionary["environmentIOS"] = transaction.storefront.id
         if let error = transaction.error {
@@ -471,8 +471,8 @@ public final class ExpoIapOnsideModule: Module {
     private func makeProductJSONRepresentation(from product: OnsideProduct) throws -> String {
         let priceFormatter = NumberFormatter()
         priceFormatter.numberStyle = .currency
-        priceFormatter.currencyCode = product.price.currencyCode ?? ""
-        let priceNumber = NSDecimalNumber(decimal: product.price.value)
+        priceFormatter.currencyCode = product.price.currencyCode
+        let priceNumber = NSDecimalNumber(value: product.price.value)
         let formattedPrice = priceFormatter.string(from: priceNumber) ?? "\(product.price.value)"
         let jsonObject: [String: Any] = [
             "id": product.productIdentifier,
@@ -480,7 +480,7 @@ public final class ExpoIapOnsideModule: Module {
             "description": product.localizedDescription,
             "price": [
                 "value": priceNumber,
-                "currencyCode": product.price.currencyCode ?? "",
+                "currencyCode": product.price.currencyCode,
                 "formatted": formattedPrice,
             ],
             "isFamilyShareable": false,
@@ -655,6 +655,7 @@ private final class OnsideProductFetcher: NSObject, OnsideProductsRequestDelegat
         }
     }
 
+    @MainActor
     private func cleanup() {
         request?.delegate = nil
         request?.stop()

--- a/libraries/flutter_inapp_purchase/android/src/main/kotlin/io/github/hyochan/flutter_inapp_purchase/AndroidInappPurchasePlugin.kt
+++ b/libraries/flutter_inapp_purchase/android/src/main/kotlin/io/github/hyochan/flutter_inapp_purchase/AndroidInappPurchasePlugin.kt
@@ -15,6 +15,7 @@ import dev.hyo.openiap.DeveloperBillingOptionParamsAndroid
 import dev.hyo.openiap.ExternalLinkLaunchModeAndroid
 import dev.hyo.openiap.ExternalLinkTypeAndroid
 import dev.hyo.openiap.FetchProductsResult
+import dev.hyo.openiap.FetchProductsResultAll
 import dev.hyo.openiap.FetchProductsResultProducts
 import dev.hyo.openiap.FetchProductsResultSubscriptions
 import dev.hyo.openiap.InitConnectionConfig
@@ -87,11 +88,12 @@ class AndroidInappPurchasePlugin internal constructor() : MethodCallHandler, Act
         deduplicate: Boolean = false
     ): JSONArray {
         val entries: List<Map<String, Any?>> = when (result) {
+            is FetchProductsResultAll -> result.value?.map { it.toJson() }
+                ?: emptyList()
             is FetchProductsResultProducts -> result.value?.map { it.toJson() }
                 ?: emptyList()
             is FetchProductsResultSubscriptions -> result.value?.map { it.toJson() }
                 ?: emptyList()
-            else -> emptyList<Map<String, Any?>>()
         }
         val array = JSONArray()
         val seenIds = mutableSetOf<String>()

--- a/libraries/flutter_inapp_purchase/lib/flutter_inapp_purchase.dart
+++ b/libraries/flutter_inapp_purchase/lib/flutter_inapp_purchase.dart
@@ -2734,16 +2734,34 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
           queryType: queryType,
         );
 
-        // Wrap list in appropriate union type for OpenIAP compatibility
+        // Wrap list in the generated result union for OpenIAP compatibility.
+        // `All` must preserve product and subscription variants instead of
+        // flattening the mixed result into the product-only branch.
+        if (queryType == gentype.ProductQueryType.All) {
+          final wrapped = products
+              .map<gentype.ProductOrSubscription?>((product) {
+                if (product is gentype.ProductSubscription) {
+                  return gentype.ProductOrSubscriptionProductSubscription(
+                    product,
+                  );
+                }
+                if (product is gentype.Product) {
+                  return gentype.ProductOrSubscriptionProduct(product);
+                }
+                return null;
+              })
+              .whereType<gentype.ProductOrSubscription>()
+              .toList(growable: false);
+          return gentype.FetchProductsResultAll(wrapped);
+        }
         if (queryType == gentype.ProductQueryType.Subs) {
           return gentype.FetchProductsResultSubscriptions(
             products.whereType<gentype.ProductSubscription>().toList(),
           );
-        } else {
-          return gentype.FetchProductsResultProducts(
-            products.whereType<gentype.Product>().toList(),
-          );
         }
+        return gentype.FetchProductsResultProducts(
+          products.whereType<gentype.Product>().toList(),
+        );
       };
 
   gentype.QueryHandlers get queryHandlers => gentype.QueryHandlers(

--- a/libraries/flutter_inapp_purchase/test/fetch_products_all_test.dart
+++ b/libraries/flutter_inapp_purchase/test/fetch_products_all_test.dart
@@ -99,4 +99,44 @@ void main() {
     expect(subscriptions, hasLength(1));
     expect(subscriptions.first.id, 'premium_monthly');
   });
+
+  test('fetchProducts returns mixed products when querying all type', () async {
+    final platform = FakePlatform(operatingSystem: 'ios');
+    final iap = FlutterInappPurchase.private(platform);
+
+    await iap.initConnection();
+
+    final products = await iap.fetchProducts<types.ProductCommon>(
+      skus: const ['premium_monthly', 'coin_pack'],
+      type: types.ProductQueryType.All,
+    );
+
+    expect(products, hasLength(2));
+    expect(products.whereType<types.ProductSubscription>(), hasLength(1));
+    expect(products.whereType<types.Product>(), hasLength(1));
+  });
+
+  test('queryHandlers fetchProducts preserves all result union', () async {
+    final platform = FakePlatform(operatingSystem: 'ios');
+    final iap = FlutterInappPurchase.private(platform);
+
+    await iap.initConnection();
+
+    final result = await iap.queryHandlers.fetchProducts!(
+      skus: const ['premium_monthly', 'coin_pack'],
+      type: types.ProductQueryType.All,
+    );
+
+    expect(result, isA<types.FetchProductsResultAll>());
+    final allResult = result as types.FetchProductsResultAll;
+    expect(allResult.value, hasLength(2));
+    expect(
+      allResult.value,
+      contains(isA<types.ProductOrSubscriptionProductSubscription>()),
+    );
+    expect(
+      allResult.value,
+      contains(isA<types.ProductOrSubscriptionProduct>()),
+    );
+  });
 }

--- a/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
+++ b/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
@@ -837,6 +837,8 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
                 ProductQueryType.InApp -> FetchProductsResultProducts(inAppDetails.map { it.toProduct() })
                 ProductQueryType.Subs -> FetchProductsResultSubscriptions(subsDetails.mapNotNull { it.toSubscriptionProduct() })
                 ProductQueryType.All -> {
+                    // Preserve the mixed OpenIAP `all` union by keeping in-app
+                    // products and subscriptions in their distinct variants.
                     val combined = buildList<ProductOrSubscription> {
                         addAll(inAppDetails.map { ProductOrSubscription.ProductItem(it.toProduct()) })
                         addAll(

--- a/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
+++ b/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
@@ -36,6 +36,7 @@ import io.github.hyochan.kmpiap.openiap.ExternalPurchaseNoticeResultIOS
 import io.github.hyochan.kmpiap.openiap.InitConnectionConfig
 import io.github.hyochan.kmpiap.openiap.UserChoiceBillingDetails
 import io.github.hyochan.kmpiap.openiap.FetchProductsResult
+import io.github.hyochan.kmpiap.openiap.FetchProductsResultAll
 import io.github.hyochan.kmpiap.openiap.FetchProductsResultProducts
 import io.github.hyochan.kmpiap.openiap.FetchProductsResultSubscriptions
 import io.github.hyochan.kmpiap.openiap.MutationDeepLinkToSubscriptionsHandler
@@ -46,6 +47,7 @@ import io.github.hyochan.kmpiap.openiap.MutationRequestPurchaseHandler
 import io.github.hyochan.kmpiap.openiap.MutationValidateReceiptHandler
 import io.github.hyochan.kmpiap.openiap.MutationHandlers
 import io.github.hyochan.kmpiap.openiap.Product
+import io.github.hyochan.kmpiap.openiap.ProductOrSubscription
 import io.github.hyochan.kmpiap.openiap.ProductQueryType
 import io.github.hyochan.kmpiap.openiap.ProductRequest
 import io.github.hyochan.kmpiap.openiap.Purchase
@@ -835,11 +837,17 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
                 ProductQueryType.InApp -> FetchProductsResultProducts(inAppDetails.map { it.toProduct() })
                 ProductQueryType.Subs -> FetchProductsResultSubscriptions(subsDetails.mapNotNull { it.toSubscriptionProduct() })
                 ProductQueryType.All -> {
-                    val combined = buildList<Product> {
-                        addAll(inAppDetails.map { it.toProduct() })
-                        addAll(subsDetails.map { it.toProduct() })
+                    val combined = buildList<ProductOrSubscription> {
+                        addAll(inAppDetails.map { ProductOrSubscription.ProductItem(it.toProduct()) })
+                        addAll(
+                            subsDetails.mapNotNull { detail ->
+                                detail.toSubscriptionProduct()?.let {
+                                    ProductOrSubscription.ProductSubscriptionItem(it)
+                                }
+                            }
+                        )
                     }
-                    FetchProductsResultProducts(combined)
+                    FetchProductsResultAll(combined)
                 }
             }
         }

--- a/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
+++ b/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
@@ -777,7 +777,7 @@ internal class InAppPurchaseAndroid : KmpInAppPurchase, Application.ActivityLife
                 PurchaseError(code = ErrorCode.EmptySkuList, message = "SKU list is empty")
             )
 
-            val queryType = params.type ?: ProductQueryType.All
+            val queryType = params.type ?: ProductQueryType.InApp
             val includeInApp = queryType == ProductQueryType.InApp || queryType == ProductQueryType.All
             val includeSubs = queryType == ProductQueryType.Subs || queryType == ProductQueryType.All
 

--- a/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
+++ b/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
@@ -1271,12 +1271,14 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
     private fun convertAnyListToProductOrSubscriptions(data: Any?): List<ProductOrSubscription> {
         if (data == null) return emptyList()
 
-        return try {
-            val list = data as? List<*> ?: return emptyList()
-            list.mapNotNull { item ->
-                val dict = (item as? Map<*, *>) ?: return@mapNotNull null
+        val list = data as? List<*> ?: return emptyList()
+        return list.mapNotNull { item ->
+            runCatching {
+                val dict = (item as? Map<*, *>) ?: return@runCatching null
                 val map = dict.mapKeys { it.key.toString() }
 
+                // Native iOS may return either generated union JSON or raw StoreKit maps;
+                // decode the union first, then recover by product type for legacy payloads.
                 runCatching { ProductOrSubscription.fromJson(map) }.getOrElse {
                     val type = map["type"] as? String
                     if (type == ProductType.Subs.rawValue) {
@@ -1289,9 +1291,7 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
                         }
                     }
                 }
-            }
-        } catch (e: Exception) {
-            emptyList()
+            }.getOrNull()
         }
     }
 

--- a/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
+++ b/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
@@ -474,13 +474,21 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
                             val subscriptions = convertAnyListToProductSubscriptions(result)
                             continuation.resume(FetchProductsResultSubscriptions(subscriptions))
                         }
+                        ProductQueryType.All -> {
+                            val items = convertAnyListToProductOrSubscriptions(result)
+                            continuation.resume(FetchProductsResultAll(items))
+                        }
                         else -> {
                             val products = convertAnyListToProducts(result)
                             continuation.resume(FetchProductsResultProducts(products))
                         }
                     }
                 } else {
-                    continuation.resume(FetchProductsResultProducts(emptyList()))
+                    when (params.type) {
+                        ProductQueryType.Subs -> continuation.resume(FetchProductsResultSubscriptions(emptyList()))
+                        ProductQueryType.All -> continuation.resume(FetchProductsResultAll(emptyList()))
+                        else -> continuation.resume(FetchProductsResultProducts(emptyList()))
+                    }
                 }
             }
         }
@@ -1254,6 +1262,33 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
                     type = ProductType.Subs,
                     typeIOS = ProductTypeIOS.AutoRenewableSubscription
                 )
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun convertAnyListToProductOrSubscriptions(data: Any?): List<ProductOrSubscription> {
+        if (data == null) return emptyList()
+
+        return try {
+            val list = data as? List<*> ?: return emptyList()
+            list.mapNotNull { item ->
+                val dict = (item as? Map<*, *>) ?: return@mapNotNull null
+                val map = dict.mapKeys { it.key.toString() }
+
+                runCatching { ProductOrSubscription.fromJson(map) }.getOrElse {
+                    val type = map["type"] as? String
+                    if (type == ProductType.Subs.rawValue) {
+                        convertAnyListToProductSubscriptions(listOf(item)).firstOrNull()?.let {
+                            ProductOrSubscription.ProductSubscriptionItem(it)
+                        }
+                    } else {
+                        convertAnyListToProducts(listOf(item)).firstOrNull()?.let {
+                            ProductOrSubscription.ProductItem(it)
+                        }
+                    }
+                }
             }
         } catch (e: Exception) {
             emptyList()

--- a/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
+++ b/libraries/kmp-iap/library/src/iosMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseIOS.kt
@@ -1281,7 +1281,7 @@ internal class InAppPurchaseIOS : KmpInAppPurchase {
                 // decode the union first, then recover by product type for legacy payloads.
                 runCatching { ProductOrSubscription.fromJson(map) }.getOrElse {
                     val type = map["type"] as? String
-                    if (type == ProductType.Subs.rawValue) {
+                    if (type?.equals(ProductType.Subs.rawValue, ignoreCase = true) == true) {
                         convertAnyListToProductSubscriptions(listOf(item)).firstOrNull()?.let {
                             ProductOrSubscription.ProductSubscriptionItem(it)
                         }

--- a/packages/docs/src/pages/docs/apis/fetch-products.tsx
+++ b/packages/docs/src/pages/docs/apis/fetch-products.tsx
@@ -12,12 +12,15 @@ function FetchProducts() {
     <div className="doc-page">
       <SEO
         title="fetchProducts"
-        description="Retrieve products or subscriptions from the store by SKU."
+        description="Retrieve in-app products, subscriptions, or mixed all results from the store by SKU."
         path="/docs/apis/fetch-products"
         keywords="fetchProducts, product info, SKU, ProductRequest"
       />
       <h1>fetchProducts</h1>
-      <p>Retrieve products or subscriptions from the store by SKU.</p>
+      <p>
+        Retrieve in-app products, subscriptions, or a mixed result from the
+        store by SKU.
+      </p>
       <p>
         <strong>iOS:</strong> Wraps <code>Product.products(for:)</code>{' '}
         (StoreKit 2). Fetches the localized price/title for each SKU. Unknown
@@ -41,7 +44,10 @@ function FetchProducts() {
         >
           Google docs
         </a>
-        .
+        . When <code>type</code> is <code>&apos;all&apos;</code>, Android
+        queries both <code>INAPP</code> and <code>SUBS</code> product details
+        and returns a mixed result that preserves product and subscription
+        variants.
       </p>
 
       <AnchorLink id="request-apis" level="h2">
@@ -113,9 +119,9 @@ type FetchProductsResult =
             <CodeBlock language="kotlin">{`suspend fun fetchProducts(request: ProductRequest): FetchProductsResult`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`Future<FetchProductsResult> fetchProducts({
+            <CodeBlock language="dart">{`Future<List<T>> fetchProducts<T extends ProductCommon>({
   required List<String> skus,
-  ProductQueryType? type,
+  ProductQueryType type = ProductQueryType.InApp,
 });`}</CodeBlock>
           ),
           gdscript: (
@@ -196,14 +202,147 @@ public sealed record FetchProductsResultAll(IReadOnlyList<ProductOrSubscription>
           <em>
             (for <code>type: 'all'</code>)
           </em>{' '}
-          — Mixed array; use each entry's <code>type</code> field to
-          disambiguate.
+          — Mixed array that preserves each item as either a product or a
+          subscription. TypeScript-based wrappers expose this as a flat
+          discriminated union; generated Kotlin, Dart, and C# schema handlers
+          expose the same contract through their language-specific union
+          wrappers.
         </li>
         <li>
           <code>null</code> <em>(legacy)</em> — Older schema branch retained for
           backwards compatibility.
         </li>
       </ul>
+
+      <AnchorLink id="fetch-all-product-types" level="h2">
+        Fetch all product types
+      </AnchorLink>
+      <p>
+        Use <code>type: &apos;all&apos;</code> only when you intentionally want
+        one request to return both in-app products and subscriptions. If{' '}
+        <code>type</code> is omitted, OpenIAP defaults to in-app products.
+      </p>
+      <LanguageTabs>
+        {{
+          typescript: (
+            <CodeBlock language="typescript">{`import { fetchProducts } from 'expo-iap';
+
+const items = await fetchProducts({
+  skus: ['com.app.coins_100', 'com.app.monthly'],
+  type: 'all',
+});
+
+for (const item of items ?? []) {
+  if (item.type === 'subs') {
+    console.log('subscription', item.id, item.subscriptionOffers);
+  } else {
+    console.log('in-app product', item.id, item.displayPrice);
+  }
+}`}</CodeBlock>
+          ),
+          swift: (
+            <CodeBlock language="swift">{`let result = try await OpenIapModule.shared.fetchProducts(
+    ProductRequest(skus: ["com.app.coins_100", "com.app.monthly"], type: .all)
+)
+
+if case let .all(items) = result {
+    for item in items ?? [] {
+        switch item {
+        case let .product(product):
+            print("in-app product \\(product.id)")
+        case let .productSubscription(subscription):
+            print("subscription \\(subscription.id)")
+        }
+    }
+}`}</CodeBlock>
+          ),
+          kotlin: (
+            <CodeBlock language="kotlin">{`val result = openIapStore.fetchProducts(
+    ProductRequest(
+        skus = listOf("com.app.coins_100", "com.app.monthly"),
+        type = ProductQueryType.All,
+    )
+)
+
+if (result is FetchProductsResultAll) {
+    result.value.orEmpty().forEach { item ->
+        when (item) {
+            is ProductOrSubscription.ProductItem ->
+                println("in-app product " + item.value.id)
+            is ProductOrSubscription.ProductSubscriptionItem ->
+                println("subscription " + item.value.id)
+        }
+    }
+}`}</CodeBlock>
+          ),
+          kmp: (
+            <CodeBlock language="kotlin">{`val result = kmpIAP.fetchProducts(
+    ProductRequest(
+        skus = listOf("com.app.coins_100", "com.app.monthly"),
+        type = ProductQueryType.All,
+    )
+)
+
+if (result is FetchProductsResultAll) {
+    result.value.orEmpty().forEach { item ->
+        when (item) {
+            is ProductOrSubscription.ProductItem ->
+                println("in-app product " + item.value.id)
+            is ProductOrSubscription.ProductSubscriptionItem ->
+                println("subscription " + item.value.id)
+        }
+    }
+}`}</CodeBlock>
+          ),
+          dart: (
+            <CodeBlock language="dart">{`final items = await FlutterInappPurchase.instance
+    .fetchProducts<ProductCommon>(
+  skus: ['com.app.coins_100', 'com.app.monthly'],
+  type: ProductQueryType.All,
+);
+
+for (final item in items) {
+  switch (item.type) {
+    case ProductType.Subs:
+      print('subscription ' + item.id);
+    case ProductType.InApp:
+      print('in-app product ' + item.id);
+  }
+}`}</CodeBlock>
+          ),
+          gdscript: (
+            <CodeBlock language="gdscript">{`var request = ProductRequest.new()
+request.skus = ["com.app.coins_100", "com.app.monthly"]
+request.type = ProductQueryType.ALL
+var items = await iap.fetch_products(request)
+
+for item in items:
+    if item.type == ProductType.SUBS:
+        print("subscription ", item.id)
+    else:
+        print("in-app product ", item.id)`}</CodeBlock>
+          ),
+          csharp: (
+            <CodeBlock language="csharp">{`var result = await iap.FetchProductsAsync(new ProductRequest {
+    Skus = new[] { "com.app.coins_100", "com.app.monthly" },
+    Type = ProductQueryType.All,
+});
+
+if (result is FetchProductsResultAll allResult) {
+    foreach (var item in allResult.Value ?? Array.Empty<ProductOrSubscription>()) {
+        switch (item) {
+            case Product product:
+                Console.WriteLine($"in-app product {product.Id}");
+                break;
+            case ProductSubscription subscription:
+                Console.WriteLine($"subscription {subscription.Id}");
+                break;
+        }
+    }
+}`}</CodeBlock>
+          ),
+        }}
+      </LanguageTabs>
 
       <h2>Example</h2>
       <LanguageTabs>
@@ -283,16 +422,14 @@ val products = kmpIAP.fetchProducts {
 }`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`final FetchProductsResult result = await FlutterInappPurchase.instance.fetchProducts(
+            <CodeBlock language="dart">{`final products = await FlutterInappPurchase.instance.fetchProducts<Product>(
   skus: ['com.app.premium'],
   type: ProductQueryType.InApp,
 );
 
-// fetchProducts returns a sealed FetchProductsResult — unwrap by variant.
-final List<Product> products = switch (result) {
-  FetchProductsResultProducts(value: final list) => list ?? <Product>[],
-  _ => <Product>[],
-};`}</CodeBlock>
+for (final product in products) {
+  print(product.title + ': ' + product.displayPrice);
+}`}</CodeBlock>
           ),
           gdscript: (
             <CodeBlock language="gdscript">{`var request = ProductRequest.new()

--- a/packages/docs/src/pages/docs/types/product-request.tsx
+++ b/packages/docs/src/pages/docs/types/product-request.tsx
@@ -153,20 +153,22 @@ val allProducts = openIapStore.fetchProducts(
             ),
             dart: (
               <CodeBlock language="dart">{`// Fetch in-app purchases (default)
-final inappProducts = await FlutterInappPurchase.instance.fetchProducts(
+final inappProducts = await FlutterInappPurchase.instance.fetchProducts<Product>(
   skus: ['product1', 'product2'],
 );
 
 // Fetch only subscriptions
-final subscriptions = await FlutterInappPurchase.instance.fetchProducts(
+final subscriptions = await FlutterInappPurchase.instance
+    .fetchProducts<ProductSubscription>(
   skus: ['sub1', 'sub2'],
-  type: ProductQueryType.subs,
+  type: ProductQueryType.Subs,
 );
 
 // Fetch all products (both in-app and subscriptions)
-final allProducts = await FlutterInappPurchase.instance.fetchProducts(
+final allProducts = await FlutterInappPurchase.instance
+    .fetchProducts<ProductCommon>(
   skus: ['product1', 'sub1'],
-  type: ProductQueryType.all,
+  type: ProductQueryType.All,
 );`}</CodeBlock>
             ),
             csharp: (

--- a/packages/docs/src/pages/docs/types/request-purchase-props.tsx
+++ b/packages/docs/src/pages/docs/types/request-purchase-props.tsx
@@ -218,7 +218,7 @@ await FlutterInappPurchase.instance.requestPurchase(
       apple: RequestPurchaseIosProps(sku: 'monthly_sub'),
       google: RequestPurchaseAndroidProps(skus: ['monthly_sub']),
     ),
-    type: ProductQueryType.subs,
+    type: ProductQueryType.Subs,
   ),
 );`}</CodeBlock>
             ),

--- a/packages/docs/src/pages/docs/updates/releases.tsx
+++ b/packages/docs/src/pages/docs/updates/releases.tsx
@@ -26,6 +26,198 @@ function Releases() {
   useScrollToHash();
 
   const allNotes: Note[] = [
+    // June 26, 2026 — fetchProducts all mixed-result parity hotfix
+    {
+      id: 'fetch-products-all-parity-hotfix-2026-06-26',
+      date: new Date('2026-06-26'),
+      element: (
+        <div
+          key="fetch-products-all-parity-hotfix-2026-06-26"
+          style={noteCardStyle}
+        >
+          <AnchorLink
+            id="fetch-products-all-parity-hotfix-2026-06-26"
+            level="h4"
+          >
+            June 26, 2026 — fetchProducts all mixed-result parity hotfix
+          </AnchorLink>
+
+          <p
+            style={{
+              marginBottom: '1rem',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            Publishes a cross-SDK hotfix for{' '}
+            <code>{'fetchProducts({ type: "all" })'}</code> so combined product
+            queries preserve both in-app products and subscriptions instead of
+            collapsing to an empty or product-only result. The{' '}
+            <strong>OpenIAP Spec remains 2.0.2</strong>; this release updates
+            Android bridge/result mapping and wrapper compatibility layers for{' '}
+            <code>openiap-google</code>, <code>expo-iap</code>,{' '}
+            <code>flutter_inapp_purchase</code>, and <code>kmp-iap</code>. Track
+            the regression in{' '}
+            <a
+              href="https://github.com/hyodotdev/openiap/issues/192"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="external-link"
+            >
+              issue #192
+            </a>{' '}
+            and{' '}
+            <a
+              href="https://github.com/hyodotdev/openiap/pull/193"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="external-link"
+            >
+              PR #193
+            </a>
+            .
+          </p>
+
+          <ul
+            style={{
+              marginBottom: '1rem',
+              paddingLeft: '1.25rem',
+              fontSize: '0.9rem',
+            }}
+          >
+            <li>
+              <strong>Mixed all results preserved</strong> — explicit{' '}
+              <code>ProductQueryType.All</code> now returns the generated{' '}
+              <code>FetchProductsResultAll</code> branch in Google Play,
+              Horizon, Expo Android, Flutter Android, and KMP Android/iOS paths
+              that participate in the shared result contract.
+            </li>
+            <li>
+              <strong>Default product queries aligned</strong> — omitted{' '}
+              <code>ProductRequest.type</code> falls back to{' '}
+              <code>ProductQueryType.InApp</code>, matching the schema default
+              and docs while keeping explicit <code>All</code> behavior
+              available.
+            </li>
+            <li>
+              <strong>Flutter compatibility fixed</strong> — the public{' '}
+              <code>fetchProducts&lt;T&gt;()</code> convenience API keeps
+              returning typed lists, while{' '}
+              <code>queryHandlers.fetchProducts</code> now wraps{' '}
+              <code>All</code> results as <code>FetchProductsResultAll</code>{' '}
+              instead of dropping subscriptions through the product-only branch.
+            </li>
+            <li>
+              <strong>KMP iOS bridge hardened</strong> — mixed payload decoding
+              now preserves valid items even when one native bridge payload
+              fails to decode, and falls back by product type only after the
+              generated union decoder has been tried.
+            </li>
+            <li>
+              <strong>Expo Onside iOS bridge fixes</strong> — queue mutations
+              run on the main actor, available-purchase publishing honors{' '}
+              <code>alsoPublishToEventListenerIOS</code>, transaction dates stay
+              stable across repeated serialization, and price serialization
+              avoids direct binary floating-point formatting.
+            </li>
+            <li>
+              <strong>Audited unchanged SDKs</strong> — React Native, Godot, and
+              MAUI already preserve the mixed result contract and do not require
+              code changes in this release.
+            </li>
+          </ul>
+
+          <div
+            style={{
+              paddingTop: '1rem',
+              borderTop: '1px solid var(--border-color)',
+            }}
+          >
+            <h5 style={{ margin: '0 0 0.5rem 0' }}>Package Releases</h5>
+            <ul
+              style={{
+                margin: 0,
+                paddingLeft: '1.25rem',
+                fontSize: '0.9rem',
+              }}
+            >
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/google-2.2.3"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  openiap-google 2.2.3
+                </a>{' '}
+                (
+                <a
+                  href="https://central.sonatype.com/artifact/io.github.hyochan.openiap/openiap-google/2.2.3"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Maven Central
+                </a>
+                )
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/expo-iap-4.3.4"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  expo-iap 4.3.4
+                </a>{' '}
+                (
+                <a
+                  href="https://www.npmjs.com/package/expo-iap/v/4.3.4"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  npm
+                </a>
+                )
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.3.5"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  flutter_inapp_purchase 9.3.5
+                </a>{' '}
+                (
+                <a
+                  href="https://pub.dev/packages/flutter_inapp_purchase/versions/9.3.5"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  pub.dev
+                </a>
+                )
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/kmp-iap-2.3.3"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  kmp-iap 2.3.3
+                </a>{' '}
+                (
+                <a
+                  href="https://central.sonatype.com/artifact/io.github.hyochan/kmp-iap/2.3.3"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Maven Central
+                </a>
+                )
+              </li>
+            </ul>
+          </div>
+        </div>
+      ),
+    },
+
     // June 23, 2026 — Flutter Swift Package Manager support
     {
       id: 'flutter-swift-package-manager-support-2026-06-23',

--- a/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
@@ -33,7 +33,6 @@ import dev.hyo.openiap.utils.HorizonBillingConverters.toActiveSubscription
 import dev.hyo.openiap.utils.HorizonBillingConverters.toInAppProduct
 import dev.hyo.openiap.utils.HorizonBillingConverters.toPurchase
 import dev.hyo.openiap.utils.HorizonBillingConverters.toSubscriptionProduct
-import dev.hyo.openiap.utils.toProduct
 import dev.hyo.openiap.utils.verifyPurchaseWithGooglePlay
 import dev.hyo.openiap.utils.verifyPurchaseWithHorizon
 import dev.hyo.openiap.MutationVerifyPurchaseHandler
@@ -220,11 +219,11 @@ class OpenIapModule(
                 ProductQueryType.InApp -> FetchProductsResultProducts(inAppProducts)
                 ProductQueryType.Subs -> FetchProductsResultSubscriptions(subscriptionProducts)
                 ProductQueryType.All -> {
-                    val combined = buildList<Product> {
-                        addAll(inAppProducts)
-                        addAll(subscriptionProducts.map(ProductSubscriptionAndroid::toProduct))
+                    val combined = buildList<ProductOrSubscription> {
+                        addAll(inAppProducts.map { ProductOrSubscription.ProductItem(it) })
+                        addAll(subscriptionProducts.map { ProductOrSubscription.ProductSubscriptionItem(it) })
                     }
-                    FetchProductsResultProducts(combined)
+                    FetchProductsResultAll(combined)
                 }
             }
         }

--- a/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
@@ -183,7 +183,7 @@ class OpenIapModule(
             OpenIapLog.i("Requested SKUs: ${params.skus}", TAG)
             OpenIapLog.i("Query type: ${params.type}", TAG)
 
-            val queryType = params.type ?: ProductQueryType.All
+            val queryType = params.type ?: ProductQueryType.InApp
             val includeInApp = queryType == ProductQueryType.InApp || queryType == ProductQueryType.All
             val includeSubs = queryType == ProductQueryType.Subs || queryType == ProductQueryType.All
 

--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/OpenIapModule.kt
@@ -205,7 +205,7 @@ class OpenIapModule(
             if (!client.isReady) throw OpenIapError.NotPrepared
             if (params.skus.isEmpty() && params.type != ProductQueryType.All) throw OpenIapError.EmptySkuList
 
-            val queryType = params.type ?: ProductQueryType.All
+            val queryType = params.type ?: ProductQueryType.InApp
 
             when (queryType) {
                 ProductQueryType.InApp -> {


### PR DESCRIPTION
## Summary

- Fix `fetchProducts({ type: 'all' })` empty-result regression by preserving the `FetchProductsResultAll` mixed product/subscription union at the Expo Android bridge boundary.
- Keep the same mixed-result contract in Flutter Android, KMP Android/iOS, and Google Play/Horizon so SDK parity does not collapse subscriptions into plain products.
- Fix Flutter's generated `queryHandlers.fetchProducts` compatibility layer so `ProductQueryType.All` returns `FetchProductsResultAll` instead of dropping subscriptions through the product-only branch.
- Align omitted product-query type defaults to `InApp` while preserving explicit `All` behavior.
- Address review feedback in the Expo Onside iOS bridge: main-actor queue mutation, stable transaction-date serialization, `alsoPublish` event publishing, and decimal-safe price serialization.
- Update docs for `fetchProducts(type: 'all')`, correct Flutter enum/generic examples, and add post-release notes for the expected patch releases.
- Audited React Native, Godot, and MAUI paths; they already preserve the mixed `all` result and did not need code changes.

Closes #192

## Scope note

Although #192 reproduces through the Expo Android example, the bug is a shared SDK contract issue around `FetchProductsResultAll`. This PR keeps the fix in one branch because each touched adapter is part of the same fetch-products parity surface; splitting only the Expo Android line would leave the same contract mismatch in sibling libraries.

## Release note scope

Assuming this PR is released after merge, the docs release note records the expected package patch releases as:

- `openiap-google 2.2.3`
- `expo-iap 4.3.4`
- `flutter_inapp_purchase 9.3.5`
- `kmp-iap 2.3.3`

The OpenIAP Spec remains `2.0.2`. Apple, React Native, Godot, and MAUI are documented as audited/unchanged for this regression.

## Test plan

- [x] `cd libraries/expo-iap && bun run lint:tsc`
- [x] `cd libraries/expo-iap && bun run lint`
- [x] `cd libraries/expo-iap && bun run test`
- [x] `cd libraries/expo-iap/example && bun run test`
- [x] `cd libraries/expo-iap/example/android && ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :expo-iap:compileDebugKotlin`
- [x] `cd packages/google && ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :openiap:compilePlayDebugKotlin`
- [x] `cd packages/google && ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :openiap:compileHorizonDebugKotlin`
- [x] `cd libraries/kmp-iap && ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :library:compileDebugKotlinAndroid`
- [x] `cd libraries/kmp-iap && ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :library:testDebugUnitTest`
- [x] `cd libraries/kmp-iap && ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :library:compileKotlinIosSimulatorArm64`
- [x] `xcodebuild -workspace libraries/expo-iap/example/ios/expoiapexample.xcworkspace -scheme expoiapexample -configuration Debug -destination 'id=0ED50699-1016-4DFE-8DAF-6BB29AD7FAF1' build`
- [x] Android device E2E on Pixel 2 (`HT79F1A00473`): product listing, function calls, and real Google Play purchase path verified. Amazon device was intentionally skipped because it is outside this PR.
- [x] iOS Expo example E2E: product loading and real purchase sheet cancel path verified when the system auth prompt appears.
- [x] `bun run audit:parity`
- [x] `cd libraries/flutter_inapp_purchase && PATH="$HOME/.cache/codex/flutter-3.41.9/bin:$PATH" flutter pub get && flutter analyze && flutter test`
- [x] `cd libraries/flutter_inapp_purchase/example && PATH="$HOME/.cache/codex/flutter-3.41.9/bin:$PATH" flutter pub get && ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" flutter build apk --debug`
- [x] Confirmed `cd libraries/flutter_inapp_purchase/android && ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew compileDebugKotlin --no-daemon --stacktrace` is not a representative standalone check without a Flutter host project; it fails before this patch on missing `io.flutter.*` embedding classes. Android compile coverage is provided by the Flutter example host build above.
- [x] `cd packages/docs && PATH="$HOME/.bun/bin:$PATH" bun run lint`
- [x] `PATH="$HOME/.bun/bin:$PATH" bun audit:docs`
- [x] `git diff --check`

Preview recording: not applicable; this is a native bridge/result mapping and documentation/release-note fix with no visual UI surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "All" product queries now return a combined list containing both in-app products and subscriptions.
* **Bug Fixes**
  * Fixed product fetching so "All" results are converted and delivered consistently across platforms.
  * Improved type-aware handling for empty "All" results (and removed inconsistent fallbacks).
  * Updated behavior when no product type is specified to return in-app products only.
  * Refined Onside transaction handling and improved transaction/product data serialization (date, currency, storefront).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
