### PR TITLE
test(ci): harden web and store e2e checks

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -9,6 +9,7 @@ Complete workflow: branch → commit → push → PR
 ```
 
 **Options:**
+
 - `--push` or `-p`: Push to remote after commit
 - `--pr`: Create PR after push
 - `--all` or `-a`: Commit all changes at once
@@ -48,6 +49,7 @@ git branch --show-current
 ```
 
 **If on `main`** → Create a feature branch first:
+
 ```bash
 git checkout -b feat/<feature-name>
 ```
@@ -55,13 +57,22 @@ git checkout -b feat/<feature-name>
 **If NOT on `main`** → Proceed with commits directly.
 
 **Branch naming conventions:**
+
+- **Do not use generic agent/tool prefixes** such as `codex/`, `claude/`, or
+  `agent/` for OpenIAP branches, even if the local tool suggests one.
+- **Use a semantic prefix** that describes the change type: `feat/`, `fix/`,
+  `ci/`, `docs/`, `test/`, `chore/`, or `refactor/`.
 - **Always include the target library/package name** in the branch name
 - `feat/<library>-<feature-name>` - New features (e.g., `feat/godot-win-back-offers`)
 - `fix/<library>-<bug-description>` - Bug fixes (e.g., `fix/expo-double-init`)
+- `ci/<library>-<workflow-change>` - CI/workflow changes (e.g., `ci/kmp-store-e2e`)
 - `docs/<library>-<doc-update>` - Documentation only (e.g., `docs/flutter-api-reference`)
+- `test/<library>-<test-change>` - Test/e2e changes (e.g., `test/maui-store-e2e`)
 - `chore/<library>-<task>` - Maintenance tasks (e.g., `chore/kmp-bump-deps`)
+- `refactor/<library>-<change>` - Refactors (e.g., `refactor/google-store-flavors`)
 
 **Library shortnames:**
+
 - `rn` or `react-native` → react-native-iap
 - `expo` → expo-iap
 - `flutter` → flutter_inapp_purchase
@@ -82,21 +93,25 @@ git diff --name-only
 ### 3. Stage Changes
 
 **GQL schema only (FIRST COMMIT):**
+
 ```bash
 git add packages/gql/src/*.graphql
 ```
 
 **Generated types (SECOND COMMIT):**
+
 ```bash
 git add packages/gql/src/generated/
 ```
 
 **Specific path:**
+
 ```bash
 git add <path>
 ```
 
 **All changes:**
+
 ```bash
 git add .
 ```
@@ -124,16 +139,18 @@ EOF
 ```
 
 **Commit Types:**
-| Type | Description |
-|------|-------------|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `docs` | Documentation only |
-| `refactor` | Code refactoring |
-| `chore` | Maintenance tasks |
-| `test` | Adding/updating tests |
+
+| Type       | Description           |
+| ---------- | --------------------- |
+| `feat`     | New feature           |
+| `fix`      | Bug fix               |
+| `docs`     | Documentation only    |
+| `refactor` | Code refactoring      |
+| `chore`    | Maintenance tasks     |
+| `test`     | Adding/updating tests |
 
 **Scope Examples:**
+
 - `gql` - GraphQL schema changes
 - `apple` - iOS/macOS package
 - `google` - Android package
@@ -209,6 +226,7 @@ gh pr edit <PR_NUMBER> --add-label "<label1>,<label2>"
 ```
 
 **Label selection guide:**
+
 - Changes to `packages/apple/` → `📱 iOS`
 - Changes to `packages/google/` → `🤖 android`
 - Changes to `packages/docs/` → `📖 documentation`
@@ -232,17 +250,18 @@ gh pr edit <PR_NUMBER> --add-label "<label1>,<label2>"
 
 When making cross-package changes, commit in this order:
 
-| Order | Path | Description |
-|-------|------|-------------|
-| 1 | `packages/gql/src/*.graphql` | GraphQL schema ONLY (no generated types) |
-| 2 | `packages/gql/src/generated/` | Generated types (after schema review) |
-| 3 | `packages/apple/` | iOS implementation |
-| 4 | `packages/google/` | Android implementation |
-| 5 | `packages/docs/` | Documentation updates |
-| 6 | `.claude/commands/` | Skill/workflow updates |
-| 7 | `knowledge/` | Knowledge base updates |
+| Order | Path                          | Description                              |
+| ----- | ----------------------------- | ---------------------------------------- |
+| 1     | `packages/gql/src/*.graphql`  | GraphQL schema ONLY (no generated types) |
+| 2     | `packages/gql/src/generated/` | Generated types (after schema review)    |
+| 3     | `packages/apple/`             | iOS implementation                       |
+| 4     | `packages/google/`            | Android implementation                   |
+| 5     | `packages/docs/`              | Documentation updates                    |
+| 6     | `.claude/commands/`           | Skill/workflow updates                   |
+| 7     | `knowledge/`                  | Knowledge base updates                   |
 
 **IMPORTANT - First Commit Must Be GQL Spec Only:**
+
 ```bash
 # Stage ONLY .graphql files (not generated/)
 git add packages/gql/src/*.graphql
@@ -258,6 +277,7 @@ git commit -m "feat(gql): add new types..."
 ```
 
 This order allows:
+
 - API schema to be reviewed first before any implementation
 - Generated types committed after schema approval
 - Platform implementations to follow the approved schema
@@ -268,6 +288,7 @@ This order allows:
 ## Example Commit Messages
 
 **GQL schema update:**
+
 ```
 feat(gql): add win-back offer and product status types
 
@@ -284,6 +305,7 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 ```
 
 **Generated types:**
+
 ```
 chore(gql): regenerate types for all platforms
 
@@ -294,6 +316,7 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 ```
 
 **iOS implementation:**
