### PR TITLE
docs: fix ios commitment release notes

### DIFF
--- a/packages/docs/src/pages/docs/features/subscription/index.tsx
+++ b/packages/docs/src/pages/docs/features/subscription/index.tsx
@@ -59,9 +59,20 @@ function Subscription() {
           <p>
             <strong>Availability:</strong> billing plan selection requires iOS,
             iPadOS, macOS, tvOS, or visionOS 26.4+ and an app compiled with the
-            26.5 SDK or later. If the app runs on an older Apple OS version,
-            omit <code>billingPlanType</code> and let StoreKit purchase the
-            default plan. Never send <code>unknown</code> as a purchase option.
+            StoreKit billing-plan APIs available in Xcode 26.4+ / Swift 6.3+. If
+            the app runs on an older Apple OS version, omit{' '}
+            <code>billingPlanType</code> and let StoreKit purchase the default
+            plan. Never send <code>unknown</code> as a purchase option.
+          </p>
+        </div>
+
+        <div className="alert-card alert-card--info">
+          <p>
+            Treat <code>pricingTermsIOS</code> as the source of truth before
+            showing a commitment option. If StoreKit does not return a term for
+            the user&apos;s selected <code>billingPlanType</code>, fall back to
+            the default subscription purchase and leave{' '}
+            <code>billingPlanType</code> unset.
           </p>
         </div>
 

--- a/packages/docs/src/pages/docs/types/ios/subscription-billing-plan-ios.tsx
+++ b/packages/docs/src/pages/docs/types/ios/subscription-billing-plan-ios.tsx
@@ -31,8 +31,9 @@ function SubscriptionBillingPlanIOS() {
         <p>
           <strong>Availability:</strong> billing plan selection requires iOS,
           iPadOS, macOS, tvOS, or visionOS 26.4+ and an app compiled with the
-          26.5 SDK or later. On older runtimes, omit{' '}
-          <code>billingPlanType</code> and use the store's default billing plan.
+          StoreKit billing-plan APIs available in Xcode 26.4+ / Swift 6.3+. On
+          older runtimes, omit <code>billingPlanType</code> and use the store's
+          default billing plan.
         </p>
       </div>
 

--- a/packages/docs/src/pages/docs/types/ios/subscription-billing-plan-ios.tsx
+++ b/packages/docs/src/pages/docs/types/ios/subscription-billing-plan-ios.tsx
@@ -32,8 +32,8 @@ function SubscriptionBillingPlanIOS() {
           <strong>Availability:</strong> billing plan selection requires iOS,
           iPadOS, macOS, tvOS, or visionOS 26.4+ and an app compiled with the
           StoreKit billing-plan APIs available in Xcode 26.4+ / Swift 6.3+. On
-          older runtimes, omit <code>billingPlanType</code> and use the store's
-          default billing plan.
+          older runtimes, omit <code>billingPlanType</code> and use the
+          store&apos;s default billing plan.
         </p>
       </div>
 

--- a/packages/docs/src/pages/docs/updates/releases.tsx
+++ b/packages/docs/src/pages/docs/updates/releases.tsx
@@ -48,9 +48,8 @@ function Releases() {
               color: 'var(--text-secondary)',
             }}
           >
-            Publishes <strong>OpenIAP Spec 2.0.4</strong> and SDK releases for
-            StoreKit 26.4 subscription billing plans, including monthly billing
-            with a 12-month commitment. Apps can pass{' '}
+            Publishes SDK releases for StoreKit 26.4 subscription billing plans,
+            including monthly billing with a 12-month commitment. Apps can pass{' '}
             <code>RequestSubscriptionIosProps.billingPlanType</code> during
             subscription purchase requests and inspect pricing terms,
             transaction commitment progress, and renewal billing-plan metadata
@@ -67,7 +66,9 @@ function Releases() {
             <Link to="/docs/features/subscription#ios-commitment-billing-plans">
               iOS commitment billing plans guide
             </Link>{' '}
-            for usage examples and field references.
+            for usage examples and field references. The OpenIAP spec version is
+            tracked in <code>openiap-versions.json</code> and is not a
+            separately published package release.
           </p>
 
           <ul
@@ -83,8 +84,8 @@ function Releases() {
               <code>monthly</code> and <code>up-front</code> values, mapping to
               StoreKit&apos;s{' '}
               <code>Product.PurchaseOption.billingPlanType</code> on iOS,
-              iPadOS, macOS, tvOS, and visionOS 26.4+ when compiled with the
-              26.5 SDK or later.
+              iPadOS, macOS, tvOS, and visionOS 26.4+ when compiled with Xcode
+              26.4+ / Swift 6.3+.
             </li>
             <li>
               <strong>Introductory offer eligibility correction</strong> —{' '}
@@ -143,15 +144,6 @@ function Releases() {
                 fontSize: '0.9rem',
               }}
             >
-              <li>
-                <a
-                  href="https://github.com/hyodotdev/openiap/releases/tag/gql-2.0.4"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  openiap-spec 2.0.4
-                </a>
-              </li>
               <li>
                 <a
                   href="https://github.com/hyodotdev/openiap/releases/tag/2.2.4"
@@ -947,7 +939,6 @@ function Releases() {
                 fontSize: '0.9rem',
               }}
             >
-              <li>OpenIAP Spec 2.0.2</li>
               <li>
                 <a
                   href="https://github.com/hyodotdev/openiap/releases/tag/google-2.2.2"
@@ -1093,9 +1084,8 @@ function Releases() {
               color: 'var(--text-secondary)',
             }}
           >
-            Publishes <strong>OpenIAP Spec 2.0.3</strong> and SDK patch releases
-            so iOS subscription products expose the App Store subscription group
-            identifier directly as{' '}
+            Publishes SDK patch releases so iOS subscription products expose the
+            App Store subscription group identifier directly as{' '}
             <code>ProductSubscriptionIOS.subscriptionGroupIdIOS</code>.{' '}
             <code>subscriptionInfoIOS</code> remains deprecated: apps should use{' '}
             <code>subscriptionOffers</code> for offer metadata and{' '}
@@ -1165,15 +1155,6 @@ function Releases() {
                 fontSize: '0.9rem',
               }}
             >
