### PR TITLE
fix(rn): serialize iOS billing plan type

### DIFF
--- a/libraries/godot-iap/addons/godot-iap/android/GodotIap.gdap
+++ b/libraries/godot-iap/addons/godot-iap/android/GodotIap.gdap
@@ -5,4 +5,4 @@ binary="GodotIap.release.aar"
 
 [dependencies]
 local=[]
-remote=["io.github.hyochan.openiap:openiap-google:2.2.3", "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0"]
+remote=["io.github.hyochan.openiap:openiap-google:2.2.4", "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0"]

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -208,8 +208,8 @@ class HybridRnIap: HybridRnIapSpec {
                 if case .second(let advancedCommerceData) = iosRequest.advancedCommerceData {
                     iosPayload["advancedCommerceData"] = advancedCommerceData
                 }
-                if case .second(let billingPlanType) = iosRequest.billingPlanType {
-                    iosPayload["billingPlanType"] = billingPlanType
+                if let billingPlanType = iosRequest.billingPlanType {
+                    iosPayload["billingPlanType"] = billingPlanType.stringValue
                 }
                 // WWDC 2025 / iOS 18+ subscription offer fields
                 if case .second(let compactJWS) = iosRequest.compactJWS {


### PR DESCRIPTION
## Summary
- Fix React Native iOS purchase request serialization for `SubscriptionBillingPlanTypeIOS` now generated as an optional enum instead of a Nitro variant.
- Regenerate the Godot Android GDAP dependency pin after `openiap-google` 2.2.4 so parity audit stays green.

## Context
The `release-react-native` workflow failed in `Build iOS library` with:

```
type `SubscriptionBillingPlanTypeIOS?` has no member `second`
```

`billingPlanType` should be unwrapped as an optional enum and serialized through `stringValue`.

## Validation
- `cd libraries/react-native-iap && yarn typecheck`
- `cd libraries/react-native-iap && yarn nitrogen`
- `cd libraries/react-native-iap/example/ios && bundle exec pod install --repo-update`
- `cd libraries/react-native-iap/example/ios && xcodebuild build -workspace example.xcworkspace -scheme example -destination 'generic/platform=iOS Simulator' -configuration Debug CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO`\n- `bun run audit:parity`\n- `git diff --check`\n\nDevice-backed store E2E was not run here; this PR fixes the compile-time release blocker before rerunning the package release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved purchase flow handling on iOS for better compatibility with subscription-related purchase data.
  * Updated the Android in-app purchase library to a newer version, which may improve stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->