+
 ```
 feat(apple): implement win-back offers and JWS promotional offers
 
@@ -306,6 +329,7 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 ```
 
 **Documentation update:**
+
 ```
 docs: add release notes and type documentation
 
@@ -331,20 +355,24 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 ## Changes
 
 ### GraphQL Schema (packages/gql)
+
 - `WinBackOfferInputIOS` - Win-back offer input type
 - `ProductStatusAndroid` - Product fetch status enum
 - `PromotionalOfferJWSInputIOS` - JWS format promo offers
 
 ### iOS (packages/apple)
+
 - Implement win-back offer handling in purchase flow
 - Add JWS promotional offer support (back-deployed to iOS 15)
 - Add introductory offer eligibility override
 
 ### Android (packages/google)
+
 - Map ProductStatusAndroid from BillingResult
 - Return status in fetchProducts response
 
 ### Documentation (packages/docs)
+
 - Release notes for v1.3.13
 - Type documentation updates
 - Example code updates

--- a/.claude/commands/e2e-tests.md
+++ b/.claude/commands/e2e-tests.md
@@ -27,16 +27,16 @@ When `e2e-tests` is requested without a narrower scope, run every applicable
 row and report every unavailable row as `BLOCKED` or `UNSUPPORTED` with the
 exact missing command, tool, device, or store prerequisite.
 
-| Target | Android / Play | FireOS / Amazon | Horizon | iOS | VegaOS | Onside |
-| ------ | -------------- | --------------- | ------- | --- | ------ | ------ |
-| `packages/google` native | build + tests | build + tests | build-only | n/a | n/a | n/a |
-| `packages/apple` native | n/a | n/a | n/a | build + tests | n/a | n/a |
-| `react-native-iap` | build + device flow | build + device flow | build-only | build + device flow | RN only | n/a |
-| `expo-iap` | build + device flow | build + device flow | build-only | build + device flow | Expo only | build-only |
-| `flutter_inapp_purchase` | build + device flow | build + device flow | build-only | build + device flow | n/a | n/a |
-| `kmp-iap` | build + device flow | required row; currently blocked unless a FireOS flavor is wired | required row; currently blocked unless a Horizon flavor is wired | build + device flow | n/a | n/a |
-| `maui-iap` | build + device flow | required row; currently blocked unless an Amazon binding flavor is wired | required row; currently blocked unless a Horizon binding flavor is wired | build + device flow | n/a | n/a |
-| `godot-iap` | build + device flow | n/a | n/a | build + device flow | n/a | n/a |
+| Target                   | Android / Play      | FireOS / Amazon     | Horizon    | iOS                 | VegaOS    | Onside     |
+| ------------------------ | ------------------- | ------------------- | ---------- | ------------------- | --------- | ---------- |
+| `packages/google` native | build + tests       | build + tests       | build-only | n/a                 | n/a       | n/a        |
+| `packages/apple` native  | n/a                 | n/a                 | n/a        | build + tests       | n/a       | n/a        |
+| `react-native-iap`       | build + device flow | build + device flow | build-only | build + device flow | RN only   | n/a        |
+| `expo-iap`               | build + device flow | build + device flow | build-only | build + device flow | Expo only | build-only |
+| `flutter_inapp_purchase` | build + device flow | build + device flow | build-only | build + device flow | n/a       | n/a        |
+| `kmp-iap`                | build + device flow | build + device flow | build-only | build + device flow | n/a       | n/a        |
+| `maui-iap`               | build + device flow | build + device flow | build-only | build + device flow | n/a       | n/a        |
+| `godot-iap`              | build + device flow | n/a                 | n/a        | build + device flow | n/a       | n/a        |
 
 Notes:
 
@@ -45,9 +45,9 @@ Notes:
 - Horizon is build-only unless the user explicitly provides a Horizon device and
   the library has a runnable Horizon example.
 - Onside is Expo-only and build-only; do not require Onside purchase approval.
-- KMP and MAUI must still appear in the final report for FireOS/Horizon. If the
-  repo has no flavor switch for those libraries, mark the row blocked instead of
-  treating the Play Android build as coverage.
+- KMP and MAUI must still appear in the final report for FireOS/Horizon. Use
+  the store-specific commands below; do not count the Play Android build as
+  FireOS or Horizon coverage.
 
 ## Rules
 
@@ -497,15 +497,39 @@ cd libraries/kmp-iap
 ./gradlew :library:build :library:test :library:podspec :library:generateDummyFramework
 ```
 
-Normal Android build and launch smoke:
+Normal Android / Play build and launch smoke:
 
 ```bash
-cd libraries/kmp-iap/example
-./gradlew :composeApp:assembleDebug
+cd libraries/kmp-iap
+./gradlew \
+  :library:compilePlayDebugKotlinAndroid \
+  :example:composeApp:assemblePlayDebug
 # Build-only regression can stop here.
 : "${ANDROID_SERIAL:?Set ANDROID_SERIAL to the target Android device serial}"
-adb -s "$ANDROID_SERIAL" install -r composeApp/build/outputs/apk/debug/composeApp-debug.apk
+adb -s "$ANDROID_SERIAL" install -r example/composeApp/build/outputs/apk/play/debug/composeApp-play-debug.apk
 adb -s "$ANDROID_SERIAL" shell monkey -p dev.hyo.martie 1
+```
+
+FireOS/Amazon Android build and launch smoke:
+
+```bash
+cd libraries/kmp-iap
+./gradlew \
+  :library:compileAmazonDebugKotlinAndroid \
+  :example:composeApp:assembleAmazonDebug
+# Build-only regression can stop here.
+: "${FIREOS_SERIAL:?Set FIREOS_SERIAL to the target FireOS device serial}"
+adb -s "$FIREOS_SERIAL" install -r example/composeApp/build/outputs/apk/amazon/debug/composeApp-amazon-debug.apk
+adb -s "$FIREOS_SERIAL" shell monkey -p dev.hyo.martie 1
+```
+
+Horizon Android build-only path:
+
+```bash
+cd libraries/kmp-iap
+./gradlew \
+  :library:compileHorizonDebugKotlinAndroid \
+  :example:composeApp:assembleHorizonDebug
 ```
 
 iOS physical-device build and launch smoke:
