### PR TITLE
fix(expo-iap): don't rewrite applicationId/namespace to = assignment (breaks expo run:android)

### DIFF
--- a/libraries/expo-iap/plugin/__tests__/withIAP.test.ts
+++ b/libraries/expo-iap/plugin/__tests__/withIAP.test.ts
@@ -198,7 +198,14 @@ describe('android configuration', () => {
 
     expect(result).toContain('ndkVersion = rootProject.ext.ndkVersion');
     expect(result).toContain('compileSdk = rootProject.ext.compileSdkVersion');
-    expect(result).toContain("namespace = 'dev.hyo.openiap.expo.example'");
+    // namespace/applicationId stay in method-call form (see withIAP.ts): AGP
+    // accepts both, but @expo/config-plugins only parses the no-`=` form.
+    expect(result).toContain("namespace 'dev.hyo.openiap.expo.example'");
+    expect(result).not.toContain("namespace = 'dev.hyo.openiap.expo.example'");
+    expect(result).toContain("applicationId 'dev.hyo.openiap.expo.example'");
+    expect(result).not.toContain(
+      "applicationId = 'dev.hyo.openiap.expo.example'",
+    );
     expect(result).toContain('minSdk = rootProject.ext.minSdkVersion');
     expect(result).toContain('targetSdk = rootProject.ext.targetSdkVersion');
     expect(result).toContain('signingConfig = signingConfigs.debug');

--- a/libraries/expo-iap/plugin/src/withIAP.ts
+++ b/libraries/expo-iap/plugin/src/withIAP.ts
@@ -106,8 +106,11 @@ export const normalizeGeneratedGroovyAppBuildGradle = (
       /^(\s*)compileSdk\s+rootProject\.ext\.compileSdkVersion\s*$/gm,
       '$1compileSdk = rootProject.ext.compileSdkVersion',
     ],
-    [/^(\s*)namespace\s+(['"][^'"]+['"])\s*$/gm, '$1namespace = $2'],
-    [/^(\s*)applicationId\s+(['"][^'"]+['"])\s*$/gm, '$1applicationId = $2'],
+    // Note: `namespace` and `applicationId` are intentionally left in
+    // method-call form. AGP accepts both, but @expo/config-plugins parses them
+    // with regexes that only match the no-`=` form (getApplicationIdAsync and
+    // setPackageInBuildGradle), so converting them breaks `expo run:android`
+    // app-id resolution. See hyodotdev/openiap#228.
     [
       /^(\s*)minSdkVersion\s+rootProject\.ext\.minSdkVersion\s*$/gm,
       '$1minSdk = rootProject.ext.minSdkVersion',


### PR DESCRIPTION
## Problem

`expo run:android` fails with `NO_APP_ID` before launch on any Expo project using this plugin:

```
CommandError: Failed to locate the android application identifier in the "android/" folder. This is required to open the app.
```

## Cause

`normalizeGeneratedGroovyAppBuildGradle` (added in "feat(runtime): add fire os and vega support", first shipped in 4.4.0-rc.6 / 4.4.0) rewrites the Expo-generated `android/app/build.gradle` from Groovy method-call syntax to `=` assignment syntax. That is correct and necessary for Gradle 9 for most properties (`compileSdk`, `ndkVersion`, `signingConfig`, `url = uri(...)`, etc.), but it also converts `applicationId` and `namespace`, which do **not** need `=`.

Expo's `@expo/config-plugins` parses those two with regexes that only match the no-`=` form:

- `getApplicationIdAsync`: `/applicationId ['"](.*)['"]/` → returns `null` against `applicationId = '…'`, so `expo run:android` throws `NO_APP_ID` (via `resolveLaunchProps` → `getAppIdFromNativeAsync`).
- `setPackageInBuildGradle`: `(applicationId|namespace) ['"].*['"]` → the same blind spot silently breaks the package-rename mod for `namespace = '…'`.

AGP accepts both forms for these two, so leaving them in method-call form loses nothing. Evidence: Expo's own SDK 54–57 bare template ships `applicationId '…'` / `namespace '…'` and builds fine under Gradle 9.

## Fix

Drop just the `applicationId` and `namespace` entries from the normalizer's replacements array; every other Gradle-9 conversion is untouched. Updated the corresponding assertion in `withIAP.test.ts` to verify both stay in method-call form while the rest still convert.

Full plugin suite passes locally (`76 passed, 4 suites`).

Fixes #228
