### PR TITLE
fix: harden continuation resume guard

### DIFF
--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/helpers/ContinuationResumeGuard.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/helpers/ContinuationResumeGuard.kt
@@ -1,9 +1,8 @@
 package dev.hyo.openiap.helpers
 
 import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.InternalCoroutinesApi
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 /**
  * Atomically completes a cancellable continuation at most once.
@@ -26,16 +25,18 @@ internal class ContinuationResumeGuard<T>(
         }
     }
 
+    @OptIn(InternalCoroutinesApi::class)
     fun resume(value: T) {
-        if (didComplete.compareAndSet(false, true)) {
-            continuation.resume(value)
-        }
+        val token = continuation.tryResume(value, null) ?: return
+        didComplete.set(true)
+        continuation.completeResume(token)
     }
 
+    @OptIn(InternalCoroutinesApi::class)
     fun resumeWithException(error: Throwable) {
-        if (didComplete.compareAndSet(false, true)) {
-            continuation.resumeWithException(error)
-        }
+        val token = continuation.tryResumeWithException(error) ?: return
+        didComplete.set(true)
+        continuation.completeResume(token)
     }
 }
 

--- a/packages/google/openiap/src/test/java/dev/hyo/openiap/helpers/ContinuationResumeGuardTest.kt
+++ b/packages/google/openiap/src/test/java/dev/hyo/openiap/helpers/ContinuationResumeGuardTest.kt
@@ -1,0 +1,29 @@
+package dev.hyo.openiap.helpers
+
+import kotlin.coroutines.resume
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class ContinuationResumeGuardTest {
+    @Test
+    fun `resumeGuard ignores late completion after continuation already resumed`() = runTest {
+        var captured: CancellableContinuation<Unit>? = null
+        val deferred = async(start = CoroutineStart.UNDISPATCHED) {
+            suspendCancellableCoroutine<Unit> { continuation ->
+                captured = continuation
+            }
+        }
+        val continuation = checkNotNull(captured)
+        val guard = continuation.resumeGuard()
+
+        continuation.resume(Unit)
+        deferred.await()
+
+        guard.resumeWithException(IllegalStateException("late product query failure"))
+        guard.resume(Unit)
+    }
+}


### PR DESCRIPTION
## Summary
- use CancellableContinuation.tryResume/completeResume in ContinuationResumeGuard so late callbacks cannot throw Already resumed
- add a regression test for a late product-query failure after a continuation was already completed

## Verification
- env JAVA_HOME=/Users/arian/Library/Java/JavaVirtualMachines/jbr-17.0.14/Contents/Home ./gradlew :openiap:testPlayDebugUnitTest --tests dev.hyo.openiap.helpers.ContinuationResumeGuardTest --tests dev.hyo.openiap.QueryPurchasesRaceTest
- env JAVA_HOME=/Users/arian/Library/Java/JavaVirtualMachines/jbr-17.0.14/Contents/Home ./gradlew :openiap:compileHorizonDebugKotlin :openiap:compileAmazonDebugKotlin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coroutine completion handling so late or duplicate resume attempts are safely ignored.
  * Increased stability around asynchronous operations that may complete more than once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->