@@ -525,37 +549,108 @@ xcodebuild \
   -allowProvisioningDeviceRegistration
 ```
 
-FireOS/Amazon and Horizon rows:
-
-```text
-KMP currently has no FireOS/Amazon or Horizon flavor switch in
-libraries/kmp-iap/library/build.gradle.kts or example/composeApp/build.gradle.kts.
-Report these rows as BLOCKED until the flavor is wired; do not count the normal
-Android build as FireOS or Horizon coverage.
-```
-
 ## MAUI Checks
 
 Library build and native binding prerequisites:
 
 ```bash
 cd packages/google
-./gradlew :openiap:assemblePlayRelease
-cd ../../libraries/maui-iap/android
-../../../packages/google/gradlew :openiap:assembleRelease
+./gradlew \
+  :openiap:assemblePlayRelease \
+  :openiap:assembleAmazonRelease \
+  :openiap:assembleHorizonRelease
 cd ../../..
 bash packages/apple/scripts/build-xcframework.sh
 cd libraries/maui-iap
-dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj -f net9.0
-dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj -f net9.0-android
-dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj -f net9.0-ios
+dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net9.0 --nologo
+dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net9.0-ios --nologo
 ```
 
-Normal Android build and launch smoke:
+Normal Android / Play build and launch smoke:
 
 ```bash
-cd libraries/maui-iap/example/OpenIap.Maui.Example
-dotnet build -t:Run -f net9.0-android
+# The MAUI-owned Android facade AAR output path is shared, so build it for the
+# requested store immediately before the matching dotnet build. The library
+# build disables ProjectReference rebuilds because the Android binding is built
+# explicitly first.
+cd libraries/maui-iap/android
+../../../packages/google/gradlew :openiap:assembleRelease -PopenIapAndroidStore=play
+cd ..
+dotnet build-server shutdown || true
+rm -rf src/OpenIap.Maui.Bindings.Android/bin src/OpenIap.Maui.Bindings.Android/obj
+dotnet build src/OpenIap.Maui.Bindings.Android/OpenIap.Maui.Bindings.Android.csproj \
+  -p:TargetFrameworks=net9.0-android \
+  -p:OpenIapAndroidStore=play \
+  --nologo
+dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj \
+  -p:TargetFrameworks=net9.0-android \
+  -p:OpenIapAndroidStore=play \
+  -p:BuildProjectReferences=false \
+  --nologo
+dotnet build example/OpenIap.Maui.Example/OpenIap.Maui.Example.csproj \
+  -f net9.0-android \
+  -p:OpenIapAndroidStore=play \
+  --nologo
+# Build-only regression can stop here.
+: "${ANDROID_SERIAL:?Set ANDROID_SERIAL to the target Android device serial}"
+ANDROID_SERIAL="$ANDROID_SERIAL" dotnet build example/OpenIap.Maui.Example/OpenIap.Maui.Example.csproj \
+  -t:Run \
+  -f net9.0-android \
+  -p:OpenIapAndroidStore=play \
+  --nologo
+```
+
+FireOS/Amazon Android build and launch smoke:
+
+```bash
+cd libraries/maui-iap/android
+../../../packages/google/gradlew :openiap:assembleRelease -PopenIapAndroidStore=amazon
+cd ..
+dotnet build-server shutdown || true
+rm -rf src/OpenIap.Maui.Bindings.Android/bin src/OpenIap.Maui.Bindings.Android/obj
+dotnet build src/OpenIap.Maui.Bindings.Android/OpenIap.Maui.Bindings.Android.csproj \
+  -p:TargetFrameworks=net9.0-android \
+  -p:OpenIapAndroidStore=amazon \
+  --nologo
+dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj \
+  -p:TargetFrameworks=net9.0-android \
+  -p:OpenIapAndroidStore=amazon \
+  -p:BuildProjectReferences=false \
+  --nologo
+dotnet build example/OpenIap.Maui.Example/OpenIap.Maui.Example.csproj \
+  -f net9.0-android \
+  -p:OpenIapAndroidStore=amazon \
+  --nologo
+# Build-only regression can stop here.
+: "${FIREOS_SERIAL:?Set FIREOS_SERIAL to the target FireOS device serial}"
+ANDROID_SERIAL="$FIREOS_SERIAL" dotnet build example/OpenIap.Maui.Example/OpenIap.Maui.Example.csproj \
+  -t:Run \
+  -f net9.0-android \
+  -p:OpenIapAndroidStore=amazon \
+  --nologo
+```
+
+Horizon Android build-only path:
+
+```bash
+cd libraries/maui-iap/android
+../../../packages/google/gradlew :openiap:assembleRelease -PopenIapAndroidStore=horizon
+cd ..
+dotnet build-server shutdown || true
+rm -rf src/OpenIap.Maui.Bindings.Android/bin src/OpenIap.Maui.Bindings.Android/obj
+dotnet build src/OpenIap.Maui.Bindings.Android/OpenIap.Maui.Bindings.Android.csproj \
+  -p:TargetFrameworks=net9.0-android \
+  -p:OpenIapAndroidStore=horizon \
+  --nologo
+dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj \
+  -p:TargetFrameworks=net9.0-android \
+  -p:OpenIapAndroidStore=horizon \
+  -p:BuildProjectReferences=false \
+  --nologo
+dotnet build example/OpenIap.Maui.Example/OpenIap.Maui.Example.csproj \
+  -f net9.0-android \
+  -p:OpenIapAndroidStore=horizon \
+  --nologo
 ```
 
 iOS physical-device build and launch smoke:
@@ -564,14 +659,6 @@ iOS physical-device build and launch smoke:
 cd libraries/maui-iap/example/OpenIap.Maui.Example
 : "${IOS_UDID:?Set IOS_UDID to the target iOS device UDID}"
 dotnet build -t:Run -f net9.0-ios -p:_DeviceName="$IOS_UDID"
-```
-
-FireOS/Amazon and Horizon rows:
-
-```text
-MAUI currently builds its Android binding against the Play flavor. It has no
-Amazon or Horizon binding flavor switch. Report FireOS/Horizon rows as BLOCKED
-until libraries/maui-iap/android and the binding csproj expose those variants.
 ```
 
 ## Godot Checks
