### PR TITLE
fix(kit): bootstrap subscriptions from receipt verification

### DIFF
--- a/packages/apple/Example/OpenIapExample/Screens/SubscriptionFlowScreen.swift
+++ b/packages/apple/Example/OpenIapExample/Screens/SubscriptionFlowScreen.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 import OpenIAP
 
@@ -26,6 +27,16 @@ struct SubscriptionFlowScreen: View {
         ProcessInfo.processInfo.environment["IAPKIT_API_KEY"] ??
         Bundle.main.object(forInfoDictionaryKey: "IAPKIT_API_KEY") as? String
     }
+
+    private var iapkitBaseUrl: String {
+        if let value = Bundle.main.object(forInfoDictionaryKey: "IAPKIT_BASE_URL") as? String,
+           !value.isEmpty {
+            return value
+        }
+        return ProcessInfo.processInfo.environment["IAPKIT_BASE_URL"] ?? "https://kit.openiap.dev"
+    }
+
+    private let iapkitExampleUserId = "martie-e2e-user"
 
     // Product IDs for subscription testing
     // Ordered from lowest to highest tier for upgrade scenarios
@@ -660,15 +671,33 @@ struct SubscriptionFlowScreen: View {
                 let result = try await iapStore.verifyPurchaseWithProvider(props)
                 let isValid = result?.isValid ?? false
                 let state = result?.state.rawValue ?? "unknown"
+                var resultMessage = "\(isValid ? "✅" : "❌") IAPKit: isValid=\(isValid), state=\(state)"
 
                 print("📱 [SubscriptionFlow] IAPKit verification result:")
                 print("  - Product: \(purchase.productId)")
                 print("  - isValid: \(isValid)")
                 print("  - state: \(state)")
 
+                if isValid {
+                    do {
+                        let bindResult = try await bindIapkitSubscriptionUser(
+                            apiKey: apiKey,
+                            purchaseToken: jws
+                        )
+                        print("📱 [SubscriptionFlow] IAPKit bindUser result:")
+                        print("  - bound: \(bindResult.bound)")
+                        print("  - active: \(bindResult.active)")
+                        print("  - productId: \(bindResult.productId ?? "-")")
+                        resultMessage += "\n✅ bindUser(\(iapkitExampleUserId)): bound=\(bindResult.bound), active=\(bindResult.active), product=\(bindResult.productId ?? "-")"
+                    } catch {
+                        print("❌ [SubscriptionFlow] IAPKit bindUser failed: \(error.localizedDescription)")
+                        resultMessage += "\n❌ bindUser failed: \(error.localizedDescription)"
+                    }
+                }
+
                 await MainActor.run {
                     isVerifying = false
-                    verificationResultMessage = "\(isValid ? "✅" : "❌") IAPKit: isValid=\(isValid), state=\(state)"
+                    verificationResultMessage = resultMessage
                 }
             } catch {
                 await MainActor.run {
@@ -679,6 +708,50 @@ struct SubscriptionFlowScreen: View {
                 }
             }
         }
