### PR TITLE
fix: align changelog release notes

### DIFF
--- a/.github/workflows/release-flutter.yml
+++ b/.github/workflows/release-flutter.yml
@@ -262,9 +262,18 @@ jobs:
           PREV_VERSION: ${{ steps.bump.outputs.prev_version }}
         run: |
           DATE=$(date +%Y-%m-%d)
+          CONSOLIDATED_RELEASE_NOTES="https://openiap.dev/docs/updates/releases"
           CHANGES=""
-          if git rev-parse "$PREV_VERSION" >/dev/null 2>&1; then
-            PR_LINES=$(git log "${PREV_VERSION}..HEAD" --merges --pretty=format:"%s" | \
+          PREV_TAG=""
+          for CANDIDATE in "flutter-iap-$PREV_VERSION" "$PREV_VERSION"; do
+            if [ -n "$CANDIDATE" ] && git rev-parse "$CANDIDATE" >/dev/null 2>&1; then
+              PREV_TAG="$CANDIDATE"
+              break
+            fi
+          done
+
+          if [ -n "$PREV_TAG" ]; then
+            PR_LINES=$(git log "${PREV_TAG}..HEAD" --merges --pretty=format:"%s" -- libraries/flutter_inapp_purchase/ packages/google/ packages/apple/ | \
               sed -n 's/^Merge pull request #\([0-9]*\) from .*/\1/p')
             for PR_NUM in $PR_LINES; do
               PR_TITLE=$(git log --all --grep="Merge pull request #${PR_NUM}" --pretty=format:"%s" | head -1 | sed "s|Merge pull request #${PR_NUM} from [^ ]* ||")
@@ -273,12 +282,16 @@ jobs:
               fi
             done
             if [ -z "$CHANGES" ]; then
-              CHANGES=$(git log "${PREV_VERSION}..HEAD" --no-merges --pretty=format:"- %s" | head -20)
-              CHANGES="${CHANGES}\n"
+              LOG_LINES=$(git log "${PREV_TAG}..HEAD" --no-merges --pretty=format:"- %s" -- libraries/flutter_inapp_purchase/ packages/google/ packages/apple/ | head -20)
+              if [ -n "$LOG_LINES" ]; then
+                CHANGES="${LOG_LINES}\n"
+              fi
             fi
-          else
-            CHANGES="- Initial release\n"
           fi
+          if [ -z "$CHANGES" ]; then
+            CHANGES="- No direct Flutter package changes found between releases; this release picks up the latest OpenIAP native package updates.\n"
+          fi
+          CHANGES="${CHANGES}- See the consolidated OpenIAP release notes: ${CONSOLIDATED_RELEASE_NOTES}\n"
           ENTRY="## ${NEW_VERSION} (${DATE})\n\n${CHANGES}"
           if [ -f CHANGELOG.md ]; then
             EXISTING=$(cat CHANGELOG.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
 # Changelog
 
-For detailed release notes, see: [openiap.dev/docs/updates/notes](https://www.openiap.dev/docs/updates/notes)
+OpenIAP keeps release history centralized to avoid package-local drift.
+
+- Consolidated release notes: [openiap.dev/docs/updates/releases](https://openiap.dev/docs/updates/releases)
+- GitHub Releases: [hyodotdev/openiap/releases](https://github.com/hyodotdev/openiap/releases)

--- a/libraries/expo-iap/CHANGELOG.md
+++ b/libraries/expo-iap/CHANGELOG.md
@@ -1,3 +1,6 @@
 # CHANGELOG
 
-[Check release notes](https://github.com/hyochan/expo-iap/releases)
+OpenIAP keeps detailed release history centralized to avoid package-local drift.
+
+- Consolidated release notes: [openiap.dev/docs/updates/releases](https://openiap.dev/docs/updates/releases)
+- Expo package releases: [hyodotdev/openiap/releases?q=expo-iap](https://github.com/hyodotdev/openiap/releases?q=expo-iap&expanded=true)

--- a/libraries/flutter_inapp_purchase/CHANGELOG.md
+++ b/libraries/flutter_inapp_purchase/CHANGELOG.md
@@ -1,134 +1,139 @@
 # Changelog
 
+Flutter keeps this file for pub.dev, while detailed release history remains
+centralized in the OpenIAP release notes and GitHub Releases.
+
+- Consolidated release notes: https://openiap.dev/docs/updates/releases
+- Flutter package releases: https://github.com/hyodotdev/openiap/releases?q=flutter-iap&expanded=true
+
 ## 9.4.0-rc.3 (2026-07-05)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.4.0-rc.3
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.4.0-rc.2 (2026-07-05)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.4.0-rc.2
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.3.7 (2026-07-01)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.3.7
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.3.6 (2026-06-27)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.3.6
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.3.5 (2026-06-25)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.3.5
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.3.4 (2026-06-23)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.3.4
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.3.3 (2026-06-23)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.3.3
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.3.2 (2026-06-11)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.3.2
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.3.1 (2026-05-19)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.3.1
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.3.0 (2026-05-16)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.3.0
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.2.8 (2026-05-13)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.2.8
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.2.7 (2026-05-08)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.2.7
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.2.6 (2026-05-08)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.2.6
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.2.5 (2026-05-07)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.2.5
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.2.4 (2026-05-04)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.2.4
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.2.3 (2026-04-24)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.2.3
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.2.2 (2026-04-24)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.2.2
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.2.1 (2026-04-16)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.2.1
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.2.0 (2026-04-16)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.2.0
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.1.0 (2026-04-15)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.1.0
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.0.3 (2026-04-15)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.0.3
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.0.2 (2026-04-14)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.0.2
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.0.1 (2026-04-13)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.0.1
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.0.0 (2026-04-10)
 
-- Initial release
-
+- See the Flutter GitHub Release for package-specific changes: https://github.com/hyodotdev/openiap/releases/tag/flutter-iap-9.0.0
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 9.0.0-rc.1 (2026-04-10)
 
-- Initial release
-
+- See the Flutter release tag for the source snapshot: https://github.com/hyodotdev/openiap/tree/flutter-iap-9.0.0-rc.1
+- See the consolidated OpenIAP release notes: https://openiap.dev/docs/updates/releases
 
 ## 8.2.10 (2026-03-25)
 
 - Initial release
-
 
 ## 8.2.9 (2026-03-25)
 
@@ -138,7 +143,6 @@
 - chore(deps): bump ajv in /docs (#620)
 - fix(errors): support macOS in getCurrentPlatform — return IapPlatform.IOS for StoreKit platforms (#626)
 - fix: publish directly from deploy workflow
-
 
 ## 8.2.8 (2026-02-27)
 

--- a/libraries/react-native-iap/CHANGELOG.md
+++ b/libraries/react-native-iap/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+OpenIAP keeps detailed release history centralized to avoid package-local drift.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-Check out [Releases](https://github.com/hyochan/react-native-iap/releases).
+- Consolidated release notes: [openiap.dev/docs/updates/releases](https://openiap.dev/docs/updates/releases)
+- React Native package releases: [hyodotdev/openiap/releases?q=react-native-iap](https://github.com/hyodotdev/openiap/releases?q=react-native-iap&expanded=true)

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -156,6 +156,15 @@ function expectNotIncludes(relativePath, needles, label = relativePath) {
   }
 }
 
+function expectNoMatch(relativePath, regex, label = relativePath) {
+  expectFile(relativePath);
+  if (!exists(relativePath)) return;
+  const text = read(relativePath);
+  if (regex.test(text)) {
+    fail(`${label} must not match ${regex}`);
+  }
+}
+
 function expectOptionalIncludes(relativePath, needles, label = relativePath) {
   if (!exists(relativePath)) return;
   expectIncludes(relativePath, needles, label);
@@ -1174,6 +1183,13 @@ function checkFrameworkDependencyHygiene() {
     "documentationUrl: 'https://hyochan.github.io/kmp-iap'",
     "documentationUrl: 'https://hyochan.github.io/godot-iap'",
   ], 'docs library cards must not point at legacy standalone docs');
+  expectIncludes('CHANGELOG.md', [
+    'https://openiap.dev/docs/updates/releases',
+    'https://github.com/hyodotdev/openiap/releases',
+  ], 'root changelog should point at OpenIAP release SSOT');
+  expectNotIncludes('CHANGELOG.md', [
+    'https://www.openiap.dev/docs/updates/notes',
+  ], 'root changelog must not point at redirected release notes URL');
   expectIncludes('libraries/expo-iap/README.md', [
     'https://openiap.dev/frameworks/expo.svg',
     'https://openiap.dev/docs/setup/expo',
@@ -1206,6 +1222,13 @@ function checkFrameworkDependencyHygiene() {
     'https://github.com/user-attachments/assets/319d8966-6839-498d-8ead-ce8cc72c3bca',
     'https://www.openiap.dev',
   ], 'Expo README must not point at legacy standalone docs');
+  expectIncludes('libraries/expo-iap/CHANGELOG.md', [
+    'https://openiap.dev/docs/updates/releases',
+    'https://github.com/hyodotdev/openiap/releases?q=expo-iap&expanded=true',
+  ], 'Expo changelog release SSOT links');
+  expectNotIncludes('libraries/expo-iap/CHANGELOG.md', [
+    'github.com/hyochan/expo-iap',
+  ], 'Expo changelog must not point at the legacy standalone repository');
   for (const expoDocsFile of [
     'libraries/expo-iap/CONTRIBUTING.md',
     'libraries/expo-iap/src/index.ts',
@@ -1239,6 +1262,13 @@ function checkFrameworkDependencyHygiene() {
     'https://github.com/user-attachments/assets/319d8966-6839-498d-8ead-ce8cc72c3bca',
     'https://www.openiap.dev',
   ], 'React Native README must not point at legacy standalone docs');
+  expectIncludes('libraries/react-native-iap/CHANGELOG.md', [
+    'https://openiap.dev/docs/updates/releases',
+    'https://github.com/hyodotdev/openiap/releases?q=react-native-iap&expanded=true',
+  ], 'React Native changelog release SSOT links');
+  expectNotIncludes('libraries/react-native-iap/CHANGELOG.md', [
+    'github.com/hyochan/react-native-iap',
+  ], 'React Native changelog must not point at the legacy standalone repository');
   expectNotIncludes('libraries/react-native-iap/CONTRIBUTING.md', [
     'hyochan.github.io/react-native-iap',
     'Recent highlights (',
@@ -1269,6 +1299,19 @@ function checkFrameworkDependencyHygiene() {
   expectNotIncludes('libraries/flutter_inapp_purchase/CONTRIBUTING.md', [
     'github.com/hyochan/openiap.dev',
   ], 'Flutter contributing links must point at the monorepo');
+  expectIncludes('libraries/flutter_inapp_purchase/CHANGELOG.md', [
+    'https://openiap.dev/docs/updates/releases',
+    'https://github.com/hyodotdev/openiap/releases?q=flutter-iap&expanded=true',
+  ], 'Flutter changelog release SSOT links');
+  expectNoMatch(
+    'libraries/flutter_inapp_purchase/CHANGELOG.md',
+    /^## 9\.[^\n]*\n\n- Initial release$/m,
+    'Flutter v9 changelog entries must not be placeholders',
+  );
+  expectIncludes('.github/workflows/release-flutter.yml', [
+    'flutter-iap-$PREV_VERSION',
+    'CONSOLIDATED_RELEASE_NOTES="https://openiap.dev/docs/updates/releases"',
+  ], 'Flutter release workflow should generate changelog entries from prefixed tags');
   expectIncludes('libraries/godot-iap/README.md', [
     'https://openiap.dev/docs/setup/godot',
     'https://openiap.dev/docs/guides/ai-assistants',

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -160,6 +160,7 @@ function expectNoMatch(relativePath, regex, label = relativePath) {
   expectFile(relativePath);
   if (!exists(relativePath)) return;
   const text = read(relativePath);
+  regex.lastIndex = 0;
   if (regex.test(text)) {
     fail(`${label} must not match ${regex}`);
   }
@@ -1305,7 +1306,7 @@ function checkFrameworkDependencyHygiene() {
   ], 'Flutter changelog release SSOT links');
   expectNoMatch(
     'libraries/flutter_inapp_purchase/CHANGELOG.md',
-    /^## 9\.[^\n]*\n\n- Initial release$/m,
+    /^## 9\.[^\r\n]*\r?\n\r?\n- Initial release\r?$/m,
     'Flutter v9 changelog entries must not be placeholders',
   );
   expectIncludes('.github/workflows/release-flutter.yml', [

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -160,8 +160,14 @@ function expectNoMatch(relativePath, regex, label = relativePath) {
   expectFile(relativePath);
   if (!exists(relativePath)) return;
   const text = read(relativePath);
-  regex.lastIndex = 0;
-  if (regex.test(text)) {
+  let matched = false;
+  if (regex instanceof RegExp) {
+    regex.lastIndex = 0;
+    matched = regex.test(text);
+  } else {
+    matched = text.includes(regex);
+  }
+  if (matched) {
     fail(`${label} must not match ${regex}`);
   }
 }


### PR DESCRIPTION
## Summary

- Keep root, React Native, Expo, and Flutter changelogs pointed at the OpenIAP release-note SSOT.
- Replace Flutter v9 placeholder changelog entries with concrete release or tag links.
- Fix Flutter release workflow changelog generation to resolve prefixed `flutter-iap-*` tags before falling back.

Closes #206

## Changes

### Release SSOT
- Update package-local changelogs to point at `openiap.dev/docs/updates/releases` and monorepo GitHub Releases.
- Remove legacy standalone release links from React Native and Expo changelogs.

### Flutter changelog generation
- Resolve `flutter-iap-$PREV_VERSION` before raw previous versions.
- Limit generated changelog entries to Flutter/native OpenIAP paths.
- Use a useful fallback plus OpenIAP release-note link instead of `Initial release`.

### Regression checks
- Add `bun audit:parity` checks for changelog SSOT links and Flutter v9 placeholder entries.

## Test plan

- [x] `bun audit:parity`
- [x] `node --check scripts/audit-non-godot-parity.mjs`
- [x] `bash -n` on the updated Flutter changelog generation run block
- [x] `bunx prettier --check CHANGELOG.md libraries/react-native-iap/CHANGELOG.md libraries/expo-iap/CHANGELOG.md libraries/flutter_inapp_purchase/CHANGELOG.md .github/workflows/release-flutter.yml`

## Preview

Not applicable: this changes Markdown release pointers, a GitHub Actions release script, and an audit script with no visual or interactive surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated root and package changelogs to direct readers to centralized OpenIAP release notes and release pages.
  * Replaced older “check releases”/generic links with consolidated references for Expo, Flutter, and React Native packages.
  * Enhanced the Flutter-iap changelog entries with per-version links to detailed upstream release information and consolidated OpenIAP notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->