@@ -665,12 +752,12 @@ Flutter FireOS        | {serial}      | build/install/purchase | PASS | ...
 Flutter Horizon       | local Gradle  | build        | PASS   | build-only
 Flutter iOS           | {UDID}        | build/install/purchase | PASS | ...
 KMP Android           | {serial}      | build/install/purchase | PASS | ...
-KMP FireOS            | n/a           | flavor check | BLOCKED | not wired
-KMP Horizon           | n/a           | flavor check | BLOCKED | not wired
+KMP FireOS            | {serial}      | build/install/purchase | PASS | ...
+KMP Horizon           | local Gradle  | build        | PASS   | build-only
 KMP iOS               | {UDID}        | build/install/purchase | PASS | ...
 MAUI Android          | {serial}      | build/run/purchase | PASS | ...
-MAUI FireOS           | n/a           | flavor check | BLOCKED | not wired
-MAUI Horizon          | n/a           | flavor check | BLOCKED | not wired
+MAUI FireOS           | {serial}      | build/run/purchase | PASS | ...
+MAUI Horizon          | local dotnet  | build        | PASS   | build-only
 MAUI iOS              | {UDID}        | build/run/purchase | PASS | ...
 Godot Android         | {serial}      | build/install/purchase | PASS | ...
 Godot iOS             | {UDID}        | build/install/purchase | PASS | ...

--- a/.claude/commands/e2e-tests.md
+++ b/.claude/commands/e2e-tests.md
@@ -559,7 +559,7 @@ cd packages/google
   :openiap:assemblePlayRelease \
   :openiap:assembleAmazonRelease \
   :openiap:assembleHorizonRelease
-cd ../../..
+cd ../..
 bash packages/apple/scripts/build-xcframework.sh
 cd libraries/maui-iap
 dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net9.0 --nologo

--- a/.codex/skills/openiap-workflows/SKILL.md
+++ b/.codex/skills/openiap-workflows/SKILL.md
@@ -86,6 +86,10 @@ appropriate labels before merging.
   web/docs/dashboard previews when applicable.
 - Keep commits in Angular Conventional Commits format:
   `<type>(<scope>): <subject>`.
+- When creating branches for commit/push/PR workflows, follow
+  `.claude/commands/commit.md`: use meaningful semantic prefixes such as
+  `feat/`, `fix/`, `ci/`, `docs/`, `test/`, `chore/`, or `refactor/`. Do not
+  use generic agent/tool prefixes such as `codex/`.
 
 ## GitHub Review Threads
 

--- a/.github/workflows/ci-kmp-iap.yml
+++ b/.github/workflows/ci-kmp-iap.yml
@@ -4,11 +4,17 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'libraries/kmp-iap/**'
+      - "libraries/kmp-iap/**"
+      - "packages/google/**"
+      - "openiap-versions.json"
+      - ".github/workflows/ci-kmp-iap.yml"
   push:
     branches: [main]
     paths:
-      - 'libraries/kmp-iap/**'
+      - "libraries/kmp-iap/**"
+      - "packages/google/**"
+      - "openiap-versions.json"
+      - ".github/workflows/ci-kmp-iap.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,8 +36,8 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
 
       - uses: gradle/gradle-build-action@v3
         with:
@@ -43,4 +49,7 @@ jobs:
           ./gradlew \
             :library:compilePlayDebugKotlinAndroid \
             :library:compileHorizonDebugKotlinAndroid \
-            :library:compileAmazonDebugKotlinAndroid
+            :library:compileAmazonDebugKotlinAndroid \
+            :example:composeApp:assemblePlayDebug \
+            :example:composeApp:assembleHorizonDebug \
+            :example:composeApp:assembleAmazonDebug

--- a/.github/workflows/ci-maui-iap.yml
+++ b/.github/workflows/ci-maui-iap.yml
@@ -4,31 +4,25 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'libraries/maui-iap/**'
-      - 'packages/gql/**'
-      - 'packages/google/openiap/**'
-      - 'packages/google/build.gradle.kts'
-      - 'packages/google/settings.gradle.kts'
-      - 'packages/google/gradle.properties'
-      - 'packages/apple/Sources/OpenIapModule+ObjC.swift'
-      - 'packages/apple/wrapper/**'
-      - 'packages/apple/scripts/build-xcframework.sh'
-      - 'openiap-versions.json'
-      - '.github/workflows/ci-maui-iap.yml'
+      - "libraries/maui-iap/**"
+      - "packages/gql/**"
+      - "packages/google/**"
+      - "packages/apple/Sources/OpenIapModule+ObjC.swift"
+      - "packages/apple/wrapper/**"
+      - "packages/apple/scripts/build-xcframework.sh"
+      - "openiap-versions.json"
+      - ".github/workflows/ci-maui-iap.yml"
   push:
     branches: [main]
     paths:
