### PR TITLE
fix(apple): preserve syncIOS cancellation errors

### DIFF
--- a/packages/apple/Sources/Models/OpenIapError.swift
+++ b/packages/apple/Sources/Models/OpenIapError.swift
@@ -95,18 +95,43 @@ public extension PurchaseError {
     }
 
     /// Wraps any error into a `PurchaseError`, preserving existing instances.
-    /// Automatically maps StoreKitError to appropriate PurchaseError codes.
+    /// Automatically maps StoreKit errors to appropriate PurchaseError codes.
     static func wrap(
         _ error: Error,
         fallback: ErrorCode = .purchaseError,
         productId: String? = nil
     ) -> PurchaseError {
+        func isStoreKitCancellation(_ error: Error) -> Bool {
+            if let storeKitError = error as? StoreKitError {
+                switch storeKitError {
+                case .userCancelled:
+                    return true
+                case .systemError(let underlyingError):
+                    return isStoreKitCancellation(underlyingError)
+                default:
+                    return false
+                }
+            }
+
+            if let skError = error as? SKError {
+                return skError.code == .paymentCancelled
+            }
+
+            let nsError = error as NSError
+            return nsError.domain == SKError.errorDomain &&
+                nsError.code == SKError.Code.paymentCancelled.rawValue
+        }
+
         // If already a PurchaseError, return as-is
         if let purchaseError = error as? PurchaseError {
             return purchaseError
         }
 
-        // Map StoreKitError to PurchaseError
+        if isStoreKitCancellation(error) {
+            return make(code: .userCancelled, productId: productId, message: error.localizedDescription)
+        }
+
+        // Map StoreKit 2 errors to PurchaseError
         if let storeKitError = error as? StoreKitError {
             let errorCode: ErrorCode
             switch storeKitError {

--- a/packages/apple/Sources/OpenIapModule.swift
+++ b/packages/apple/Sources/OpenIapModule.swift
@@ -1149,7 +1149,7 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
             try await AppStore.sync()
             return true
         } catch {
-            throw makePurchaseError(code: .serviceError, message: error.localizedDescription)
+            throw PurchaseError.wrap(error, fallback: .serviceError)
         }
     }
 

--- a/packages/apple/Tests/OpenIapTests.swift
+++ b/packages/apple/Tests/OpenIapTests.swift
@@ -1,3 +1,4 @@
+import StoreKit
 import XCTest
 @testable import OpenIAP
 
@@ -58,6 +59,32 @@ final class OpenIapTests: XCTestCase {
     func testPurchaseErrorMakeProvidesDefaultMessage() {
         let error = PurchaseError.make(code: .userCancelled, productId: "sku", message: nil)
         XCTAssertEqual(error.message, "User cancelled the purchase flow")
+    }
+
+    func testPurchaseErrorWrapMapsStoreKitUserCancelled() {
+        let error = PurchaseError.wrap(StoreKitError.userCancelled, fallback: .serviceError)
+        XCTAssertEqual(error.code, .userCancelled)
+    }
+
+    func testPurchaseErrorWrapMapsSKPaymentCancelled() {
+        let error = PurchaseError.wrap(SKError(.paymentCancelled), fallback: .serviceError)
+        XCTAssertEqual(error.code, .userCancelled)
+    }
+
+    func testPurchaseErrorWrapMapsStoreKitSystemPaymentCancelled() {
+        let error = PurchaseError.wrap(
+            StoreKitError.systemError(SKError(.paymentCancelled)),
+            fallback: .serviceError
+        )
+        XCTAssertEqual(error.code, .userCancelled)
+    }
+
+    func testPurchaseErrorWrapMapsStoreKitNSErrorPaymentCancelled() {
+        let error = PurchaseError.wrap(
+            NSError(domain: SKError.errorDomain, code: SKError.Code.paymentCancelled.rawValue),
+            fallback: .serviceError
+        )
+        XCTAssertEqual(error.code, .userCancelled)
     }
 
     @available(iOS 15.0, macOS 14.0, tvOS 16.0, watchOS 8.0, *)

--- a/packages/docs/src/pages/docs/updates/releases.tsx
+++ b/packages/docs/src/pages/docs/updates/releases.tsx
@@ -26,6 +26,225 @@ function Releases() {
   useScrollToHash();
 
   const allNotes: Note[] = [
+    // June 28, 2026 — iOS syncIOS cancellation error hotfix
+    {
+      id: 'ios-syncios-cancellation-error-hotfix-2026-06-28',
+      date: new Date('2026-06-28'),
+      element: (
+        <div
+          key="ios-syncios-cancellation-error-hotfix-2026-06-28"
+          style={noteCardStyle}
+        >
+          <AnchorLink
+            id="ios-syncios-cancellation-error-hotfix-2026-06-28"
+            level="h4"
+          >
+            June 28, 2026 — iOS syncIOS cancellation error hotfix
+          </AnchorLink>
+
+          <p
+            style={{
+              marginBottom: '1rem',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            Publishes an iOS hotfix for{' '}
+            <Link to="/docs/apis/ios/sync-ios">
+              <code>syncIOS()</code>
+            </Link>{' '}
+            so user-cancelled App Store sign-in prompts surface as{' '}
+            <code>user-cancelled</code> instead of <code>service-error</code>.
+            The <strong>OpenIAP Spec remains 2.0.2</strong>; this release
+            updates the native Apple package and framework-library iOS
+            integrations that consume it. Track the fix in{' '}
+            <a
+              href="https://github.com/hyodotdev/openiap/issues/194"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="external-link"
+            >
+              issue #194
+            </a>{' '}
+            and{' '}
+            <a
+              href="https://github.com/hyodotdev/openiap/pull/195"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="external-link"
+            >
+              PR #195
+            </a>
+            .
+          </p>
+
+          <ul
+            style={{
+              marginBottom: '1rem',
+              paddingLeft: '1.25rem',
+              fontSize: '0.9rem',
+            }}
+          >
+            <li>
+              <strong>syncIOS cancellation preserved</strong> —{' '}
+              <code>AppStore.sync()</code> failures now pass through{' '}
+              <code>PurchaseError.wrap</code> so StoreKit cancellation errors
+              retain <code>ErrorCode.UserCancelled</code> across the native
+              Apple package and framework bridges.
+            </li>
+            <li>
+              <strong>StoreKit error shapes normalized</strong> — cancellation
+              is detected from <code>StoreKitError.userCancelled</code>,{' '}
+              <code>SKError.paymentCancelled</code>, matching{' '}
+              <code>NSError</code> values, and{' '}
+              <code>StoreKitError.systemError</code> wrappers.
+            </li>
+            <li>
+              <strong>Framework helper behavior restored</strong> — React Native
+              and Expo apps can rely on <code>isUserCancelledError()</code> for
+              cancelled <code>syncIOS()</code> prompts instead of treating the
+              flow as a service failure.
+            </li>
+            <li>
+              <strong>Wrapper rollout</strong> — React Native, Expo, Flutter,
+              KMP, Godot, and MAUI patch releases carry the native Apple
+              cancellation mapping through their iOS integrations.
+            </li>
+            <li>
+              <strong>Regression coverage</strong> — Apple package tests cover
+              direct StoreKit 2 cancellation, StoreKit 1 payment cancellation,
+              raw <code>NSError</code> bridging, and nested system-error
+              cancellation.
+            </li>
+          </ul>
+
+          <div
+            style={{
+              paddingTop: '1rem',
+              borderTop: '1px solid var(--border-color)',
+            }}
+          >
+            <h5 style={{ margin: '0 0 0.5rem 0' }}>Package Releases</h5>
+            <ul
+              style={{
+                margin: 0,
+                paddingLeft: '1.25rem',
+                fontSize: '0.9rem',
+              }}
+            >
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/2.2.3"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  openiap-apple 2.2.3
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/react-native-iap-15.3.4"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  react-native-iap 15.3.4
+                </a>{' '}
+                (
+                <a
+                  href="https://www.npmjs.com/package/react-native-iap/v/15.3.4"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  npm
+                </a>
+                )
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/expo-iap-4.3.5"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  expo-iap 4.3.5
+                </a>{' '}
+                (
+                <a
+                  href="https://www.npmjs.com/package/expo-iap/v/4.3.5"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  npm
+                </a>
+                )
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.3.6"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  flutter_inapp_purchase 9.3.6
+                </a>{' '}
+                (
+                <a
+                  href="https://pub.dev/packages/flutter_inapp_purchase/versions/9.3.6"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  pub.dev
+                </a>
+                )
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/kmp-iap-2.3.4"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  kmp-iap 2.3.4
+                </a>{' '}
+                (
+                <a
+                  href="https://central.sonatype.com/artifact/io.github.hyochan/kmp-iap/2.3.4"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Maven Central
+                </a>
+                )
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/godot-iap-2.3.3"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  godot-iap 2.3.3
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/hyodotdev/openiap/releases/tag/maui-iap-1.1.6"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  OpenIap.Maui 1.1.6
+                </a>{' '}
+                (
+                <a
+                  href="https://www.nuget.org/packages/OpenIap.Maui/1.1.6"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  NuGet
+                </a>
+                )
+              </li>
+            </ul>
+          </div>
+        </div>
+      ),
+    },
+
     // June 26, 2026 — fetchProducts all mixed-result parity hotfix
     {
       id: 'fetch-products-all-parity-hotfix-2026-06-26',


### PR DESCRIPTION
## Summary

- Route `syncIOS()` failures through `PurchaseError.wrap` so StoreKit cancellation stays `user-cancelled` instead of becoming `service-error`.
- Detect StoreKit cancellation across `StoreKitError.userCancelled`, `SKError.paymentCancelled`, `NSError(SKErrorDomain/paymentCancelled)`, and `StoreKitError.systemError` wrappers.
- Add Apple package tests covering the cancellation mappings.
- Add a published-style release note that assumes the Apple and framework SDK patch releases are available, with GitHub Release/package-manager links.

## Changes

### Apple
- Updated `syncIOS()` error handling to preserve mapped StoreKit errors.
- Expanded `PurchaseError.wrap` cancellation detection for StoreKit 1/2 bridging shapes.

### Docs
- Added the June 28, 2026 iOS `syncIOS()` cancellation hotfix entry to release notes.
- Documented assumed package releases for `openiap-apple 2.2.3`, `react-native-iap 15.3.4`, `expo-iap 4.3.5`, `flutter_inapp_purchase 9.3.6`, `kmp-iap 2.3.4`, `godot-iap 2.3.3`, and `OpenIap.Maui 1.1.6`.
- Included release links in the same style as existing published release notes, per the requested post-release assumption.

### Tests
- Added regression coverage for direct and wrapped StoreKit cancellation cases.

## Test plan

- [x] `cd packages/apple && swift build`
- [x] `cd packages/apple && swift test`
- [x] `cd packages/docs && bunx prettier --check "src/**/*.{ts,tsx,js,jsx,css,json}"`
- [x] `cd packages/docs && bun run build`
- [x] `bun run audit:docs`
- [x] `git diff --check`
- [x] `~/.bun/bin/bun audit:parity`

## Preview

- Docs release page rendered locally at `/docs/updates/releases#ios-syncios-cancellation-error-hotfix-2026-06-28` with Chrome.
- Verified the new release heading, issue #194 link, and assumed release links such as `openiap-apple 2.2.3` and `react-native-iap 15.3.4`.

Fixes #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling to recognize more StoreKit-related “user cancelled” scenarios consistently.
  * When iOS app store sync fails, error details are now wrapped/preserved more reliably.
* **Tests**
  * Added coverage for several cancellation input forms to ensure they map to the correct user-cancelled result.
* **Documentation**
  * Added an entry to the release notes for the iOS sync cancellation/error hotfix (June 28, 2026).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->