+    }
+
+    private func bindIapkitSubscriptionUser(
+        apiKey: String,
+        purchaseToken: String
+    ) async throws -> IapkitSubscriptionBindResult {
+        let baseUrl = iapkitBaseUrl.trimmedTrailingSlash()
+        let bindEndpoint = "\(baseUrl)/v1/subscriptions/bind-user/\(apiKey.urlPathEncoded())"
+        guard let bindUrl = URL(string: bindEndpoint) else {
+            throw URLError(.badURL)
+        }
+
+        var bindRequest = URLRequest(url: bindUrl)
+        bindRequest.httpMethod = "POST"
+        bindRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        bindRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        bindRequest.httpBody = try JSONSerialization.data(withJSONObject: [
+            "purchaseToken": purchaseToken,
+            "userId": iapkitExampleUserId
+        ])
+
+        let bindResponse: IapkitBindUserResponse = try await requestIapkitJson(bindRequest)
+        let statusEndpoint = "\(baseUrl)/v1/subscriptions/status/\(apiKey.urlPathEncoded())?userId=\(iapkitExampleUserId.urlQueryEncoded())"
+        guard let statusUrl = URL(string: statusEndpoint) else {
+            throw URLError(.badURL)
+        }
+        var statusRequest = URLRequest(url: statusUrl)
+        statusRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let statusResponse: IapkitSubscriptionStatusResponse = try await requestIapkitJson(statusRequest)
+        return IapkitSubscriptionBindResult(
+            bound: bindResponse.bound,
+            active: statusResponse.active,
+            productId: statusResponse.subscription?.productId
+        )
+    }
+
+    private func requestIapkitJson<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard (200...299).contains(statusCode) else {
+            throw IapkitSubscriptionBindError.httpStatus(statusCode)
+        }
+        return try JSONDecoder().decode(T.self, from: data)
     }
 
     private func restorePurchases() async {
@@ -914,6 +987,52 @@ private extension SubscriptionFlowScreen {
             return subscription.isActive && !renewalInfo.willAutoRenew
         }
         return false
+    }
+}
+
+private struct IapkitSubscriptionBindResult {
+    let bound: Bool
+    let active: Bool
+    let productId: String?
+}
+
+private struct IapkitBindUserResponse: Decodable {
+    let bound: Bool
+}
+
+private struct IapkitSubscriptionStatusResponse: Decodable {
+    let active: Bool
+    let subscription: IapkitSubscriptionSummary?
+}
+
+private struct IapkitSubscriptionSummary: Decodable {
+    let productId: String
+}
+
+private enum IapkitSubscriptionBindError: LocalizedError {
+    case httpStatus(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .httpStatus(let statusCode):
+            return "IAPKit request failed with HTTP \(statusCode)"
+        }
+    }
+}
+
+private extension String {
+    func trimmedTrailingSlash() -> String {
+        hasSuffix("/") ? String(dropLast()) : self
+    }
+
+    func urlPathEncoded() -> String {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/")
+        return addingPercentEncoding(withAllowedCharacters: allowed) ?? self
+    }
+
+    func urlQueryEncoded() -> String {
+        addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 }
 

--- a/packages/google/Example/src/main/java/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
+++ b/packages/google/Example/src/main/java/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
@@ -57,6 +57,12 @@ import dev.hyo.martie.util.PREMIUM_SUBSCRIPTION_PRODUCT_ID
 import dev.hyo.martie.util.SUBSCRIPTION_PREFS_NAME
 import dev.hyo.martie.util.resolvePremiumOfferInfo
 import dev.hyo.martie.util.savePremiumOffer
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 // Google Play Billing SubscriptionReplacementMode values
 // See: https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode
@@ -69,6 +75,15 @@ private object ReplacementMode {
     const val DEFERRED = 6                // Change at next billing cycle
     const val KEEP_EXISTING = 7           // Keep existing payment schedule (8.1.0+)
 }
+
+private const val IAPKIT_BASE_URL = "https://kit.openiap.dev"
+private const val IAPKIT_EXAMPLE_USER_ID = "martie-e2e-user"
+
+private data class IapkitSubscriptionBindResult(
+    val bound: Boolean,
+    val active: Boolean,
+    val productId: String?
+)
 
 // Helper to format remaining time like "3d 4h" / "2h 12m" / "35m"
 private fun formatRemaining(deltaMillis: Long): String {
@@ -857,7 +872,7 @@ fun SubscriptionFlowScreen(
                                                                 return@launch
                                                             }
 
-                                                            println("SubscriptionFlow [Horizon/Play]: Changing from ${currentOffer.basePlanId} to ${targetOffer.basePlanId} with token: $purchaseToken")
+                                                            println("SubscriptionFlow [Horizon/Play]: Changing from ${currentOffer.basePlanId} to ${targetOffer.basePlanId} with token: present")
 
                                                             // Request subscription offer change (same product, different offer)
                                                             // Using new subscriptionProductReplacementParams API (8.1.0+)
@@ -950,7 +965,7 @@ fun SubscriptionFlowScreen(
                                     }
 
                                     // Log purchase details for debugging
-                                    println("SubscriptionFlow: Current purchase details - productId: ${subscription.productId}, token: ${subscription.purchaseToken}")
+                                    println("SubscriptionFlow: Current purchase details - productId: ${subscription.productId}, token: present")
                                     println("SubscriptionFlow: Purchase state: ${subscription.purchaseState}")
 
                                     // Resolve the active offer for this subscription
@@ -1084,7 +1099,7 @@ fun SubscriptionFlowScreen(
                                                                 return@launch
                                                             }
 
-                                                            println("SubscriptionFlow: Changing from ${currentOffer.basePlanId} to ${targetOffer.basePlanId} with token: $purchaseToken")
+                                                            println("SubscriptionFlow: Changing from ${currentOffer.basePlanId} to ${targetOffer.basePlanId} with token: present")
 
                                                             // For same subscription with different offers, use CHARGE_FULL_PRICE
                                                             // This is often the only supported mode for offer changes
@@ -1363,7 +1378,7 @@ fun SubscriptionFlowScreen(
             ?: throw IllegalStateException("Purchase token is required for IAPKit verification")
 
         println("SubscriptionFlow: IAPKit verification params:")
-        println("  - purchaseToken: $token")
+        println("  - purchaseToken: present")
 
         val props = RequestVerifyPurchaseWithIapkitProps(
             apiKey = apiKey,
@@ -1438,7 +1453,31 @@ fun SubscriptionFlowScreen(
                     try {
                         val result = verifyWithIapkit(purchase, apiKey)
                         println("SubscriptionFlow: IAPKit verification result: $result")
-                        verificationResultMessage = if (result) "✅ IAPKit verification passed" else "❌ IAPKit verification failed"
+                        verificationResultMessage = if (result) {
+                            val bindResult = runCatching {
+                                val token = purchase.purchaseToken
+                                    ?: throw IllegalStateException("Purchase token is required for IAPKit bindUser")
+                                bindIapkitSubscriptionUser(apiKey, token)
+                            }.getOrElse { error ->
+                                println("SubscriptionFlow: IAPKit bindUser error: ${error.message}")
+                                null
+                            }
+
+                            if (bindResult == null) {
+                                "✅ IAPKit verification passed\n❌ bindUser failed"
+                            } else {
+                                println(
+                                    "SubscriptionFlow: IAPKit bindUser result: " +
+                                        "bound=${bindResult.bound}, active=${bindResult.active}, " +
+                                        "productId=${bindResult.productId ?: "-"}"
+                                )
+                                "✅ IAPKit verification passed\n" +
+                                    "✅ bindUser($IAPKIT_EXAMPLE_USER_ID): bound=${bindResult.bound}, " +
+                                    "active=${bindResult.active}, product=${bindResult.productId ?: "-"}"
+                            }
+                        } else {
+                            "❌ IAPKit verification failed"
+                        }
                         if (!result) {
                             // Post error with auto-refund notice
                             iapStore.postStatusMessage(
@@ -1571,5 +1610,73 @@ fun SubscriptionFlowScreen(
         )
     }
 }
+
+private suspend fun bindIapkitSubscriptionUser(
+    apiKey: String,
+    purchaseToken: String
+): IapkitSubscriptionBindResult = withContext(Dispatchers.IO) {
+    val bindPayload = JSONObject()
+        .put("purchaseToken", purchaseToken)
+        .put("userId", IAPKIT_EXAMPLE_USER_ID)
+        .toString()
+    val bindResponse = requestIapkitJson(
+        url = "$IAPKIT_BASE_URL/v1/subscriptions/bind-user/${apiKey.urlEncode()}",
+        method = "POST",
+        body = bindPayload
+    )
+    val statusResponse = requestIapkitJson(
+        url = "$IAPKIT_BASE_URL/v1/subscriptions/status/${apiKey.urlEncode()}" +
+            "?userId=${IAPKIT_EXAMPLE_USER_ID.urlEncode()}",
+        method = "GET"
+    )
+    val subscription = statusResponse.optJSONObject("subscription")
+    IapkitSubscriptionBindResult(
+        bound = bindResponse.optBoolean("bound", false),
+        active = statusResponse.optBoolean("active", false),
+        productId = subscription?.optString("productId")?.takeIf { it.isNotBlank() }
+    )
+}
+
+private fun requestIapkitJson(
+    url: String,
+    method: String,
+    body: String? = null
+): JSONObject {
+    val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+        requestMethod = method
+        connectTimeout = 15_000
+        readTimeout = 15_000
+        setRequestProperty("Accept", "application/json")
+        if (body != null) {
+            setRequestProperty("Content-Type", "application/json")
+            doOutput = true
+        }
+    }
+
+    try {
+        if (body != null) {
+            connection.outputStream.use { output ->
+                output.write(body.toByteArray(StandardCharsets.UTF_8))
+            }
+        }
+
+        val statusCode = connection.responseCode
+        val stream = if (statusCode in 200..299) {
+            connection.inputStream
+        } else {
+            connection.errorStream ?: connection.inputStream
+        }
+        val responseBody = stream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+        if (statusCode !in 200..299) {
+            error("IAPKit request failed with HTTP $statusCode")
+        }
+        return JSONObject(responseBody)
+    } finally {
+        connection.disconnect()
+    }
+}
+
+private fun String.urlEncode(): String =
+    URLEncoder.encode(this, StandardCharsets.UTF_8.name())
 
 // Moved to reusable component at: screens/uis/ActiveSubscriptionListItem.kt

--- a/packages/kit/convex/purchases/android.test.ts
+++ b/packages/kit/convex/purchases/android.test.ts
@@ -131,6 +131,57 @@ describe("Google Play v2 mappings", () => {
     });
   });
 
+  it("selects the longest-dated subscription line item and preserves renewal price", () => {
+    const soon = "2026-01-01T00:00:00.000Z";
+    const later = "2026-02-01T00:00:00.000Z";
+    const subscriptionResponse = {
+      kind: "androidpublisher#subscriptionPurchaseV2",
+      latestOrderId: "GPA.1234-5678-9012-34567",
+      startTime: "2025-10-13T20:13:42.748Z",
+      subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+      acknowledgementState: "ACKNOWLEDGEMENT_STATE_ACKNOWLEDGED",
+      lineItems: [
+        {
+          productId: "premium_monthly",
+          expiryTime: soon,
+          latestSuccessfulOrderId: "GPA.1111-1111-1111-11111",
+          autoRenewingPlan: {
+            recurringPrice: {
+              currencyCode: "USD",
+              units: "4",
+              nanos: 990_000_000,
+            },
+          },
+        },
+        {
+          productId: "premium_yearly",
+          expiryTime: later,
+          latestSuccessfulOrderId: "GPA.2222-2222-2222-22222",
+          autoRenewingPlan: {
+            recurringPrice: {
+              currencyCode: "USD",
+              units: "49",
+              nanos: 990_000_000,
+            },
+          },
+        },
+      ],
+    };
+
+    const receipt = mapSubscriptionResponseToReceiptData({
+      packageName,
+      purchaseToken: "sub-token",
+      subscriptionResponse,
+    });
+
+    expect(receipt.productId).toBe("premium_yearly");
+    expect(receipt.orderId).toBe("GPA.2222-2222-2222-22222");
+    expect(receipt.expiryTime).toBe(Date.parse(later));
+    expect(receipt.renewsAt).toBe(Date.parse(later));
+    expect(receipt.currency).toBe("USD");
+    expect(receipt.priceAmountMicros).toBe(49_990_000);
+  });
+
   it("maps productsv2.get purchased consumable that has been consumed to CONSUMED", () => {
     const productPurchaseV2Response = {
       kind: "androidpublisher#productPurchaseV2",

--- a/packages/kit/convex/purchases/android.test.ts
+++ b/packages/kit/convex/purchases/android.test.ts
@@ -4,6 +4,7 @@ import {
   mapProductResponseToReceiptData,
   mapSubscriptionResponseToReceiptData,
   parseTimeToMillis,
+  recordGooglePlayVerifiedSubscription,
 } from "./android";
 import { HarmonizedPurchaseState } from "./purchaseState";
 import { mapToGooglePlayReceiptResponse } from "./shared";
@@ -403,6 +404,82 @@ describe("Google Play v2 mappings", () => {
       state: HarmonizedPurchaseState.UNKNOWN,
       productId: "test.product",
     });
+  });
+});
+
+describe("recordGooglePlayVerifiedSubscription", () => {
+  function makeRunMutationRecorder(): {
+    ctx: Parameters<typeof recordGooglePlayVerifiedSubscription>[0];
+    calls: Record<string, unknown>[];
+  } {
+    const calls: Record<string, unknown>[] = [];
+    const ctx = {
+      runMutation: async (
+        _mutation: unknown,
+        args: Record<string, unknown>,
+      ) => {
+        calls.push(args);
+        return null;
+      },
+    } as unknown as Parameters<typeof recordGooglePlayVerifiedSubscription>[0];
+    return { ctx, calls };
+  }
+
+  it("uses the store-verified state for canonical subscription persistence", async () => {
+    const { ctx, calls } = makeRunMutationRecorder();
+
+    await recordGooglePlayVerifiedSubscription(ctx, {
+      projectId: "projects_1" as never,
+      purchaseState: HarmonizedPurchaseState.ENTITLED,
+      receiptData: {
+        transactionId: "GPA.1234-5678-9012-34567",
+        packageName,
+        productId: "premium_monthly",
+        purchaseToken: "sub-token",
+        purchaseDate: 1_700_000_000_000,
+        quantity: 1,
+        type: "Subscription",
+        subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+        expiryTime: 1_769_904_000_000,
+        renewsAt: 1_769_904_000_000,
+        currency: "USD",
+        priceAmountMicros: 9_990_000,
+      },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      projectId: "projects_1",
+      platform: "Android",
+      purchaseToken: "sub-token",
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.ENTITLED,
+      subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+      expiresAt: 1_769_904_000_000,
+      renewsAt: 1_769_904_000_000,
+      currency: "USD",
+      priceAmountMicros: 9_990_000,
+    });
+  });
+
+  it("skips one-time product receipts", async () => {
+    const { ctx, calls } = makeRunMutationRecorder();
+
+    await recordGooglePlayVerifiedSubscription(ctx, {
+      projectId: "projects_1" as never,
+      purchaseState: HarmonizedPurchaseState.ENTITLED,
+      receiptData: {
+        transactionId: "GPA.1234-5678-9012-34567",
+        packageName,
+        productId: "coins_pack",
+        purchaseToken: "product-token",
+        purchaseDate: 1_700_000_000_000,
+        quantity: 1,
+        type: "InApp",
+      },
+    });
+
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/packages/kit/convex/purchases/android.test.ts
+++ b/packages/kit/convex/purchases/android.test.ts
@@ -462,6 +462,44 @@ describe("recordGooglePlayVerifiedSubscription", () => {
     });
   });
 
+  it("persists pending-acknowledgment subscriptions as bindable rows", async () => {
+    const { ctx, calls } = makeRunMutationRecorder();
+
+    await recordGooglePlayVerifiedSubscription(ctx, {
+      projectId: "projects_1" as never,
+      purchaseState: HarmonizedPurchaseState.PENDING_ACKNOWLEDGMENT,
+      receiptData: {
+        transactionId: "GPA.1234-5678-9012-34567",
+        packageName,
+        productId: "premium_monthly",
+        purchaseToken: "pending-sub-token",
+        purchaseDate: 1_700_000_000_000,
+        quantity: 1,
+        type: "Subscription",
+        subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+        acknowledgementState: "ACKNOWLEDGEMENT_STATE_PENDING",
+        expiryTime: 1_769_904_000_000,
+        renewsAt: 1_769_904_000_000,
+        currency: "USD",
+        priceAmountMicros: 9_990_000,
+      },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      projectId: "projects_1",
+      platform: "Android",
+      purchaseToken: "pending-sub-token",
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.PENDING_ACKNOWLEDGMENT,
+      subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+      expiresAt: 1_769_904_000_000,
+      renewsAt: 1_769_904_000_000,
+      currency: "USD",
+      priceAmountMicros: 9_990_000,
+    });
+  });
+
   it("skips one-time product receipts", async () => {
     const { ctx, calls } = makeRunMutationRecorder();
 

--- a/packages/kit/convex/purchases/android.ts
+++ b/packages/kit/convex/purchases/android.ts
@@ -6,6 +6,7 @@ import { androidpublisher_v3 } from "googleapis";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
+import { moneyToMicros } from "../products/play";
 import {
   getProjectByApiKey,
   mapToGooglePlayReceiptResponse,
@@ -129,6 +130,23 @@ export const verifyGooglePlayReceiptInternalV1 = action({
         requestIp: args.requestIp,
         verificationDurationMs: Date.now() - verificationStart,
       });
+      if (receiptData.type === "Subscription") {
+        await ctx.runMutation(
+          internal.subscriptions.internal.recordVerifiedSubscription,
+          {
+            projectId: project._id,
+            platform: "Android",
+            purchaseToken: receiptData.purchaseToken,
+            productId: receiptData.productId,
+            purchaseState: receiptResponse.state,
+            subscriptionState: receiptData.subscriptionState,
+            expiresAt: receiptData.expiryTime,
+            renewsAt: receiptData.renewsAt,
+            currency: receiptData.currency,
+            priceAmountMicros: receiptData.priceAmountMicros,
+          },
+        );
+      }
 
       return receiptResponse;
     } catch (error) {
@@ -308,11 +326,14 @@ export function mapSubscriptionResponseToReceiptData(args: {
   purchaseToken: string;
   subscriptionResponse: androidpublisher_v3.Schema$SubscriptionPurchaseV2;
 }): GooglePlayReceiptData {
-  const lineItem = args.subscriptionResponse.lineItems?.[0];
+  const lineItem = selectSubscriptionLineItem(
+    args.subscriptionResponse.lineItems ?? [],
+  );
   const purchaseDate =
     parseTimeToMillis(args.subscriptionResponse.startTime) ?? Date.now();
   const expiryTime = parseTimeToMillis(lineItem?.expiryTime);
   const productId = lineItem?.productId || "unknown";
+  const recurringPrice = lineItem?.autoRenewingPlan?.recurringPrice;
 
   return {
     transactionId: args.purchaseToken,
@@ -330,7 +351,30 @@ export function mapSubscriptionResponseToReceiptData(args: {
     acknowledgementState:
       args.subscriptionResponse.acknowledgementState || undefined,
     expiryTime: expiryTime,
+    renewsAt: lineItem?.autoRenewingPlan ? expiryTime : undefined,
+    currency: recurringPrice?.currencyCode ?? undefined,
+    priceAmountMicros: moneyToMicros(recurringPrice),
   };
+}
+
+function selectSubscriptionLineItem(
+  lineItems: NonNullable<
+    androidpublisher_v3.Schema$SubscriptionPurchaseV2["lineItems"]
+  >,
+): androidpublisher_v3.Schema$SubscriptionPurchaseLineItem | undefined {
+  return (
+    lineItems.reduce<
+      androidpublisher_v3.Schema$SubscriptionPurchaseLineItem | undefined
+    >((selected, candidate) => {
+      if (!candidate.expiryTime) return selected;
+      const score = Date.parse(candidate.expiryTime);
+      if (!Number.isFinite(score)) return selected;
+      const selectedScore = selected?.expiryTime
+        ? Date.parse(selected.expiryTime)
+        : -Infinity;
+      return score > selectedScore ? candidate : selected;
+    }, undefined) ?? lineItems[0]
+  );
 }
 
 export function mapProductResponseToReceiptData(args: {

--- a/packages/kit/convex/purchases/android.ts
+++ b/packages/kit/convex/purchases/android.ts
@@ -130,23 +130,11 @@ export const verifyGooglePlayReceiptInternalV1 = action({
         requestIp: args.requestIp,
         verificationDurationMs: Date.now() - verificationStart,
       });
-      if (receiptData.type === "Subscription") {
-        await ctx.runMutation(
-          internal.subscriptions.internal.recordVerifiedSubscription,
-          {
-            projectId: project._id,
-            platform: "Android",
-            purchaseToken: receiptData.purchaseToken,
-            productId: receiptData.productId,
-            purchaseState: receiptResponse.state,
-            subscriptionState: receiptData.subscriptionState,
-            expiresAt: receiptData.expiryTime,
-            renewsAt: receiptData.renewsAt,
-            currency: receiptData.currency,
-            priceAmountMicros: receiptData.priceAmountMicros,
-          },
-        );
-      }
+      await recordGooglePlayVerifiedSubscription(ctx, {
+        projectId: project._id,
+        receiptData,
+        purchaseState: storeReceiptResponse.state,
+      });
 
       return receiptResponse;
     } catch (error) {
@@ -223,6 +211,33 @@ export const verifyGooglePlayReceiptInternalV1 = action({
     }
   },
 });
+
+export async function recordGooglePlayVerifiedSubscription(
+  ctx: Pick<ActionCtx, "runMutation">,
+  params: {
+    projectId: Id<"projects">;
+    receiptData: GooglePlayReceiptData;
+    purchaseState: HarmonizedPurchaseState;
+  },
+): Promise<void> {
+  if (params.receiptData.type !== "Subscription") return;
+
+  await ctx.runMutation(
+    internal.subscriptions.internal.recordVerifiedSubscription,
+    {
+      projectId: params.projectId,
+      platform: "Android",
+      purchaseToken: params.receiptData.purchaseToken,
+      productId: params.receiptData.productId,
+      purchaseState: params.purchaseState,
+      subscriptionState: params.receiptData.subscriptionState,
+      expiresAt: params.receiptData.expiryTime,
+      renewsAt: params.receiptData.renewsAt,
+      currency: params.receiptData.currency,
+      priceAmountMicros: params.receiptData.priceAmountMicros,
+    },
+  );
+}
 
 interface GoogleServiceAccountKey {
   type: "service_account";

--- a/packages/kit/convex/purchases/extract-order-id.test.ts
+++ b/packages/kit/convex/purchases/extract-order-id.test.ts
@@ -72,6 +72,28 @@ describe("extractOrderIdFromRemoteResponse", () => {
     );
   });
 
+  it("uses the longest-dated subscription line item order id", () => {
+    const raw = JSON.stringify({
+      kind: "androidpublisher#subscriptionPurchaseV2",
+      latestOrderId: "GPA.sub-latest-top",
+      lineItems: [
+        {
+          productId: "pro_monthly",
+          expiryTime: "2026-01-01T00:00:00.000Z",
+          latestSuccessfulOrderId: "GPA.sub-line-soon",
+        },
+        {
+          productId: "pro_yearly",
+          expiryTime: "2026-02-01T00:00:00.000Z",
+          latestSuccessfulOrderId: "GPA.sub-line-later",
+        },
+      ],
+    });
+    expect(extractOrderIdFromRemoteResponse("google", raw)).toBe(
+      "GPA.sub-line-later",
+    );
+  });
+
   it("falls back to top-level latestOrderId when line items lack an order id", () => {
     const raw = JSON.stringify({
       kind: "androidpublisher#subscriptionPurchaseV2",

--- a/packages/kit/convex/purchases/extract-product-id.test.ts
+++ b/packages/kit/convex/purchases/extract-product-id.test.ts
@@ -115,6 +115,26 @@ describe("extractProductIdFromRemoteResponse", () => {
     ).toBe("pro_monthly");
   });
 
+  it("uses the longest-dated google subscription line item productId", () => {
+    expect(
+      extractProductIdFromRemoteResponse(
+        "google",
+        JSON.stringify({
+          lineItems: [
+            {
+              productId: "pro_monthly",
+              expiryTime: "2026-01-01T00:00:00.000Z",
+            },
+            {
+              productId: "pro_yearly",
+              expiryTime: "2026-02-01T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    ).toBe("pro_yearly");
+  });
+
   it("is null-safe when google line-item arrays are empty", () => {
     expect(
       extractProductIdFromRemoteResponse(

--- a/packages/kit/convex/purchases/ios.test.ts
+++ b/packages/kit/convex/purchases/ios.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { applyExpectedProductId, mapToAppStoreReceiptResponse } from "./shared";
+import { recordAppStoreVerifiedSubscription } from "./ios";
+import {
+  applyExpectedProductId,
+  AppStoreProductType,
+  mapToAppStoreReceiptResponse,
+} from "./shared";
 import { HarmonizedPurchaseState } from "./purchaseState";
 
 describe("App Store mappings (real data)", () => {
@@ -172,5 +177,78 @@ describe("App Store mappings (real data)", () => {
       state: HarmonizedPurchaseState.INAUTHENTIC,
       productId: "dev.hyo.martie.premium",
     });
+  });
+});
+
+describe("recordAppStoreVerifiedSubscription", () => {
+  function makeRunMutationRecorder(): {
+    ctx: Parameters<typeof recordAppStoreVerifiedSubscription>[0];
+    calls: Record<string, unknown>[];
+  } {
+    const calls: Record<string, unknown>[] = [];
+    const ctx = {
+      runMutation: async (
+        _mutation: unknown,
+        args: Record<string, unknown>,
+      ) => {
+        calls.push(args);
+        return null;
+      },
+    } as unknown as Parameters<typeof recordAppStoreVerifiedSubscription>[0];
+    return { ctx, calls };
+  }
+
+  it("records subscription transactions with store-verified state and micros pricing", async () => {
+    const { ctx, calls } = makeRunMutationRecorder();
+
+    await recordAppStoreVerifiedSubscription(ctx, {
+      projectId: "projects_1" as never,
+      remoteId: "original-transaction-1",
+      purchaseState: HarmonizedPurchaseState.ENTITLED,
+      transactionData: {
+        transactionId: "transaction-1",
+        originalTransactionId: "original-transaction-1",
+        bundleId: "dev.hyo.martie",
+        productId: "dev.hyo.martie.premium",
+        type: AppStoreProductType.AUTO_RENEWABLE_SUBSCRIPTION,
+        environment: "Sandbox",
+        expiresDate: 1_769_904_000_000,
+        currency: "USD",
+        price: 9990,
+      },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      projectId: "projects_1",
+      platform: "IOS",
+      purchaseToken: "original-transaction-1",
+      productId: "dev.hyo.martie.premium",
+      purchaseState: HarmonizedPurchaseState.ENTITLED,
+      expiresAt: 1_769_904_000_000,
+      currency: "USD",
+      priceAmountMicros: 9_990_000,
+    });
+  });
+
+  it("skips non-subscription transactions", async () => {
+    const { ctx, calls } = makeRunMutationRecorder();
+
+    await recordAppStoreVerifiedSubscription(ctx, {
+      projectId: "projects_1" as never,
+      remoteId: "transaction-1",
+      purchaseState: HarmonizedPurchaseState.READY_TO_CONSUME,
+      transactionData: {
+        transactionId: "transaction-1",
+        bundleId: "dev.hyo.martie",
+        productId: "dev.hyo.martie.10bulbs",
+        type: AppStoreProductType.CONSUMABLE,
+        environment: "Sandbox",
+        currency: "USD",
+        price: 9990,
+      },
+    });
+
+    expect(calls).toHaveLength(0);
   });
 });

--- a/packages/kit/convex/purchases/ios.ts
+++ b/packages/kit/convex/purchases/ios.ts
@@ -20,6 +20,7 @@ import {
   mapToAppStoreReceiptResponse,
   applyExpectedProductId,
   AppStoreReceiptData,
+  AppStoreProductType,
   receiptResponseValidator,
   isValidState,
 } from "./shared";
@@ -37,6 +38,22 @@ import { retryOnTransient } from "./retry";
 
 function describeError(error: unknown): string {
   return error instanceof Error ? error.name : typeof error;
+}
+
+function isAppStoreSubscriptionType(type: string | undefined): boolean {
+  if (
+    type === AppStoreProductType.AUTO_RENEWABLE_SUBSCRIPTION ||
+    type === AppStoreProductType.NON_RENEWING_SUBSCRIPTION
+  ) {
+    return true;
+  }
+  return type?.toLowerCase().includes("subscription") ?? false;
+}
+
+function appStorePriceToMicros(price: number | undefined): number | undefined {
+  if (typeof price !== "number" || !Number.isFinite(price)) return undefined;
+  // Apple transaction `price` is in milliunits; kit stores micros.
+  return price * 1000;
 }
 
 export const verifyAppStoreReceiptInternalV1 = action({
@@ -139,6 +156,21 @@ export const verifyAppStoreReceiptInternalV1 = action({
       requestIp: args.requestIp,
       verificationDurationMs: Date.now() - verificationStart,
     });
+    if (isAppStoreSubscriptionType(transactionData.type)) {
+      await ctx.runMutation(
+        internal.subscriptions.internal.recordVerifiedSubscription,
+        {
+          projectId: project._id,
+          platform: "IOS",
+          purchaseToken: remoteId,
+          productId: transactionData.productId ?? "unknown",
+          purchaseState: receiptResponse.state,
+          expiresAt: transactionData.expiresDate,
+          currency: transactionData.currency,
+          priceAmountMicros: appStorePriceToMicros(transactionData.price),
+        },
+      );
+    }
 
     return receiptResponse;
   },

--- a/packages/kit/convex/purchases/ios.ts
+++ b/packages/kit/convex/purchases/ios.ts
@@ -156,25 +156,42 @@ export const verifyAppStoreReceiptInternalV1 = action({
       requestIp: args.requestIp,
       verificationDurationMs: Date.now() - verificationStart,
     });
-    if (isAppStoreSubscriptionType(transactionData.type)) {
-      await ctx.runMutation(
-        internal.subscriptions.internal.recordVerifiedSubscription,
-        {
-          projectId: project._id,
-          platform: "IOS",
-          purchaseToken: remoteId,
-          productId: transactionData.productId ?? "unknown",
-          purchaseState: receiptResponse.state,
-          expiresAt: transactionData.expiresDate,
-          currency: transactionData.currency,
-          priceAmountMicros: appStorePriceToMicros(transactionData.price),
-        },
-      );
-    }
+    await recordAppStoreVerifiedSubscription(ctx, {
+      projectId: project._id,
+      remoteId,
+      transactionData,
+      purchaseState: storeReceiptResponse.state,
+    });
 
     return receiptResponse;
   },
 });
+
+export async function recordAppStoreVerifiedSubscription(
+  ctx: Pick<ActionCtx, "runMutation">,
+  params: {
+    projectId: Id<"projects">;
+    remoteId: string;
+    transactionData: AppStoreReceiptData;
+    purchaseState: HarmonizedPurchaseState;
+  },
+): Promise<void> {
+  if (!isAppStoreSubscriptionType(params.transactionData.type)) return;
+
+  await ctx.runMutation(
+    internal.subscriptions.internal.recordVerifiedSubscription,
+    {
+      projectId: params.projectId,
+      platform: "IOS",
+      purchaseToken: params.remoteId,
+      productId: params.transactionData.productId ?? "unknown",
+      purchaseState: params.purchaseState,
+      expiresAt: params.transactionData.expiresDate,
+      currency: params.transactionData.currency,
+      priceAmountMicros: appStorePriceToMicros(params.transactionData.price),
+    },
+  );
+}
 
 function decodeJwsPayload(jws: string): JWSTransactionDecodedPayload {
   const parts = jws.split(".");

--- a/packages/kit/convex/purchases/shared.test.ts
+++ b/packages/kit/convex/purchases/shared.test.ts
@@ -42,6 +42,17 @@ describe("mapGooglePlayPurchaseState", () => {
     expect(state).toBe(HarmonizedPurchaseState.EXPIRED);
   });
 
+  it("keeps canceled-but-not-expired subscriptions entitled", () => {
+    const state = mapGooglePlayPurchaseState({
+      type: "Subscription",
+      subscriptionState: "SUBSCRIPTION_STATE_CANCELED",
+      acknowledgementState: "ACKNOWLEDGED",
+      expiryTime: Date.now() + 1000,
+    });
+
+    expect(state).toBe(HarmonizedPurchaseState.ENTITLED);
+  });
+
   it("marks in-app purchases as consumed when Google Play reports it", () => {
     const state = mapGooglePlayPurchaseState({
       type: "InApp",

--- a/packages/kit/convex/purchases/shared.ts
+++ b/packages/kit/convex/purchases/shared.ts
@@ -41,6 +41,9 @@ export const googlePlayReceiptDataValidator = v.object({
   acknowledgementState: v.optional(v.string()),
   consumptionState: v.optional(v.string()),
   expiryTime: v.optional(v.number()),
+  renewsAt: v.optional(v.number()),
+  currency: v.optional(v.string()),
+  priceAmountMicros: v.optional(v.number()),
 });
 
 export type GooglePlayReceiptData = Infer<
@@ -271,7 +274,9 @@ export function mapGooglePlayPurchaseState(
 
     switch (subscriptionState) {
       case "SUBSCRIPTION_STATE_CANCELED":
-        return HarmonizedPurchaseState.CANCELED;
+        return isAcknowledged(receipt.acknowledgementState)
+          ? HarmonizedPurchaseState.ENTITLED
+          : HarmonizedPurchaseState.PENDING_ACKNOWLEDGMENT;
       case "SUBSCRIPTION_STATE_EXPIRED":
         return HarmonizedPurchaseState.EXPIRED;
       case "SUBSCRIPTION_STATE_PENDING":
@@ -473,14 +478,13 @@ export function extractOrderIdFromRemoteResponse(
     // Subscriptions V2: the top-level identifier is `latestOrderId`,
     // with `lineItems[].latestSuccessfulOrderId` as the per-line
     // fallback. `mapSubscriptionResponseToReceiptData` in android.ts
-    // already prefers the per-line id, so mirror that precedence here
-    // to keep the write-time column and the response-extracted id in
-    // sync.
+    // selects the longest-dated line item, so mirror that selection
+    // here to keep the write-time column and the receipt-derived id
+    // in sync.
     if ("lineItems" in parsed && Array.isArray(parsed.lineItems)) {
-      const lineItem = parsed.lineItems[0];
+      const lineItem = selectGoogleSubscriptionLineItem(parsed.lineItems);
       if (
         lineItem &&
-        typeof lineItem === "object" &&
         "latestSuccessfulOrderId" in lineItem &&
         typeof lineItem.latestSuccessfulOrderId === "string" &&
         lineItem.latestSuccessfulOrderId.length > 0
@@ -551,10 +555,9 @@ export function extractProductIdFromRemoteResponse(
         }
 
         if ("lineItems" in parsed && Array.isArray(parsed.lineItems)) {
-          const lineItem = parsed.lineItems[0];
+          const lineItem = selectGoogleSubscriptionLineItem(parsed.lineItems);
           if (
             lineItem &&
-            typeof lineItem === "object" &&
             "productId" in lineItem &&
             typeof lineItem.productId === "string"
           ) {
@@ -589,4 +592,30 @@ export function extractProductIdFromRemoteResponse(
   }
 
   return null;
+}
+
+function selectGoogleSubscriptionLineItem(
+  lineItems: unknown[],
+): Record<string, unknown> | null {
+  let fallback: Record<string, unknown> | null = null;
+  let selected: Record<string, unknown> | null = null;
+  let selectedScore = -Infinity;
+
+  for (const lineItem of lineItems) {
+    if (!isRecord(lineItem)) continue;
+    fallback ??= lineItem;
+
+    if (typeof lineItem.expiryTime !== "string") continue;
+    const score = Date.parse(lineItem.expiryTime);
+    if (!Number.isFinite(score) || score <= selectedScore) continue;
+
+    selected = lineItem;
+    selectedScore = score;
+  }
+
+  return selected ?? fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
 }

--- a/packages/kit/convex/subscriptions/internal.test.ts
+++ b/packages/kit/convex/subscriptions/internal.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HarmonizedPurchaseState } from "../purchases/purchaseState";
 import {
+  bindSubscriptionToUserHandler,
   buildVerifiedSubscriptionSnapshot,
   mergeVerifiedSubscriptionSnapshot,
   recordVerifiedSubscriptionHandler,
@@ -509,6 +510,54 @@ describe("recordVerifiedSubscriptionHandler", () => {
         currency: "USD",
         activeSubs: 1,
         mrrMicros: 9_990_000,
+      },
+    ]);
+  });
+
+  it("supports the verify -> bind flow for SDK clients", async () => {
+    const db = new MemDb();
+    db.seedProduct({
+      projectId: PROJECT_ID,
+      platform: "Android",
+      productId: "premium_monthly",
+      billingPeriod: "P1M",
+    });
+
+    const subscriptionId = await recordVerifiedSubscriptionHandler(
+      makeCtx(db),
+      {
+        projectId: PROJECT_ID as never,
+        platform: "Android",
+        purchaseToken: TOKEN,
+        productId: "premium_monthly",
+        purchaseState: HarmonizedPurchaseState.ENTITLED,
+        subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+        expiresAt: 1_769_904_000_000,
+        renewsAt: 1_769_904_000_000,
+        currency: "USD",
+        priceAmountMicros: 9_990_000,
+      },
+    );
+
+    const boundId = await bindSubscriptionToUserHandler(makeCtx(db), {
+      projectId: PROJECT_ID as never,
+      purchaseToken: TOKEN,
+      userId: "user-1",
+    });
+
+    expect(boundId).toBe(subscriptionId);
+    expect(db.rows("subscriptions")).toMatchObject([
+      {
+        _id: subscriptionId,
+        projectId: PROJECT_ID,
+        purchaseToken: TOKEN,
+        productId: "premium_monthly",
+        platform: "Android",
+        state: "Active",
+        userId: "user-1",
+        willRenew: true,
+        currency: "USD",
+        priceAmountMicros: 9_990_000,
       },
     ]);
   });

--- a/packages/kit/convex/subscriptions/internal.test.ts
+++ b/packages/kit/convex/subscriptions/internal.test.ts
@@ -1,0 +1,499 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HarmonizedPurchaseState } from "../purchases/purchaseState";
+import {
+  buildVerifiedSubscriptionSnapshot,
+  mergeVerifiedSubscriptionSnapshot,
+  recordVerifiedSubscriptionHandler,
+} from "./internal";
+
+type Row = Record<string, unknown> & { _id: string; _creationTime: number };
+
+class MemQuery {
+  constructor(private rows: Row[]) {}
+
+  withIndex(_name: string, cb?: (q: IndexBuilder) => IndexBuilder): MemQuery {
+    if (!cb) return this;
+    const builder = new IndexBuilder();
+    cb(builder);
+    return new MemQuery(
+      this.rows.filter((row) =>
+        builder.predicates.every((predicate) => predicate(row)),
+      ),
+    );
+  }
+
+  async unique(): Promise<Row | null> {
+    if (this.rows.length > 1) {
+      throw new Error("unique() called on a query that returned > 1 row");
+    }
+    return this.rows[0] ?? null;
+  }
+}
+
+class IndexBuilder {
+  predicates: Array<(row: Row) => boolean> = [];
+
+  eq(field: string, value: unknown): IndexBuilder {
+    this.predicates.push((row) => row[field] === value);
+    return this;
+  }
+}
+
+class MemDb {
+  tables = new Map<string, Map<string, Row>>();
+  private counter = 0;
+
+  private table(name: string): Map<string, Row> {
+    let table = this.tables.get(name);
+    if (!table) {
+      table = new Map();
+      this.tables.set(name, table);
+    }
+    return table;
+  }
+
+  query(tableName: string): MemQuery {
+    return new MemQuery([...this.table(tableName).values()]);
+  }
+
+  async insert(
+    tableName: string,
+    doc: Record<string, unknown>,
+  ): Promise<string> {
+    const id = `${tableName}_${++this.counter}`;
+    this.table(tableName).set(id, {
+      ...doc,
+      _id: id,
+      _creationTime: Date.now(),
+    });
+    return id;
+  }
+
+  async get(id: string): Promise<Row | null> {
+    for (const table of this.tables.values()) {
+      const row = table.get(id);
+      if (row) return row;
+    }
+    return null;
+  }
+
+  async patch(id: string, patch: Record<string, unknown>): Promise<void> {
+    for (const table of this.tables.values()) {
+      const row = table.get(id);
+      if (row) {
+        Object.assign(row, patch);
+        return;
+      }
+    }
+    throw new Error(`patch: no doc with id ${id}`);
+  }
+
+  rows(tableName: string): Row[] {
+    return [...this.table(tableName).values()];
+  }
+
+  seedProduct(doc: {
+    projectId: string;
+    platform: "IOS" | "Android";
+    productId: string;
+    billingPeriod?: string;
+  }): void {
+    this.table("products").set(`products_${++this.counter}`, {
+      _id: `products_${this.counter}`,
+      _creationTime: Date.now(),
+      ...doc,
+    });
+  }
+}
+
+function makeCtx(db: MemDb) {
+  return { db } as unknown as Parameters<
+    typeof recordVerifiedSubscriptionHandler
+  >[0];
+}
+
+const PROJECT_ID = "projects_seed_1";
+const TOKEN = "purchase_token_1";
+
+describe("buildVerifiedSubscriptionSnapshot", () => {
+  it("bootstraps an active subscription from an entitled Google verification", () => {
+    const snapshot = buildVerifiedSubscriptionSnapshot({
+      platform: "Android",
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.ENTITLED,
+      subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+      expiresAt: 2_000_000_000_000,
+    });
+
+    expect(snapshot).toEqual({
+      productId: "premium_monthly",
+      state: "Active",
+      expiresAt: 2_000_000_000_000,
+      renewsAt: undefined,
+      willRenew: true,
+      cancellationReason: undefined,
+      clearCancellationReason: true,
+      currency: undefined,
+      priceAmountMicros: undefined,
+    });
+  });
+
+  it("treats pending-acknowledgment subscriptions as entitled while still bindable", () => {
+    const snapshot = buildVerifiedSubscriptionSnapshot({
+      platform: "Android",
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.PENDING_ACKNOWLEDGMENT,
+      subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+    });
+
+    expect(snapshot).toMatchObject({
+      productId: "premium_monthly",
+      state: "Active",
+      willRenew: true,
+      clearCancellationReason: true,
+    });
+  });
+
+  it("preserves access for canceled Google subscriptions until expiry", () => {
+    const snapshot = buildVerifiedSubscriptionSnapshot({
+      platform: "Android",
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.CANCELED,
+      subscriptionState: "SUBSCRIPTION_STATE_CANCELED",
+      expiresAt: 2_000_000_000_000,
+    });
+
+    expect(snapshot).toMatchObject({
+      productId: "premium_monthly",
+      state: "Active",
+      willRenew: false,
+      cancellationReason: "UserCanceled",
+      expiresAt: 2_000_000_000_000,
+    });
+  });
+
+  it("maps on-hold Google subscriptions to billing retry", () => {
+    const snapshot = buildVerifiedSubscriptionSnapshot({
+      platform: "Android",
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.PENDING,
+      subscriptionState: "SUBSCRIPTION_STATE_ON_HOLD",
+    });
+
+    expect(snapshot).toMatchObject({
+      productId: "premium_monthly",
+      state: "InBillingRetry",
+      cancellationReason: "BillingError",
+    });
+  });
+
+  it("does not infer renewal status when Google omits subscriptionState", () => {
+    const snapshot = buildVerifiedSubscriptionSnapshot({
+      platform: "Android",
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.PENDING_ACKNOWLEDGMENT,
+    });
+
+    expect(snapshot).toMatchObject({
+      productId: "premium_monthly",
+      state: "Active",
+    });
+    expect(snapshot?.willRenew).toBeUndefined();
+    expect(snapshot?.cancellationReason).toBeUndefined();
+    expect(snapshot?.clearCancellationReason).toBeUndefined();
+  });
+
+  it("does not create a subscription row for expected-product mismatches", () => {
+    const snapshot = buildVerifiedSubscriptionSnapshot({
+      platform: "Android",
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.INAUTHENTIC,
+      subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+    });
+
+    expect(snapshot).toBeNull();
+  });
+
+  it("does not create a subscription row when Google omits the product id", () => {
+    const snapshot = buildVerifiedSubscriptionSnapshot({
+      platform: "Android",
+      productId: "unknown",
+      purchaseState: HarmonizedPurchaseState.ENTITLED,
+      subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+    });
+
+    expect(snapshot).toBeNull();
+  });
+
+  it("bootstraps an Apple subscription without guessing auto-renew status", () => {
+    const snapshot = buildVerifiedSubscriptionSnapshot({
+      platform: "IOS",
+      productId: "com.example.premium",
+      purchaseState: HarmonizedPurchaseState.ENTITLED,
+      expiresAt: 2_000_000_000_000,
+      currency: "USD",
+      priceAmountMicros: 9_990_000,
+    });
+
+    expect(snapshot).toEqual({
+      productId: "com.example.premium",
+      state: "Active",
+      expiresAt: 2_000_000_000_000,
+      renewsAt: undefined,
+      cancellationReason: undefined,
+      currency: "USD",
+      priceAmountMicros: 9_990_000,
+    });
+  });
+});
+
+describe("mergeVerifiedSubscriptionSnapshot", () => {
+  it("preserves existing timing and price fields when verify omits them", () => {
+    const snapshot = mergeVerifiedSubscriptionSnapshot(
+      {
+        expiresAt: 2_000_000_000_000,
+        renewsAt: 2_000_000_000_000,
+        willRenew: true,
+        cancellationReason: undefined,
+        currency: "USD",
+        priceAmountMicros: 9_990_000,
+      },
+      {
+        productId: "premium_monthly",
+        state: "Active",
+        willRenew: true,
+      },
+    );
+
+    expect(snapshot).toEqual({
+      productId: "premium_monthly",
+      state: "Active",
+      expiresAt: 2_000_000_000_000,
+      renewsAt: 2_000_000_000_000,
+      willRenew: true,
+      cancellationReason: undefined,
+      currency: "USD",
+      priceAmountMicros: 9_990_000,
+    });
+  });
+
+  it("clears stale cancellation reason when verify confirms active state", () => {
+    const snapshot = mergeVerifiedSubscriptionSnapshot(
+      {
+        expiresAt: undefined,
+        renewsAt: undefined,
+        willRenew: false,
+        cancellationReason: "UserCanceled",
+        currency: undefined,
+        priceAmountMicros: undefined,
+      },
+      {
+        productId: "premium_monthly",
+        state: "Active",
+        willRenew: true,
+        cancellationReason: undefined,
+        clearCancellationReason: true,
+      },
+    );
+
+    expect(snapshot.cancellationReason).toBeUndefined();
+    expect(snapshot.willRenew).toBe(true);
+  });
+
+  it("preserves cancellation reason when verify cannot prove auto-renew is enabled", () => {
+    const snapshot = mergeVerifiedSubscriptionSnapshot(
+      {
+        expiresAt: undefined,
+        renewsAt: undefined,
+        willRenew: false,
+        cancellationReason: "UserCanceled",
+        currency: undefined,
+        priceAmountMicros: undefined,
+      },
+      {
+        productId: "premium_monthly",
+        state: "Active",
+      },
+    );
+
+    expect(snapshot.cancellationReason).toBe("UserCanceled");
+    expect(snapshot.willRenew).toBe(false);
+  });
+});
+
+describe("recordVerifiedSubscriptionHandler", () => {
+  beforeEach(() => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("creates a bindable subscription row from Google receipt verification", async () => {
+    const db = new MemDb();
+    db.seedProduct({
+      projectId: PROJECT_ID,
+      platform: "Android",
+      productId: "premium_monthly",
+      billingPeriod: "P1M",
+    });
+
+    const subscriptionId = await recordVerifiedSubscriptionHandler(
+      makeCtx(db),
+      {
+        projectId: PROJECT_ID as never,
+        platform: "Android",
+        purchaseToken: TOKEN,
+        productId: "premium_monthly",
+        purchaseState: HarmonizedPurchaseState.ENTITLED,
+        subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+        expiresAt: 1_769_904_000_000,
+        renewsAt: 1_769_904_000_000,
+        currency: "USD",
+        priceAmountMicros: 9_990_000,
+      },
+    );
+
+    expect(subscriptionId).toBe("subscriptions_2");
+    expect(db.rows("subscriptions")).toMatchObject([
+      {
+        _id: "subscriptions_2",
+        projectId: PROJECT_ID,
+        purchaseToken: TOKEN,
+        productId: "premium_monthly",
+        platform: "Android",
+        state: "Active",
+        willRenew: true,
+        currency: "USD",
+        priceAmountMicros: 9_990_000,
+      },
+    ]);
+    expect(db.rows("subscriptionStats")).toMatchObject([
+      {
+        projectId: PROJECT_ID,
+        currency: "USD",
+        activeSubs: 1,
+        inGracePeriod: 0,
+        inBillingRetry: 0,
+        mrrMicros: 9_990_000,
+      },
+    ]);
+  });
+
+  it("creates an active bindable row for pending-acknowledgment Google subscriptions", async () => {
+    const db = new MemDb();
+    db.seedProduct({
+      projectId: PROJECT_ID,
+      platform: "Android",
+      productId: "premium_monthly",
+      billingPeriod: "P1M",
+    });
+
+    await recordVerifiedSubscriptionHandler(makeCtx(db), {
+      projectId: PROJECT_ID as never,
+      platform: "Android",
+      purchaseToken: TOKEN,
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.PENDING_ACKNOWLEDGMENT,
+      subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+      expiresAt: 1_769_904_000_000,
+      currency: "USD",
+      priceAmountMicros: 9_990_000,
+    });
+
+    expect(db.rows("subscriptions")).toMatchObject([
+      {
+        purchaseToken: TOKEN,
+        productId: "premium_monthly",
+        platform: "Android",
+        state: "Active",
+        willRenew: true,
+      },
+    ]);
+    expect(db.rows("subscriptionStats")).toMatchObject([
+      {
+        activeSubs: 1,
+        mrrMicros: 9_990_000,
+      },
+    ]);
+  });
+
+  it("keeps repeated verification idempotent for subscription stats", async () => {
+    const db = new MemDb();
+    db.seedProduct({
+      projectId: PROJECT_ID,
+      platform: "Android",
+      productId: "premium_monthly",
+      billingPeriod: "P1M",
+    });
+    const args = {
+      projectId: PROJECT_ID as never,
+      platform: "Android" as const,
+      purchaseToken: TOKEN,
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.ENTITLED,
+      subscriptionState: "SUBSCRIPTION_STATE_ACTIVE",
+      expiresAt: 1_769_904_000_000,
+      currency: "USD",
+      priceAmountMicros: 9_990_000,
+    };
+
+    await recordVerifiedSubscriptionHandler(makeCtx(db), args);
+    await recordVerifiedSubscriptionHandler(makeCtx(db), args);
+
+    expect(db.rows("subscriptions")).toHaveLength(1);
+    expect(db.rows("subscriptionStats")).toMatchObject([
+      {
+        activeSubs: 1,
+        mrrMicros: 9_990_000,
+      },
+    ]);
+  });
+
+  it("creates a bindable Apple subscription row from receipt verification", async () => {
+    const db = new MemDb();
+    db.seedProduct({
+      projectId: PROJECT_ID,
+      platform: "IOS",
+      productId: "com.example.premium",
+      billingPeriod: "P1M",
+    });
+
+    const subscriptionId = await recordVerifiedSubscriptionHandler(
+      makeCtx(db),
+      {
+        projectId: PROJECT_ID as never,
+        platform: "IOS",
+        purchaseToken: "original_transaction_1",
+        productId: "com.example.premium",
+        purchaseState: HarmonizedPurchaseState.ENTITLED,
+        expiresAt: 1_769_904_000_000,
+        currency: "USD",
+        priceAmountMicros: 9_990_000,
+      },
+    );
+
+    expect(subscriptionId).toBe("subscriptions_2");
+    expect(db.rows("subscriptions")).toMatchObject([
+      {
+        _id: "subscriptions_2",
+        projectId: PROJECT_ID,
+        purchaseToken: "original_transaction_1",
+        productId: "com.example.premium",
+        platform: "IOS",
+        state: "Active",
+        willRenew: undefined,
+      },
+    ]);
+    expect(db.rows("subscriptionStats")).toMatchObject([
+      {
+        projectId: PROJECT_ID,
+        currency: "USD",
+        activeSubs: 1,
+        mrrMicros: 9_990_000,
+      },
+    ]);
+  });
+});

--- a/packages/kit/convex/subscriptions/internal.test.ts
+++ b/packages/kit/convex/subscriptions/internal.test.ts
@@ -242,6 +242,7 @@ describe("buildVerifiedSubscriptionSnapshot", () => {
       expiresAt: 2_000_000_000_000,
       renewsAt: undefined,
       cancellationReason: undefined,
+      clearCancellationReason: true,
       currency: "USD",
       priceAmountMicros: 9_990_000,
     });
@@ -278,27 +279,42 @@ describe("mergeVerifiedSubscriptionSnapshot", () => {
     });
   });
 
-  it("clears stale cancellation reason when verify confirms active state", () => {
-    const snapshot = mergeVerifiedSubscriptionSnapshot(
-      {
-        expiresAt: undefined,
-        renewsAt: undefined,
-        willRenew: false,
-        cancellationReason: "UserCanceled",
-        currency: undefined,
-        priceAmountMicros: undefined,
-      },
-      {
-        productId: "premium_monthly",
-        state: "Active",
-        willRenew: true,
-        cancellationReason: undefined,
-        clearCancellationReason: true,
-      },
+  it("clears stale cancellation reason when verified snapshots request it", () => {
+    const existing = {
+      expiresAt: undefined,
+      renewsAt: undefined,
+      willRenew: false,
+      cancellationReason: "UserCanceled" as const,
+      currency: undefined,
+      priceAmountMicros: undefined,
+    };
+    const appleSnapshot = buildVerifiedSubscriptionSnapshot({
+      platform: "IOS",
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.ENTITLED,
+    });
+    const graceSnapshot = buildVerifiedSubscriptionSnapshot({
+      platform: "Android",
+      productId: "premium_monthly",
+      purchaseState: HarmonizedPurchaseState.ENTITLED,
+      subscriptionState: "SUBSCRIPTION_STATE_IN_GRACE_PERIOD",
+    });
+
+    expect(appleSnapshot?.clearCancellationReason).toBe(true);
+    expect(graceSnapshot?.clearCancellationReason).toBe(true);
+
+    const appleMerged = mergeVerifiedSubscriptionSnapshot(
+      existing,
+      appleSnapshot!,
+    );
+    const graceMerged = mergeVerifiedSubscriptionSnapshot(
+      existing,
+      graceSnapshot!,
     );
 
-    expect(snapshot.cancellationReason).toBeUndefined();
-    expect(snapshot.willRenew).toBe(true);
+    expect(appleMerged.cancellationReason).toBeUndefined();
+    expect(graceMerged.cancellationReason).toBeUndefined();
+    expect(graceMerged.willRenew).toBe(true);
   });
 
   it("preserves cancellation reason when verify cannot prove auto-renew is enabled", () => {

--- a/packages/kit/convex/subscriptions/internal.ts
+++ b/packages/kit/convex/subscriptions/internal.ts
@@ -201,6 +201,7 @@ export function buildVerifiedSubscriptionSnapshot(
           ...base,
           state: "Active",
           cancellationReason: undefined,
+          clearCancellationReason: true,
         };
       case HarmonizedPurchaseState.EXPIRED:
         return {
@@ -270,6 +271,7 @@ export function buildVerifiedSubscriptionSnapshot(
         state: "InGracePeriod",
         willRenew: true,
         cancellationReason: undefined,
+        clearCancellationReason: true,
       };
     case "SUBSCRIPTION_STATE_ON_HOLD":
       return {

--- a/packages/kit/convex/subscriptions/internal.ts
+++ b/packages/kit/convex/subscriptions/internal.ts
@@ -92,6 +92,12 @@ type RecordVerifiedSubscriptionArgs = {
   priceAmountMicros?: number;
 };
 
+type BindSubscriptionToUserArgs = {
+  projectId: Id<"projects">;
+  purchaseToken: string;
+  userId: string;
+};
+
 interface PersistSubscriptionSnapshotArgs {
   projectId: Id<"projects">;
   platform: SubscriptionPlatform;
@@ -545,18 +551,23 @@ export const bindSubscriptionToUser = internalMutation({
     userId: v.string(),
   },
   returns: v.union(v.id("subscriptions"), v.null()),
-  handler: async (ctx, args) => {
-    const sub = await findSubscriptionByToken(
-      ctx,
-      args.projectId,
-      args.purchaseToken,
-    );
-    if (!sub) return null;
-    if (sub.userId === args.userId) return sub._id;
-    await ctx.db.patch(sub._id, {
-      userId: args.userId,
-      updatedAt: Date.now(),
-    });
-    return sub._id;
-  },
+  handler: async (ctx, args) => bindSubscriptionToUserHandler(ctx, args),
 });
+
+export async function bindSubscriptionToUserHandler(
+  ctx: MutationCtx,
+  args: BindSubscriptionToUserArgs,
+): Promise<Id<"subscriptions"> | null> {
+  const sub = await findSubscriptionByToken(
+    ctx,
+    args.projectId,
+    args.purchaseToken,
+  );
+  if (!sub) return null;
+  if (sub.userId === args.userId) return sub._id;
+  await ctx.db.patch(sub._id, {
+    userId: args.userId,
+    updatedAt: Date.now(),
+  });
+  return sub._id;
+}

--- a/packages/kit/convex/subscriptions/internal.ts
+++ b/packages/kit/convex/subscriptions/internal.ts
@@ -2,6 +2,7 @@ import { internalMutation, type MutationCtx } from "../_generated/server";
 import { v, type Infer } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
 
+import { HarmonizedPurchaseState } from "../purchases/purchaseState";
 import {
   applySubscriptionTransition,
   type CurrentSubscription,
@@ -20,6 +21,11 @@ const subscriptionStateValidator = v.union(
   v.literal("Unknown"),
 );
 
+const subscriptionPlatformValidator = v.union(
+  v.literal("IOS"),
+  v.literal("Android"),
+);
+
 const eventInputValidator = v.object({
   type: v.string(),
   productId: v.optional(v.string()),
@@ -29,11 +35,72 @@ const eventInputValidator = v.object({
   cancellationReason: v.optional(v.string()),
   currency: v.optional(v.string()),
   priceAmountMicros: v.optional(v.number()),
-  platform: v.union(v.literal("IOS"), v.literal("Android")),
+  platform: subscriptionPlatformValidator,
   purchaseToken: v.string(),
 });
 
 type RawEventInput = Infer<typeof eventInputValidator>;
+type SubscriptionState = Infer<typeof subscriptionStateValidator>;
+type SubscriptionCancellationReason = NonNullable<
+  Doc<"subscriptions">["cancellationReason"]
+>;
+type SubscriptionPlatform = Doc<"subscriptions">["platform"];
+
+export type VerifiedSubscriptionInput = {
+  platform: SubscriptionPlatform;
+  productId: string;
+  purchaseState: HarmonizedPurchaseState;
+  subscriptionState?: string;
+  expiresAt?: number;
+  renewsAt?: number;
+  currency?: string;
+  priceAmountMicros?: number;
+};
+
+export type VerifiedSubscriptionSnapshot = {
+  productId: string;
+  state: SubscriptionState;
+  expiresAt?: number;
+  renewsAt?: number;
+  willRenew?: boolean;
+  cancellationReason?: SubscriptionCancellationReason;
+  clearCancellationReason?: boolean;
+  currency?: string;
+  priceAmountMicros?: number;
+};
+
+type ExistingSubscriptionSnapshotFields = Pick<
+  Doc<"subscriptions">,
+  | "expiresAt"
+  | "renewsAt"
+  | "willRenew"
+  | "cancellationReason"
+  | "currency"
+  | "priceAmountMicros"
+>;
+
+type RecordVerifiedSubscriptionArgs = {
+  projectId: Id<"projects">;
+  platform: SubscriptionPlatform;
+  purchaseToken: string;
+  productId: string;
+  purchaseState: string;
+  subscriptionState?: string;
+  expiresAt?: number;
+  renewsAt?: number;
+  currency?: string;
+  priceAmountMicros?: number;
+};
+
+interface PersistSubscriptionSnapshotArgs {
+  projectId: Id<"projects">;
+  platform: SubscriptionPlatform;
+  purchaseToken: string;
+  existing: Doc<"subscriptions"> | null;
+  next: NonNullable<CurrentSubscription>;
+  now: number;
+  lastEventId?: Id<"webhookEvents">;
+}
 
 // Apply a webhook event to the canonical `subscriptions` table. Idempotent
 // with respect to `lastEventId` so a re-run of the same event (after a
@@ -50,14 +117,11 @@ export const applySubscriptionEvent = internalMutation({
     subscriptionId: v.optional(v.id("subscriptions")),
   }),
   handler: async (ctx, args) => {
-    const existing = await ctx.db
-      .query("subscriptions")
-      .withIndex("by_project_and_token", (q) =>
-        q
-          .eq("projectId", args.projectId)
-          .eq("purchaseToken", args.event.purchaseToken),
-      )
-      .unique();
+    const existing = await findSubscriptionByToken(
+      ctx,
+      args.projectId,
+      args.event.purchaseToken,
+    );
 
     if (existing && existing.lastEventId === args.eventId) {
       return {
@@ -93,92 +157,15 @@ export const applySubscriptionEvent = internalMutation({
       };
     }
 
-    const now = Date.now();
-    const next = transition.next;
-
-    // Pull billing period for MRR calculation. Skipped if state isn't
-    // counted (Active / InGracePeriod / InBillingRetry) since
-    // statsContributionFor returns null in that case anyway. The
-    // AFTER side always uses the new product's period.
-    const billingPeriod = await fetchBillingPeriod(
-      ctx,
-      args.projectId,
-      args.event.platform,
-      next.productId,
-    );
-
-    // BEFORE side has to use the OLD product's billing period — when
-    // an upgrade or downgrade event flips `productId`, using the new
-    // product's period to compute the BEFORE delta would subtract
-    // the wrong monthly-normalized amount from MRR and corrupt the
-    // incremental counter (PR #124
-    // (https://github.com/hyodotdev/openiap/pull/124) review).
-    // Reuse `billingPeriod` only when the productId didn't change.
-    const beforeBillingPeriod =
-      existing && existing.productId !== next.productId
-        ? await fetchBillingPeriod(
-            ctx,
-            args.projectId,
-            args.event.platform,
-            existing.productId,
-          )
-        : billingPeriod;
-
-    // Capture the BEFORE contribution against the still-existing row
-    // so the stats delta below subtracts what the row used to count
-    // for, then adds what it counts for after the patch.
-    const beforeContribution = existing
-      ? statsContributionFor(existing, beforeBillingPeriod, now)
-      : null;
-
-    let subscriptionId: Id<"subscriptions">;
-    let updatedRow: Doc<"subscriptions">;
-    if (existing) {
-      await ctx.db.patch(existing._id, {
-        productId: next.productId,
-        state: next.state,
-        expiresAt: next.expiresAt,
-        renewsAt: next.renewsAt,
-        willRenew: next.willRenew,
-        cancellationReason: next.cancellationReason,
-        currency: next.currency,
-        priceAmountMicros: next.priceAmountMicros,
-        updatedAt: now,
-        lastEventId: args.eventId,
-      });
-      subscriptionId = existing._id;
-      updatedRow = (await ctx.db.get(existing._id))!;
-    } else {
-      subscriptionId = await ctx.db.insert("subscriptions", {
-        projectId: args.projectId,
-        purchaseToken: args.event.purchaseToken,
-        productId: next.productId,
-        platform: args.event.platform,
-        state: next.state,
-        expiresAt: next.expiresAt,
-        renewsAt: next.renewsAt,
-        willRenew: next.willRenew,
-        cancellationReason: next.cancellationReason,
-        currency: next.currency,
-        priceAmountMicros: next.priceAmountMicros,
-        startedAt: now,
-        updatedAt: now,
-        lastEventId: args.eventId,
-      });
-      updatedRow = (await ctx.db.get(subscriptionId))!;
-    }
-
-    const afterContribution = statsContributionFor(
-      updatedRow,
-      billingPeriod,
-      now,
-    );
-    await applyStatsTransition(
-      ctx,
-      args.projectId,
-      beforeContribution,
-      afterContribution,
-    );
+    const subscriptionId = await persistSubscriptionSnapshot(ctx, {
+      projectId: args.projectId,
+      platform: args.event.platform,
+      purchaseToken: args.event.purchaseToken,
+      existing,
+      next: transition.next,
+      now: Date.now(),
+      lastEventId: args.eventId,
+    });
 
     return {
       transition: transition.transition ?? null,
@@ -187,6 +174,299 @@ export const applySubscriptionEvent = internalMutation({
     };
   },
 });
+
+export function buildVerifiedSubscriptionSnapshot(
+  input: VerifiedSubscriptionInput,
+): VerifiedSubscriptionSnapshot | null {
+  if (input.productId.length === 0 || input.productId === "unknown") {
+    return null;
+  }
+  if (input.purchaseState === HarmonizedPurchaseState.INAUTHENTIC) return null;
+
+  const base: Pick<
+    VerifiedSubscriptionSnapshot,
+    "productId" | "expiresAt" | "renewsAt" | "currency" | "priceAmountMicros"
+  > = {
+    productId: input.productId,
+    expiresAt: input.expiresAt,
+    renewsAt: input.renewsAt,
+    currency: input.currency,
+    priceAmountMicros: input.priceAmountMicros,
+  };
+
+  if (input.platform === "IOS") {
+    switch (input.purchaseState) {
+      case HarmonizedPurchaseState.ENTITLED:
+        return {
+          ...base,
+          state: "Active",
+          cancellationReason: undefined,
+        };
+      case HarmonizedPurchaseState.EXPIRED:
+        return {
+          ...base,
+          state: "Expired",
+          willRenew: false,
+        };
+      case HarmonizedPurchaseState.CANCELED:
+        return {
+          ...base,
+          state: "Revoked",
+          willRenew: false,
+          cancellationReason: "Refunded",
+        };
+      case HarmonizedPurchaseState.PENDING_ACKNOWLEDGMENT:
+      case HarmonizedPurchaseState.PENDING:
+      case HarmonizedPurchaseState.UNKNOWN:
+        return {
+          ...base,
+          state: "Unknown",
+        };
+      case HarmonizedPurchaseState.READY_TO_CONSUME:
+      case HarmonizedPurchaseState.CONSUMED:
+        return null;
+    }
+  }
+
+  switch (input.purchaseState) {
+    case HarmonizedPurchaseState.UNKNOWN:
+      return {
+        ...base,
+        state: "Unknown",
+      };
+    case HarmonizedPurchaseState.EXPIRED:
+      return {
+        ...base,
+        state: "Expired",
+        willRenew: false,
+      };
+    case HarmonizedPurchaseState.READY_TO_CONSUME:
+    case HarmonizedPurchaseState.CONSUMED:
+      return null;
+    case HarmonizedPurchaseState.ENTITLED:
+    case HarmonizedPurchaseState.CANCELED:
+      break;
+  }
+
+  switch (input.subscriptionState?.toUpperCase()) {
+    case "SUBSCRIPTION_STATE_ACTIVE":
+      return {
+        ...base,
+        state: "Active",
+        willRenew: true,
+        cancellationReason: undefined,
+        clearCancellationReason: true,
+      };
+    case "SUBSCRIPTION_STATE_CANCELED":
+      return {
+        ...base,
+        state: "Active",
+        willRenew: false,
+        cancellationReason: "UserCanceled",
+      };
+    case "SUBSCRIPTION_STATE_IN_GRACE_PERIOD":
+      return {
+        ...base,
+        state: "InGracePeriod",
+        willRenew: true,
+        cancellationReason: undefined,
+      };
+    case "SUBSCRIPTION_STATE_ON_HOLD":
+      return {
+        ...base,
+        state: "InBillingRetry",
+        cancellationReason: "BillingError",
+      };
+    case "SUBSCRIPTION_STATE_PAUSED":
+      return {
+        ...base,
+        state: "Paused",
+        willRenew: false,
+      };
+    case "SUBSCRIPTION_STATE_EXPIRED":
+      return {
+        ...base,
+        state: "Expired",
+        willRenew: false,
+      };
+    case "SUBSCRIPTION_STATE_PENDING":
+      return {
+        ...base,
+        state: "Unknown",
+      };
+  }
+
+  return {
+    ...base,
+    state:
+      input.purchaseState === HarmonizedPurchaseState.ENTITLED ||
+      input.purchaseState === HarmonizedPurchaseState.PENDING_ACKNOWLEDGMENT
+        ? "Active"
+        : "Unknown",
+  };
+}
+
+export function mergeVerifiedSubscriptionSnapshot(
+  existing: ExistingSubscriptionSnapshotFields | null,
+  snapshot: VerifiedSubscriptionSnapshot,
+): VerifiedSubscriptionSnapshot {
+  if (!existing) return snapshot;
+
+  return {
+    ...snapshot,
+    expiresAt: snapshot.expiresAt ?? existing.expiresAt,
+    renewsAt: snapshot.renewsAt ?? existing.renewsAt,
+    willRenew: snapshot.willRenew ?? existing.willRenew,
+    cancellationReason:
+      snapshot.cancellationReason !== undefined ||
+      snapshot.clearCancellationReason
+        ? snapshot.cancellationReason
+        : existing.cancellationReason,
+    currency: snapshot.currency ?? existing.currency,
+    priceAmountMicros: snapshot.priceAmountMicros ?? existing.priceAmountMicros,
+  };
+}
+
+// Receipt verification is the synchronous bootstrap path for
+// subscriptions. Webhooks keep lifecycle state fresh later, but a
+// successful verify must be enough for SDK clients to bind the just-
+// purchased token to their app user.
+export const recordVerifiedSubscription = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    platform: subscriptionPlatformValidator,
+    purchaseToken: v.string(),
+    productId: v.string(),
+    purchaseState: v.string(),
+    subscriptionState: v.optional(v.string()),
+    expiresAt: v.optional(v.number()),
+    renewsAt: v.optional(v.number()),
+    currency: v.optional(v.string()),
+    priceAmountMicros: v.optional(v.number()),
+  },
+  returns: v.union(v.id("subscriptions"), v.null()),
+  handler: async (ctx, args) => recordVerifiedSubscriptionHandler(ctx, args),
+});
+
+export async function recordVerifiedSubscriptionHandler(
+  ctx: MutationCtx,
+  args: RecordVerifiedSubscriptionArgs,
+): Promise<Id<"subscriptions"> | null> {
+  const snapshot = buildVerifiedSubscriptionSnapshot({
+    platform: args.platform,
+    productId: args.productId,
+    purchaseState: normalizeHarmonizedPurchaseState(args.purchaseState),
+    subscriptionState: args.subscriptionState,
+    expiresAt: args.expiresAt,
+    renewsAt: args.renewsAt,
+    currency: args.currency,
+    priceAmountMicros: args.priceAmountMicros,
+  });
+  if (!snapshot) return null;
+
+  const existing = await findSubscriptionByToken(
+    ctx,
+    args.projectId,
+    args.purchaseToken,
+  );
+  const now = Date.now();
+
+  const next = mergeVerifiedSubscriptionSnapshot(existing, snapshot);
+  return persistSubscriptionSnapshot(ctx, {
+    projectId: args.projectId,
+    platform: args.platform,
+    purchaseToken: args.purchaseToken,
+    existing,
+    next,
+    now,
+  });
+}
+
+async function persistSubscriptionSnapshot(
+  ctx: MutationCtx,
+  args: PersistSubscriptionSnapshotArgs,
+): Promise<Id<"subscriptions">> {
+  // Stats deltas must compare the old row against the old catalog entry
+  // and the new row against the new one; otherwise product/platform changes
+  // subtract the wrong MRR bucket.
+  const afterBillingPeriod = await fetchBillingPeriod(
+    ctx,
+    args.projectId,
+    args.platform,
+    args.next.productId,
+  );
+  const beforeBillingPeriod =
+    args.existing &&
+    (args.existing.productId !== args.next.productId ||
+      args.existing.platform !== args.platform)
+      ? await fetchBillingPeriod(
+          ctx,
+          args.projectId,
+          args.existing.platform,
+          args.existing.productId,
+        )
+      : afterBillingPeriod;
+  const beforeContribution = args.existing
+    ? statsContributionFor(args.existing, beforeBillingPeriod, args.now)
+    : null;
+
+  const row = {
+    productId: args.next.productId,
+    platform: args.platform,
+    state: args.next.state,
+    expiresAt: args.next.expiresAt,
+    renewsAt: args.next.renewsAt,
+    willRenew: args.next.willRenew,
+    cancellationReason: args.next.cancellationReason,
+    currency: args.next.currency,
+    priceAmountMicros: args.next.priceAmountMicros,
+    updatedAt: args.now,
+    ...(args.lastEventId !== undefined
+      ? { lastEventId: args.lastEventId }
+      : {}),
+  };
+
+  const subscriptionId = args.existing
+    ? args.existing._id
+    : await ctx.db.insert("subscriptions", {
+        projectId: args.projectId,
+        purchaseToken: args.purchaseToken,
+        startedAt: args.now,
+        ...row,
+      });
+
+  if (args.existing) {
+    await ctx.db.patch(args.existing._id, row);
+  }
+
+  const updatedRow = (await ctx.db.get(subscriptionId))!;
+  const afterContribution = statsContributionFor(
+    updatedRow,
+    afterBillingPeriod,
+    args.now,
+  );
+  await applyStatsTransition(
+    ctx,
+    args.projectId,
+    beforeContribution,
+    afterContribution,
+  );
+
+  return subscriptionId;
+}
+
+function findSubscriptionByToken(
+  ctx: MutationCtx,
+  projectId: Id<"projects">,
+  purchaseToken: string,
+): Promise<Doc<"subscriptions"> | null> {
+  return ctx.db
+    .query("subscriptions")
+    .withIndex("by_project_and_token", (q) =>
+      q.eq("projectId", projectId).eq("purchaseToken", purchaseToken),
+    )
+    .unique();
+}
 
 // Look up a product's billing period from the kit-side catalog. We
 // Look up the row for the EXACT (platform, productId) — `products` is
@@ -202,7 +482,7 @@ export const applySubscriptionEvent = internalMutation({
 async function fetchBillingPeriod(
   ctx: MutationCtx,
   projectId: Id<"projects">,
-  platform: "IOS" | "Android",
+  platform: SubscriptionPlatform,
   productId: string,
 ): Promise<string | undefined> {
   const product = await ctx.db
@@ -242,6 +522,18 @@ function isActive(
   return true;
 }
 
+function normalizeHarmonizedPurchaseState(
+  state: string,
+): HarmonizedPurchaseState {
+  const normalized = state.trim().toUpperCase().replace(/-/g, "_");
+  if (normalized in HarmonizedPurchaseState) {
+    return HarmonizedPurchaseState[
+      normalized as keyof typeof HarmonizedPurchaseState
+    ];
+  }
+  return HarmonizedPurchaseState.UNKNOWN;
+}
+
 // Bind a subscription to a userId. Called by the SDK after a successful
 // receipt validation when the host app knows which user owns the receipt.
 export const bindSubscriptionToUser = internalMutation({
@@ -252,14 +544,11 @@ export const bindSubscriptionToUser = internalMutation({
   },
   returns: v.union(v.id("subscriptions"), v.null()),
   handler: async (ctx, args) => {
-    const sub = await ctx.db
-      .query("subscriptions")
-      .withIndex("by_project_and_token", (q) =>
-        q
-          .eq("projectId", args.projectId)
-          .eq("purchaseToken", args.purchaseToken),
-      )
-      .unique();
+    const sub = await findSubscriptionByToken(
+      ctx,
+      args.projectId,
+      args.purchaseToken,
+    );
     if (!sub) return null;
     if (sub.userId === args.userId) return sub._id;
     await ctx.db.patch(sub._id, {

--- a/packages/kit/convex/subscriptions/mutation.ts
+++ b/packages/kit/convex/subscriptions/mutation.ts
@@ -1,8 +1,8 @@
 import { mutation } from "../_generated/server";
 import { v } from "convex/values";
-import type { Doc } from "../_generated/dataModel";
 
 import { resolveProjectByApiKeyFromDb } from "../projects/helpers";
+import { bindSubscriptionToUserHandler } from "./internal";
 
 // Public mutation called by SDKs after a successful receipt verification:
 // they know who the host-app user is, so they tell kit which userId owns
@@ -20,22 +20,12 @@ export const bindUser = mutation({
     const project = resolved?.project ?? null;
     if (!project) return { ok: false, bound: false };
 
-    const sub: Doc<"subscriptions"> | null = await ctx.db
-      .query("subscriptions")
-      .withIndex("by_project_and_token", (q) =>
-        q.eq("projectId", project._id).eq("purchaseToken", args.purchaseToken),
-      )
-      .unique();
-    if (!sub) return { ok: true, bound: false };
-
-    if (sub.userId === args.userId) {
-      return { ok: true, bound: true };
-    }
-
-    await ctx.db.patch(sub._id, {
+    const subscriptionId = await bindSubscriptionToUserHandler(ctx, {
+      projectId: project._id,
+      purchaseToken: args.purchaseToken,
       userId: args.userId,
-      updatedAt: Date.now(),
     });
-    return { ok: true, bound: true };
+
+    return { ok: true, bound: subscriptionId !== null };
   },
 });


### PR DESCRIPTION
## Summary

- Create subscription rows during Apple and Google receipt verification so SDK `bindUser` can attach a verified subscription before webhook delivery.
- Align Google subscription verification with webhook semantics, including pending-acknowledgment, canceled-but-not-expired subscriptions, and multi-line-item selection.
- Preserve existing webhook-derived expiry, renewal, cancellation, and price fields when later verification responses omit them.

Closes #209

## Changes

### Verification bootstrap
- Add `recordVerifiedSubscription` to upsert canonical subscription rows from receipt verification.
- Wire Google and Apple subscription verification paths into the bootstrap mutation.
- Keep repeated verification idempotent for `subscriptionStats`.

### Google subscription mapping
- Select the longest-dated SubscriptionPurchaseV2 line item for product/order/price extraction.
- Treat `SUBSCRIPTION_STATE_CANCELED` as active until expiry while marking `willRenew: false`.
- Treat `PENDING_ACKNOWLEDGMENT` subscription verification as a valid active entitlement while acknowledgement is still required.

### Tests
- Add focused subscription bootstrap tests for bindable row creation, pending acknowledgement, Apple verification, merge preservation, and stats idempotency.
- Add extraction tests for longest-dated Google subscription line items.

## Test plan

- [x] `bun run --filter @hyodotdev/openiap-kit lint`
- [x] `bun run --filter @hyodotdev/openiap-kit test` - 50 files, 564 tests
- [x] `bun run --filter @hyodotdev/openiap-kit format:check`
- [x] `bun run --filter @hyodotdev/openiap-kit smoke:server`
- [x] Commit hook SDK parity audit passed

## Device verification

- [x] Kit source verification on this branch: `bun run test convex/purchases/android.test.ts convex/purchases/ios.test.ts convex/subscriptions/internal.test.ts` - 3 files, 45 tests; `bun run typecheck`; `bun run test` - 50 files, 564 tests.
- [x] Google native app on Pixel 2 (`HT79F1A00473`): installed `packages/google` Play debug build, selected `IAPKit (Server)`, completed Google Play sandbox purchase for `dev.hyo.martie.10bulbs`, and observed `PurchaseFlow: IAPKit verification result: true` plus `Purchase finished successfully`.
- [x] Google native subscription flow on Pixel 2 (`HT79F1A00473`): selected `IAPKit (Server)`, completed Google Play sandbox subscription for `dev.hyo.martie.premium`, and observed `SubscriptionFlow: IAPKit verification result: true` plus `Transaction finished successfully`.
- [x] Apple native app on iPhone 13 mini (`00008110-0004081E1A79801E`, iOS 26.5): manually completed the native `IAPKit (Server)` purchase and subscription flows against deployed `kit.openiap.dev`. Production Convex (`healthy-kudu-836`) recorded Apple `dev.hyo.martie.10bulbs` rows as `isValid=true`, `state=READY_TO_CONSUME`, and Apple `dev.hyo.martie.premium` as `isValid=true`, `state=ENTITLED`, `type=Auto-Renewable Subscription`.
- [x] Production issue reproduction before branch deploy: for Martie project `m17fc7y1htcgtnbmahmzyw8yvn7vvxcw`, production Convex `subscriptions` still had `count=0` after deployed Apple subscription verification. This confirmed the old production behavior verified receipts but did not bootstrap canonical subscription rows.
- [x] Production deploy + Android native retest: deployed this branch's Convex functions to production deployment `healthy-kudu-836`, then reran Android native Subscription Flow on Pixel 2 (`HT79F1A00473`) with `IAPKit (Server)`. Google Play sandbox returned `onPurchasesUpdated: code=0`, the app logged `SubscriptionFlow: IAPKit verification result: true`, and production Convex recorded Google `dev.hyo.martie.premium` as `isValid=true`, `state=PENDING_ACKNOWLEDGMENT`, response time ~1.39s.
- [x] Post-deploy canonical subscription persistence: production Convex now has 1 `subscriptions` row for Martie project `m17fc7y1htcgtnbmahmzyw8yvn7vvxcw`: `platform=Android`, `productId=dev.hyo.martie.premium`, `state=Active`, `isActive=true`, `willRenew=true`, `expiresAt=2026-07-07T17:05:00.571Z`, `hasPurchaseToken=true`, `userId=null`.

> Note: the post-deploy Android run exercises this branch's deployed Convex code against the real Google Play sandbox flow and confirms the issue fix for canonical subscription bootstrap. The Apple production flow previously confirmed receipt validation and reproduced the old missing-row behavior; Apple post-deploy persistence should be rechecked separately when running the Apple flow again.

## Preview

Not applicable: this is a backend/Convex receipt-verification and subscription-binding fix with no visual UI surface. Terminal proof is covered by the lint/test/format/smoke commands and device verification above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced subscription verification/recording for Google Play and the App Store, now capturing renewal/expiry times plus currency and price (micros).
  * Added verified-subscription persistence pipeline and subscription-to-user binding support (included in the example iOS/Android flows).
* **Bug Fixes**
  * More reliably selects the correct Google Play line item (latest expiry) when multiple entries exist.
  * Improved mapping for canceled-but-acknowledged Google Play subscriptions to entitlement state.
  * Better App Store subscription classification and milliunits→micros price handling.
* **Tests**
  * Expanded coverage for verified subscription recording, snapshot merge/idempotency, and receipt field mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