-      - 'libraries/maui-iap/**'
-      - 'packages/gql/**'
-      - 'packages/google/openiap/**'
-      - 'packages/google/build.gradle.kts'
-      - 'packages/google/settings.gradle.kts'
-      - 'packages/google/gradle.properties'
-      - 'packages/apple/Sources/OpenIapModule+ObjC.swift'
-      - 'packages/apple/wrapper/**'
-      - 'packages/apple/scripts/build-xcframework.sh'
-      - 'openiap-versions.json'
-      - '.github/workflows/ci-maui-iap.yml'
+      - "libraries/maui-iap/**"
+      - "packages/gql/**"
+      - "packages/google/**"
+      - "packages/apple/Sources/OpenIapModule+ObjC.swift"
+      - "packages/apple/wrapper/**"
+      - "packages/apple/scripts/build-xcframework.sh"
+      - "openiap-versions.json"
+      - ".github/workflows/ci-maui-iap.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -86,8 +80,8 @@ jobs:
       - name: Setup JDK 17
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
 
       - name: Setup .NET 10 SDK
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
@@ -97,15 +91,18 @@ jobs:
       - name: Install MAUI workload
         run: dotnet workload install maui-android --skip-sign-check
 
-      # The Android binding consumes the Google Play AAR as an unbound runtime
-      # dependency, plus the MAUI-owned OpenIapMauiModule AAR as the bound facade.
-      - name: Build Play AAR (Google)
+      # The Android binding consumes the selected Google AAR as an unbound
+      # runtime dependency, plus the MAUI-owned OpenIapMauiModule AAR as the
+      # bound facade. Build all Google store artifacts up front, then rebuild
+      # the MAUI facade/binding/library for each store because the facade AAR
+      # output path is shared across store selections.
+      - name: Build Google AARs
         working-directory: packages/google
-        run: ./gradlew :openiap:assemblePlayRelease
-
-      - name: Build MAUI Android module AAR
-        working-directory: libraries/maui-iap/android
-        run: ../../../packages/google/gradlew :openiap:assembleRelease
+        run: |
+          ./gradlew \
+            :openiap:assemblePlayRelease \
+            :openiap:assembleAmazonRelease \
+            :openiap:assembleHorizonRelease
 
       # `-p:TargetFrameworks=net9.0-android` (PLURAL) is required for the
       # second build — the singular `-f net9.0-android` filters the inner
@@ -117,10 +114,27 @@ jobs:
       - name: Build Android binding + library
         working-directory: libraries/maui-iap
         run: |
-          dotnet build src/OpenIap.Maui.Bindings.Android/OpenIap.Maui.Bindings.Android.csproj -p:TargetFrameworks=net9.0-android --nologo
-          dotnet build src/OpenIap.Maui.Bindings.Android/OpenIap.Maui.Bindings.Android.csproj -p:TargetFrameworks=net10.0-android --nologo
-          dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net9.0-android --nologo
-          dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net10.0-android --nologo
+          DOTNET_BUILD_ARGS=(/m:1 /nr:false -p:UseSharedCompilation=false --nologo)
+          dotnet build-server shutdown || true
+          rm -rf \
+            src/OpenIap.Maui.Bindings.Android/bin \
+            src/OpenIap.Maui.Bindings.Android/obj
+          (cd android && ../../../packages/google/gradlew :openiap:assembleRelease -PopenIapAndroidStore=play)
+          dotnet build src/OpenIap.Maui.Bindings.Android/OpenIap.Maui.Bindings.Android.csproj -p:TargetFrameworks=net9.0-android -p:OpenIapAndroidStore=play "${DOTNET_BUILD_ARGS[@]}"
+          dotnet build src/OpenIap.Maui.Bindings.Android/OpenIap.Maui.Bindings.Android.csproj -p:TargetFrameworks=net10.0-android -p:OpenIapAndroidStore=play "${DOTNET_BUILD_ARGS[@]}"
+          dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net9.0-android -p:OpenIapAndroidStore=play -p:BuildProjectReferences=false "${DOTNET_BUILD_ARGS[@]}"
+          dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net10.0-android -p:OpenIapAndroidStore=play -p:BuildProjectReferences=false "${DOTNET_BUILD_ARGS[@]}"
+
+          for store in amazon horizon; do
+            printf '\n== Building MAUI Android store: %s (net9.0) ==\n' "$store"
+            dotnet build-server shutdown || true
+            rm -rf \
+              src/OpenIap.Maui.Bindings.Android/bin \
+              src/OpenIap.Maui.Bindings.Android/obj
+            (cd android && ../../../packages/google/gradlew :openiap:assembleRelease -PopenIapAndroidStore="$store")
+            dotnet build src/OpenIap.Maui.Bindings.Android/OpenIap.Maui.Bindings.Android.csproj -p:TargetFrameworks=net9.0-android -p:OpenIapAndroidStore="$store" "${DOTNET_BUILD_ARGS[@]}"
+            dotnet build src/OpenIap.Maui/OpenIap.Maui.csproj -p:TargetFrameworks=net9.0-android -p:OpenIapAndroidStore="$store" -p:BuildProjectReferences=false "${DOTNET_BUILD_ARGS[@]}"
+          done
 
   ios-binding:
     name: iOS binding (net9.0/net10.0 ios + maccatalyst)

--- a/.github/workflows/ci-maui-iap.yml
+++ b/.github/workflows/ci-maui-iap.yml
@@ -72,6 +72,8 @@ jobs:
     name: Android binding (net9.0-android + net10.0-android)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:

