### PR TITLE
fix(kit): clarify ios subscription identity

### DIFF
--- a/packages/kit/convex/subscriptions/query.test.ts
+++ b/packages/kit/convex/subscriptions/query.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from "vitest";
+import type { Doc, Id } from "../_generated/dataModel";
 
-import { selectReportingMrr } from "./query";
+import { selectReportingMrr, shapeSubscriptionRow } from "./query";
+
+function subscriptionDoc(
+  overrides: Partial<Doc<"subscriptions">>,
+): Doc<"subscriptions"> {
+  return {
+    _id: "subscriptions_1" as Id<"subscriptions">,
+    _creationTime: 0,
+    projectId: "projects_1" as Id<"projects">,
+    purchaseToken: "purchase_token_1",
+    productId: "premium_monthly",
+    platform: "IOS",
+    state: "Active",
+    startedAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  };
+}
 
 describe("selectReportingMrr", () => {
   it("uses only the reporting currency for the headline MRR", () => {
@@ -56,5 +74,31 @@ describe("selectReportingMrr", () => {
       mrrMicros: 9_990_000,
       excludedMrrByCurrency: [{ currency: "EUR", mrrMicros: 8_500_000 }],
     });
+  });
+});
+
+describe("shapeSubscriptionRow", () => {
+  it("exposes originalTransactionId for iOS subscription rows", () => {
+    const row = shapeSubscriptionRow(
+      subscriptionDoc({
+        platform: "IOS",
+        purchaseToken: "2000001177054625",
+      }),
+    );
+
+    expect(row.purchaseToken).toBe("2000001177054625");
+    expect(row.originalTransactionId).toBe("2000001177054625");
+  });
+
+  it("keeps Android rows on the Play purchaseToken only", () => {
+    const row = shapeSubscriptionRow(
+      subscriptionDoc({
+        platform: "Android",
+        purchaseToken: "play-token-1",
+      }),
+    );
+
+    expect(row.purchaseToken).toBe("play-token-1");
+    expect(row.originalTransactionId).toBeUndefined();
   });
 });

--- a/packages/kit/convex/subscriptions/query.ts
+++ b/packages/kit/convex/subscriptions/query.ts
@@ -1,5 +1,5 @@
 import { query, type QueryCtx } from "../_generated/server";
-import { v } from "convex/values";
+import { v, type Infer } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
 
 import {
@@ -38,8 +38,10 @@ const subscriptionShape = v.object({
   startedAt: v.number(),
   updatedAt: v.number(),
   purchaseToken: v.string(),
+  originalTransactionId: v.optional(v.string()),
   userId: v.optional(v.string()),
 });
+type SubscriptionRow = Infer<typeof subscriptionShape>;
 
 function isActive(sub: Doc<"subscriptions">, now: number): boolean {
   const entitled = sub.state === "Active" || sub.state === "InGracePeriod";
@@ -48,8 +50,10 @@ function isActive(sub: Doc<"subscriptions">, now: number): boolean {
   return true;
 }
 
-function shapeRow(sub: Doc<"subscriptions">) {
-  return {
+export function shapeSubscriptionRow(
+  sub: Doc<"subscriptions">,
+): SubscriptionRow {
+  const row: SubscriptionRow = {
     id: sub._id,
     productId: sub.productId,
     platform: sub.platform,
@@ -65,6 +69,15 @@ function shapeRow(sub: Doc<"subscriptions">) {
     purchaseToken: sub.purchaseToken,
     userId: sub.userId,
   };
+
+  if (sub.platform === "IOS") {
+    return {
+      ...row,
+      originalTransactionId: sub.purchaseToken,
+    };
+  }
+
+  return row;
 }
 
 async function projectByApiKey(
@@ -173,7 +186,7 @@ export const subscriptionStatus = query({
 
     return {
       active: activeSubs.length > 0,
-      subscription: shapeRow(sub),
+      subscription: shapeSubscriptionRow(sub),
     };
   },
 });
@@ -207,7 +220,7 @@ export const entitlements = query({
     return {
       userId: args.userId,
       productIds: Array.from(new Set(active.map((sub) => sub.productId))),
-      subscriptions: active.map(shapeRow),
+      subscriptions: active.map(shapeSubscriptionRow),
     };
   },
 });
@@ -255,7 +268,7 @@ export const listSubscriptions = query({
         return true;
       });
       return {
-        items: filtered.slice(0, limit).map(shapeRow),
+        items: filtered.slice(0, limit).map(shapeSubscriptionRow),
         total: filtered.length,
       };
     }
@@ -314,7 +327,10 @@ export const listSubscriptions = query({
     // we just put in. The dashboard treats `total` as "rows shown
     // matching the current filter" and surfaces "+ more" affordances
     // via the next page request.
-    return { items: rows.slice(0, limit).map(shapeRow), total: rows.length };
+    return {
+      items: rows.slice(0, limit).map(shapeSubscriptionRow),
+      total: rows.length,
+    };
   },
 });
 

--- a/packages/kit/src/pages/docs/sections/api.tsx
+++ b/packages/kit/src/pages/docs/sections/api.tsx
@@ -138,6 +138,30 @@ export default function ApiReferencePage() {
         <code>state: "INAUTHENTIC"</code> on mismatch.
       </p>
 
+      <h2 className="mt-10 text-2xl font-semibold">
+        Subscription identity fields
+      </h2>
+      <p>
+        Subscription state endpoints such as{" "}
+        <code>GET /v1/subscriptions/list/{"{apiKey}"}</code> keep the legacy{" "}
+        <code>purchaseToken</code> field for the stable store identity. On
+        Google this is the Play purchase token. On iOS this is the StoreKit{" "}
+        <code>originalTransactionId</code> (falling back to{" "}
+        <code>transactionId</code>), not the raw JWS. iOS rows also expose{" "}
+        <code>originalTransactionId</code> explicitly.
+      </p>
+      <CodeBlock title="iOS subscription row" language="json">
+        {`{
+  "platform": "IOS",
+  "purchaseToken": "2000001177054625",
+  "originalTransactionId": "2000001177054625"
+}`}
+      </CodeBlock>
+      <p>
+        Send the raw StoreKit JWS only to verification or user-binding endpoints
+        that explicitly ask for a JWS. Do not log or publish JWS values.
+      </p>
+
       <div className="my-4 overflow-hidden rounded-lg border border-border">
         <table className="w-full text-sm">
           <thead className="bg-muted/40">


### PR DESCRIPTION
## Summary

- add explicit `originalTransactionId` on iOS subscription rows while keeping `purchaseToken` backward-compatible
- document that subscription state endpoints return stable store identity, not raw StoreKit JWS
- cover iOS and Android subscription row shaping with tests

Refs #213

## Test plan

- [x] `bun audit:docs`
- [x] `bun run --filter @hyodotdev/openiap-kit lint`
- [x] `bun run --filter @hyodotdev/openiap-kit format:check`
- [x] `bun run --filter @hyodotdev/openiap-kit test`
- [x] `bun run --filter @hyodotdev/openiap-kit smoke:server`

## Preview

No separate recording attached: this is a narrow API response/docs clarification. `smoke:server` built the docs app and browser-probed the mounted page successfully.