-              <li>
-                <a
-                  href="https://github.com/hyodotdev/openiap/releases/tag/gql-2.0.3"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  openiap-spec 2.0.3
-                </a>
-              </li>
               <li>
                 <a
                   href="https://github.com/hyodotdev/openiap/releases/tag/2.2.2"
@@ -1352,7 +1333,6 @@ function Releases() {
                 fontSize: '0.9rem',
               }}
             >
-              <li>OpenIAP Spec 2.0.2</li>
               <li>
                 <a
                   href="https://github.com/hyodotdev/openiap/releases/tag/google-2.2.1"
@@ -1599,7 +1579,7 @@ function Releases() {
               color: 'var(--text-secondary)',
             }}
           >
-            Publishes <strong>OpenIAP Spec 2.0.2</strong> with{' '}
+            Tracks <strong>OpenIAP Spec 2.0.2</strong> with{' '}
             <code>PurchaseUpdatedListenerOptions</code> and an iOS-only{' '}
             <code>dedupeTransactionIOS</code> flag. StoreKit can replay the same
             unfinished transaction through request and transaction-update paths
@@ -1686,7 +1666,6 @@ function Releases() {
                 fontSize: '0.9rem',
               }}
             >
-              <li>OpenIAP Spec 2.0.2</li>
               <li>
                 <a
                   href="https://github.com/hyodotdev/openiap/releases/tag/2.1.9"
@@ -3453,15 +3432,6 @@ function Releases() {
                 fontSize: '0.9rem',
               }}
             >
-              <li>
-                <a
-                  href="https://github.com/hyodotdev/openiap/releases/tag/gql-2.0.1"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  openiap-spec 2.0.1
-                </a>
-              </li>
               <li>
                 <a
                   href="https://github.com/hyodotdev/openiap/releases/tag/2.1.2"


### PR DESCRIPTION
## Summary

- Remove non-existent `openiap-spec` / `gql-2.x` package-release entries from release notes.
- Clarify that the shared OpenIAP spec version is tracked in `openiap-versions.json`, not published as a package release.
- Correct iOS commitment billing plan availability wording to match the Apple bridge guard and add `pricingTermsIOS` fallback guidance.

## Preview

Generated and verified a local docs preview recording:

- `/tmp/openiap-docs-preview/docs-preview.mp4` (312 KB)
- Captures `/docs/updates/releases#ios-subscription-commitment-billing-plans-2026-07-02`
- Captures `/docs/features/subscription#ios-commitment-billing-plans`

GitHub CLI/API does not expose PR attachment upload for local files; the preview was produced from `vite preview` with headless Chrome and verified before opening this PR.

## Verification

- `cd packages/docs && bunx prettier --check "src/**/*.{ts,tsx,js,jsx,css,json}"`
- `cd packages/docs && bun run build`
- `bun run audit:docs`
- `git diff --check`
- pre-commit: SDK parity audit, docs typecheck, audit-docs, Prettier check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated iOS “Commitment Billing Plans” availability text to use “StoreKit billing-plan APIs available in Xcode 26.4+ / Swift 6.3+”.
  * Clarified legacy guidance: omit `billingPlanType` on older OS versions so the default billing plan is used, and “Never send `unknown`” as a purchase option.
  * Refreshed release-note copy to reflect SDK publishing and that OpenIAP spec versions are tracked but not separately published, with related “Package Releases” entries removed/adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->