--- a/README.md
+++ b/README.md
@@ -30,14 +30,39 @@ This monorepo contains all OpenIAP packages:
 
 Framework SDK implementations built on top of OpenIAP. These libraries are managed in this monorepo — see [discussion #86](https://github.com/hyodotdev/openiap/discussions/86) for the rationale and migration context.
 
-| Library                                                    | Platform             | Package                                                                                                                                                                        | Downloads                                                                                                                                               |
-| ---------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [expo-iap](libraries/expo-iap)                             | Expo                 | [![npm](https://img.shields.io/npm/v/expo-iap?logo=npm&color=CB3837)](https://www.npmjs.com/package/expo-iap)                                                                  | [![npm downloads](https://img.shields.io/npm/dm/expo-iap?label=npm&color=CB3837)](https://www.npmjs.com/package/expo-iap)                               |
-| [react-native-iap](libraries/react-native-iap)             | React Native         | [![npm](https://img.shields.io/npm/v/react-native-iap?logo=npm&color=CB3837)](https://www.npmjs.com/package/react-native-iap)                                                  | [![npm downloads](https://img.shields.io/npm/dm/react-native-iap?label=npm&color=CB3837)](https://www.npmjs.com/package/react-native-iap)               |
-| [flutter_inapp_purchase](libraries/flutter_inapp_purchase) | Flutter              | [![pub.dev](https://img.shields.io/pub/v/flutter_inapp_purchase?logo=dart&color=0175C2)](https://pub.dev/packages/flutter_inapp_purchase)                                      | [![pub.dev likes](https://img.shields.io/pub/likes/flutter_inapp_purchase?label=likes&color=0175C2)](https://pub.dev/packages/flutter_inapp_purchase)   |
-| [kmp-iap](libraries/kmp-iap)                               | Kotlin Multiplatform | [![Maven Central](https://img.shields.io/maven-central/v/io.github.hyochan/kmp-iap?logo=kotlin&color=7F52FF)](https://central.sonatype.com/artifact/io.github.hyochan/kmp-iap) | —                                                                                                                                                       |
-| [maui-iap](libraries/maui-iap)                             | .NET MAUI            | [![NuGet](https://img.shields.io/nuget/v/OpenIap.Maui?logo=nuget&color=004880)](https://www.nuget.org/packages/OpenIap.Maui)                                                   | [![NuGet downloads](https://img.shields.io/nuget/dt/OpenIap.Maui?label=downloads&logo=nuget&color=004880)](https://www.nuget.org/packages/OpenIap.Maui) |
-| [godot-iap](libraries/godot-iap)                           | Godot 4.x            | [![Godot Asset Library](https://img.shields.io/badge/asset_library-godot--iap-478CBF?logo=godotengine)](https://godotengine.org/asset-library/asset/4627)                      | —                                                                                                                                                       |
+| Library                                                    | Platform             | Package                                                                                                      | Downloads                                                |
+| ---------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| [expo-iap](libraries/expo-iap)                             | Expo                 | [![expo stable][expo-stable-badge]][expo-npm]<br>[![expo next][expo-next-badge]][expo-npm]                   | [![npm downloads][expo-downloads-badge]][expo-npm]       |
+| [react-native-iap](libraries/react-native-iap)             | React Native         | [![rn stable][rn-stable-badge]][rn-npm]<br>[![rn next][rn-next-badge]][rn-npm]                               | [![npm downloads][rn-downloads-badge]][rn-npm]           |
+| [flutter_inapp_purchase](libraries/flutter_inapp_purchase) | Flutter              | [![flutter stable][flutter-stable-badge]][flutter-pub]<br>[![flutter next][flutter-next-badge]][flutter-pub] | [![pub.dev likes][flutter-likes-badge]][flutter-pub]     |
+| [kmp-iap](libraries/kmp-iap)                               | Kotlin Multiplatform | [![kmp stable][kmp-stable-badge]][kmp-maven]<br>[![kmp next][kmp-next-badge]][kmp-maven]                     | —                                                        |
+| [maui-iap](libraries/maui-iap)                             | .NET MAUI            | [![maui stable][maui-stable-badge]][maui-nuget]<br>[![maui next][maui-next-badge]][maui-nuget]               | [![NuGet downloads][maui-downloads-badge]][maui-nuget]   |
+| [godot-iap](libraries/godot-iap)                           | Godot 4.x            | [![godot stable][godot-stable-badge]][godot-releases]<br>[![godot next][godot-next-badge]][godot-releases]   | [![Godot Asset Library][godot-asset-badge]][godot-asset] |
+
+[expo-stable-badge]: https://img.shields.io/npm/v/expo-iap/latest?label=stable&logo=npm&color=CB3837
+[expo-next-badge]: https://img.shields.io/npm/v/expo-iap/next?label=next&logo=npm&color=CB3837
+[expo-downloads-badge]: https://img.shields.io/npm/dm/expo-iap?label=npm&color=CB3837
+[expo-npm]: https://www.npmjs.com/package/expo-iap
+[rn-stable-badge]: https://img.shields.io/npm/v/react-native-iap/latest?label=stable&logo=npm&color=CB3837
+[rn-next-badge]: https://img.shields.io/npm/v/react-native-iap/next?label=next&logo=npm&color=CB3837
+[rn-downloads-badge]: https://img.shields.io/npm/dm/react-native-iap?label=npm&color=CB3837
+[rn-npm]: https://www.npmjs.com/package/react-native-iap
+[flutter-stable-badge]: https://img.shields.io/pub/v/flutter_inapp_purchase?label=stable&logo=dart&color=0175C2
+[flutter-next-badge]: https://img.shields.io/pub/v/flutter_inapp_purchase?include_prereleases&label=next&logo=dart&color=0175C2
+[flutter-likes-badge]: https://img.shields.io/pub/likes/flutter_inapp_purchase?label=likes&color=0175C2
+[flutter-pub]: https://pub.dev/packages/flutter_inapp_purchase
+[kmp-stable-badge]: https://img.shields.io/badge/dynamic/xml?label=stable&query=/metadata/versioning/versions/version%5Bnot(contains(.,%22-%22))%5D%5Blast()%5D&url=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fio%2Fgithub%2Fhyochan%2Fkmp-iap%2Fmaven-metadata.xml&prefix=v&logo=kotlin&color=7F52FF
+[kmp-next-badge]: https://img.shields.io/badge/dynamic/xml?label=next&query=/metadata/versioning/latest&url=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fio%2Fgithub%2Fhyochan%2Fkmp-iap%2Fmaven-metadata.xml&prefix=v&logo=kotlin&color=7F52FF
+[kmp-maven]: https://central.sonatype.com/artifact/io.github.hyochan/kmp-iap
+[maui-stable-badge]: https://img.shields.io/nuget/v/OpenIap.Maui?label=stable&logo=nuget&color=004880
+[maui-next-badge]: https://img.shields.io/nuget/vpre/OpenIap.Maui?label=next&logo=nuget&color=004880
+[maui-downloads-badge]: https://img.shields.io/nuget/dt/OpenIap.Maui?label=downloads&logo=nuget&color=004880
+[maui-nuget]: https://www.nuget.org/packages/OpenIap.Maui
+[godot-stable-badge]: https://img.shields.io/github/v/release/hyodotdev/openiap?filter=godot-iap-*&display_name=tag&label=stable&logo=godot-engine&color=478CBF
+[godot-next-badge]: https://img.shields.io/github/v/release/hyodotdev/openiap?include_prereleases&filter=godot-iap-*&display_name=tag&label=next&logo=godot-engine&color=478CBF
+[godot-releases]: https://github.com/hyodotdev/openiap/releases?q=godot-iap&expanded=true
+[godot-asset-badge]: https://img.shields.io/badge/asset_library-godot--iap-478CBF?logo=godotengine
+[godot-asset]: https://godotengine.org/asset-library/asset/4627
 
 ## Documentation
 

--- a/scripts/e2e-web-sites.mjs
+++ b/scripts/e2e-web-sites.mjs
@@ -74,6 +74,41 @@ const PERFORMANCE_BUDGETS = {
   longTaskMs: Number(process.env.WEB_E2E_LONG_TASK_BUDGET_MS ?? 1_000),
 };
 
+function readPositiveIntegerEnv(name, fallback) {
+  const rawValue = process.env[name];
+  if (rawValue === undefined || rawValue === "") {
+    return fallback;
+  }
+
+  const parsedValue = Number(rawValue);
+  if (!Number.isFinite(parsedValue)) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.floor(parsedValue));
+}
+
+const PERFORMANCE_ATTEMPTS = readPositiveIntegerEnv(
+  "WEB_E2E_PERFORMANCE_ATTEMPTS",
+  2,
+);
+const RETRYABLE_PERFORMANCE_PREFIXES = [
+  "domContentLoaded ",
+  "load ",
+  "long tasks ",
+];
+
+class PerformanceBudgetError extends Error {
+  constructor(siteName, route, errors, metrics) {
+    super(
+      `${siteName} ${route} performance failure:\n${summarizeErrors(errors)}`,
+    );
+    this.name = "PerformanceBudgetError";
+    this.errors = errors;
+    this.metrics = metrics;
+  }
+}
+
 function normalizeBaseUrl(value) {
   return value.replace(/\/+$/, "");
 }
@@ -366,8 +401,8 @@ async function checkSeo(page, site, route) {
   return warnings;
 }
 
-async function checkPerformance(page, siteName, route) {
-  const metrics = await page.evaluate(() => {
+async function collectPerformanceMetrics(page) {
+  return page.evaluate(() => {
     const navigation = performance.getEntriesByType("navigation")[0];
     const resources = performance.getEntriesByType("resource");
     const totalTransferBytes = resources.reduce(
@@ -391,7 +426,9 @@ async function checkPerformance(page, siteName, route) {
       longTaskMs: Math.round(longTaskMs),
     };
   });
+}
 
+function getPerformanceErrors(metrics) {
   const errors = [];
   if (metrics.domContentLoadedMs > PERFORMANCE_BUDGETS.domContentLoadedMs) {
     errors.push(
@@ -417,13 +454,69 @@ async function checkPerformance(page, siteName, route) {
     );
   }
 
+  return errors;
+}
+
+function isRetryablePerformanceError(error) {
+  return (
+    error instanceof PerformanceBudgetError &&
+    error.errors.every((message) =>
+      RETRYABLE_PERFORMANCE_PREFIXES.some((prefix) =>
+        message.startsWith(prefix),
+      ),
+    )
+  );
+}
+
+async function checkPerformance(page, siteName, route) {
+  const metrics = await collectPerformanceMetrics(page);
+  const errors = getPerformanceErrors(metrics);
+
   if (errors.length > 0) {
-    throw new Error(
-      `${siteName} ${route} performance failure:\n${summarizeErrors(errors)}`,
-    );
+    throw new PerformanceBudgetError(siteName, route, errors, metrics);
   }
 
   return metrics;
+}
+
+async function clearBrowserCache(page) {
+  const session = await page.context().newCDPSession(page);
+  try {
+    await session.send("Network.clearBrowserCache");
+  } finally {
+    await session.detach();
+  }
+}
+
+async function checkPerformanceWithRetry(page, siteName, route) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= PERFORMANCE_ATTEMPTS; attempt += 1) {
+    if (attempt > 1) {
+      await clearBrowserCache(page);
+      await page.reload({
+        waitUntil: "domcontentloaded",
+        timeout: DEFAULT_TIMEOUT_MS,
+      });
+      await waitForAppReady(page);
+      await page.waitForLoadState("load", { timeout: DEFAULT_TIMEOUT_MS });
+    }
+
+    try {
+      const metrics = await checkPerformance(page, siteName, route);
+      return { metrics, attempts: attempt };
+    } catch (error) {
+      lastError = error;
+      if (
+        !isRetryablePerformanceError(error) ||
+        attempt === PERFORMANCE_ATTEMPTS
+      ) {
+        throw error;
+      }
+    }
+  }
+
+  throw lastError;
 }
 
 async function checkImages(page, siteName, route) {
@@ -536,10 +629,16 @@ async function checkSite(browser, request, site) {
         }
 
         if (viewport.name === "desktop") {
-          const metrics = await checkPerformance(page, site.name, route);
+          const { metrics, attempts } = await checkPerformanceWithRetry(
+            page,
+            site.name,
+            route,
+          );
           const linkCount = await checkInternalLinks(page, site);
+          const retryLabel =
+            attempts > 1 ? ` after ${attempts} performance attempts` : "";
           summaries.push(
-            `${site.name} ${route} desktop ok (${metrics.loadMs}ms load, ${linkCount} links)`,
+            `${site.name} ${route} desktop ok (${metrics.loadMs}ms load, ${linkCount} links${retryLabel})`,
           );
         }
 

--- a/scripts/e2e-web-sites.mjs
+++ b/scripts/e2e-web-sites.mjs
@@ -488,10 +488,11 @@ async function clearBrowserCache(page) {
   }
 }
 
-async function checkPerformanceWithRetry(page, siteName, route) {
+async function checkPerformanceWithRetry(page, siteName, route, pageErrors) {
   for (let attempt = 1; attempt <= PERFORMANCE_ATTEMPTS; attempt += 1) {
     if (attempt > 1) {
       await clearBrowserCache(page);
+      pageErrors.length = 0;
       await page.reload({
         waitUntil: "domcontentloaded",
         timeout: DEFAULT_TIMEOUT_MS,
@@ -628,6 +629,7 @@ async function checkSite(browser, request, site) {
             page,
             site.name,
             route,
+            pageErrors,
           );
           const linkCount = await checkInternalLinks(page, site);
           const retryLabel =

--- a/scripts/e2e-web-sites.mjs
+++ b/scripts/e2e-web-sites.mjs
@@ -489,8 +489,6 @@ async function clearBrowserCache(page) {
 }
 
 async function checkPerformanceWithRetry(page, siteName, route) {
-  let lastError;
-
   for (let attempt = 1; attempt <= PERFORMANCE_ATTEMPTS; attempt += 1) {
     if (attempt > 1) {
       await clearBrowserCache(page);
@@ -506,7 +504,6 @@ async function checkPerformanceWithRetry(page, siteName, route) {
       const metrics = await checkPerformance(page, siteName, route);
       return { metrics, attempts: attempt };
     } catch (error) {
-      lastError = error;
       if (
         !isRetryablePerformanceError(error) ||
         attempt === PERFORMANCE_ATTEMPTS
@@ -515,8 +512,6 @@ async function checkPerformanceWithRetry(page, siteName, route) {
       }
     }
   }
-
-  throw lastError;
 }
 
 async function checkImages(page, siteName, route) {

--- a/scripts/e2e-web-sites.mjs
+++ b/scripts/e2e-web-sites.mjs
@@ -507,6 +507,7 @@ async function checkPerformanceWithRetry(page, siteName, route, pageErrors) {
     } catch (error) {
       if (
         !isRetryablePerformanceError(error) ||
+        pageErrors.length > 0 ||
         attempt === PERFORMANCE_ATTEMPTS
       ) {
         throw error;


### PR DESCRIPTION
## Summary

- Retry timing-only web performance flakes while preserving byte-budget failures.
- Replace stale KMP/MAUI FireOS/Horizon e2e blocked rows with real store-specific build commands.
- Expand KMP/MAUI CI coverage for store flavor builds and Google package changes.
- Clarify commit workflow branch naming to use semantic prefixes instead of agent/tool prefixes.

## Test plan

- [x] `node --check scripts/e2e-web-sites.mjs`
- [x] `bunx prettier --check scripts/e2e-web-sites.mjs .claude/commands/e2e-tests.md .github/workflows/ci-kmp-iap.yml .github/workflows/ci-maui-iap.yml`
- [x] `actionlint .github/workflows/ci-kmp-iap.yml .github/workflows/ci-maui-iap.yml`
- [x] `./gradlew :library:compilePlayDebugKotlinAndroid :library:compileHorizonDebugKotlinAndroid :library:compileAmazonDebugKotlinAndroid :example:composeApp:assemblePlayDebug :example:composeApp:assembleHorizonDebug :example:composeApp:assembleAmazonDebug` from `libraries/kmp-iap`
- [x] CI-equivalent docs/kit build + preview/server + `bun run e2e:web`
- [x] SDK parity audit via pre-commit

## Preview

No recording attached: this changes CI/e2e workflow behavior and agent test instructions, with no user-facing visual surface. Terminal and CI-equivalent proof is listed above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded end-to-end regression guidance to cover FireOS/Amazon and Horizon builds for both KMP and MAUI.
  * Added more store-specific build and install steps for Android checks.
  * Introduced retry handling for performance checks, with clearer success reporting when extra attempts are needed.

* **Bug Fixes**
  * Updated regression status so previously blocked FireOS/Horizon paths now show the correct build-only or build + device-flow expectations.
  * Improved CI coverage to react to a broader set of relevant changes and build more app variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #176

