### PR TITLE
chore(rn): bump react-native-nitro-modules to 0.36.1

### DIFF
--- a/libraries/react-native-iap/.yarn/patches/nitrogen-npm-0.36.1-abe3b64156.patch
+++ b/libraries/react-native-iap/.yarn/patches/nitrogen-npm-0.36.1-abe3b64156.patch
@@ -19,7 +19,7 @@ diff --git a/src/syntax/types/ArrayType.ts b/src/syntax/types/ArrayType.ts
 index 135076c24d8e1c1569cce64349203c22b5fce9b3..7077f6f3fb2fd6101dfc440cb28a42470308f500 100644
 --- a/src/syntax/types/ArrayType.ts
 +++ b/src/syntax/types/ArrayType.ts
-@@ -18,5 +18,9 @@ export class ArrayType implements Type {
+@@ -18,7 +18,11 @@ export class ArrayType implements Type {
      return 'array'
    }
    get isEquatable(): boolean {
@@ -30,3 +30,5 @@ index 135076c24d8e1c1569cce64349203c22b5fce9b3..7077f6f3fb2fd6101dfc440cb28a4247
 +    // non-equatable until the affected Swift toolchains are no longer supported.
 +    return false
    }
+ 
+   getCode(language: Language, options?: GetCodeOptions): string {

--- a/libraries/react-native-iap/example/package.json
+++ b/libraries/react-native-iap/example/package.json
@@ -21,7 +21,7 @@
     "react": "19.1.0",
     "react-native": "0.81.1",
     "react-native-dotenv": "^3.4.11",
-    "react-native-nitro-modules": "^0.35.10",
+    "react-native-nitro-modules": "^0.36.1",
     "react-native-safe-area-context": "^5.6.1",
     "react-native-screens": "^4.15.4"
   },

--- a/libraries/react-native-iap/package.json
+++ b/libraries/react-native-iap/package.json
@@ -105,12 +105,12 @@
     "husky": "^8.0.3",
     "jest": "^30.1.1",
     "lint-staged": "^15.2.0",
-    "nitrogen": "^0.35.10",
+    "nitrogen": "^0.36.1",
     "prettier": "^3.3.3",
     "react": "19.1.0",
     "react-native": "0.81.1",
     "react-native-builder-bob": "^0.38.4",
-    "react-native-nitro-modules": "^0.35.10",
+    "react-native-nitro-modules": "^0.36.1",
     "react-test-renderer": "^19.1.1",
     "typescript": "^5.9.2"
   },
@@ -119,7 +119,7 @@
     "@amazon-devices/package-manager-lib": "~1.0.1767254401",
     "react": "*",
     "react-native": "*",
-    "react-native-nitro-modules": "^0.35.10"
+    "react-native-nitro-modules": "^0.36.1"
   },
   "peerDependenciesMeta": {
     "@amazon-devices/keplerscript-appstore-iap-lib": {
@@ -176,6 +176,6 @@
   },
   "packageManager": "yarn@3.6.1",
   "resolutions": {
-    "nitrogen@^0.35.10": "patch:nitrogen@npm%3A0.35.10#./.yarn/patches/nitrogen-npm-0.35.10-ac6318648e.patch"
+    "nitrogen@^0.36.1": "patch:nitrogen@npm%3A0.36.1#./.yarn/patches/nitrogen-npm-0.36.1-abe3b64156.patch"
   }
 }

--- a/libraries/react-native-iap/src/specs/RnIap.nitro.ts
+++ b/libraries/react-native-iap/src/specs/RnIap.nitro.ts
@@ -17,6 +17,13 @@ import type {HybridObject} from 'react-native-nitro-modules';
 // ║    - Interface types from types.ts can be imported and used directly     ║
 // ║    - Union types with 2+ values can be imported from types.ts            ║
 // ║    - Single-value unions must be redefined locally with extra values     ║
+// ║                                                                          ║
+// ║ 3. WRITE `null` FIRST IN NULLABLE UNIONS OF BOOLEANS AND ENUM ARRAYS     ║
+// ║    - Use `null | boolean`, not `boolean | null` (same for enum arrays)   ║
+// ║    - Since nitrogen 0.36 variant operands keep source order when their   ║
+// ║      "looseness" ties (boolean/enum-array tie with null), so null-last   ║
+// ║      would rename generated types (Variant_NullType_Bool →               ║
+// ║      Variant_Bool_NullType) and break hand-written Swift/Kotlin          ║
 // ╚══════════════════════════════════════════════════════════════════════════╝
 
 // NOTE: This Nitro spec re-exports types from the generated schema (src/types.ts)
@@ -278,8 +285,8 @@ export interface NitroPurchaseRequest {
  * iOS-specific options for getting available purchases
  */
 export interface NitroAvailablePurchasesIosOptions extends PurchaseOptions {
-  alsoPublishToEventListener?: boolean | null;
-  onlyIncludeActiveItems?: boolean | null;
+  alsoPublishToEventListener?: null | boolean;
+  onlyIncludeActiveItems?: null | boolean;
 }
 
 type NitroAvailablePurchasesAndroidType = 'inapp' | 'subs';
@@ -292,7 +299,7 @@ export interface NitroAvailablePurchasesAndroidOptions {
    * Users should be directed to the subscription center to resolve payment issues.
    * Default: false (only active subscriptions are returned)
    */
-  includeSuspended?: boolean | null;
+  includeSuspended?: null | boolean;
 }
 
 export interface NitroAvailablePurchasesOptions {
@@ -358,7 +365,7 @@ export interface NitroBillingProgramInformationDialogParamsAndroid {
 }
 
 export interface NitroInAppMessageParamsAndroid {
-  categories?: InAppMessageCategoryAndroid[] | null;
+  categories?: null | InAppMessageCategoryAndroid[];
 }
 
 // ╔══════════════════════════════════════════════════════════════════════════╗
@@ -450,7 +457,7 @@ export interface NitroVerifyPurchaseWithIapkitAmazonProps {
   /** Amazon Appstore receipt id returned by PurchaseResponse.getReceipt().getReceiptId(). */
   receiptId: string;
   /** Use Amazon RVS Cloud Sandbox for App Tester receipts. */
-  sandbox?: boolean | null;
+  sandbox?: null | boolean;
   /** Amazon Appstore user id returned by PurchaseResponse.getUserData().getUserId(). */
   userId?: string | null;
 }
@@ -501,7 +508,7 @@ export interface NitroBillingProgramAvailabilityResultAndroid {
   /** Whether the billing program is available for the user */
   isAvailable: boolean;
   /** Whether external-link payment is available for Billing Choice. */
-  isExternalLinkAvailable?: boolean | null;
+  isExternalLinkAvailable?: null | boolean;
 }
 
 /**
@@ -610,7 +617,7 @@ export interface NitroPurchase {
   currencySymbolIOS?: string | null;
   environmentIOS?: string | null;
   expirationDateIOS?: number | null;
-  isUpgradedIOS?: boolean | null;
+  isUpgradedIOS?: null | boolean;
   offerIOS?: string | null;
   ownershipTypeIOS?: string | null;
   reasonIOS?: string | null;
@@ -626,14 +633,14 @@ export interface NitroPurchase {
   purchaseTokenAndroid?: string | null;
   dataAndroid?: string | null;
   signatureAndroid?: string | null;
-  autoRenewingAndroid?: boolean | null;
+  autoRenewingAndroid?: null | boolean;
   purchaseStateAndroid?: number | null;
-  isAcknowledgedAndroid?: boolean | null;
+  isAcknowledgedAndroid?: null | boolean;
   packageNameAndroid?: string | null;
   obfuscatedAccountIdAndroid?: string | null;
   obfuscatedProfileIdAndroid?: string | null;
   developerPayloadAndroid?: string | null;
-  isSuspendedAndroid?: boolean | null;
+  isSuspendedAndroid?: null | boolean;
   pendingPurchaseUpdateAndroid?: PendingPurchaseUpdateAndroid | null;
 }
 
@@ -670,7 +677,7 @@ export interface NitroRenewalInfoIOS {
   pendingUpgradeProductId?: string | null;
   renewalDate?: number | null;
   expirationReason?: string | null;
-  isInBillingRetry?: boolean | null;
+  isInBillingRetry?: null | boolean;
   gracePeriodExpirationDate?: number | null;
   priceIncreaseStatus?: string | null;
   renewalBillingPlanType?: SubscriptionBillingPlanTypeIOS | null;
@@ -692,7 +699,7 @@ export interface NitroProduct {
   platform: IapPlatform;
   // iOS specific fields
   typeIOS?: string | null;
-  isFamilyShareableIOS?: boolean | null;
+  isFamilyShareableIOS?: null | boolean;
   jsonRepresentationIOS?: string | null;
   pricingTermsIOS?: string | null;
   subscriptionInfoIOS?: string | null;

--- a/libraries/react-native-iap/yarn.lock
+++ b/libraries/react-native-iap/yarn.lock
@@ -11234,33 +11234,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nitrogen@npm:0.35.10":
-  version: 0.35.10
-  resolution: "nitrogen@npm:0.35.10"
+"nitrogen@npm:0.36.1":
+  version: 0.36.1
+  resolution: "nitrogen@npm:0.36.1"
   dependencies:
     chalk: ^5.3.0
-    react-native-nitro-modules: ^0.35.10
+    react-native-nitro-modules: ^0.36.1
     ts-morph: ^28.0.0
     yargs: ^18.0.0
     zod: ^4.4.3
   bin:
     nitrogen: lib/index.js
-  checksum: 5082980782a3242708581eb51ace0c321ff67e6036fdffb53b246154171373fc844f981a772acf6c52d08ea2f8fc330390492e7013c2bda0f9c448cc76c5f1b5
+  checksum: d59f1004bfc4a31d26a2011307f5bdd1cc1f5f1ee2dbdbb07e3d7a1f184f48e032b723b6064ff84c182432491855ef894cc7c1298735b80a975f18ca28d6392a
   languageName: node
   linkType: hard
 
-"nitrogen@patch:nitrogen@npm%3A0.35.10#./.yarn/patches/nitrogen-npm-0.35.10-ac6318648e.patch::locator=react-native-iap%40workspace%3A.":
-  version: 0.35.10
-  resolution: "nitrogen@patch:nitrogen@npm%3A0.35.10#./.yarn/patches/nitrogen-npm-0.35.10-ac6318648e.patch::version=0.35.10&hash=1be88b&locator=react-native-iap%40workspace%3A."
+"nitrogen@patch:nitrogen@npm%3A0.36.1#./.yarn/patches/nitrogen-npm-0.36.1-abe3b64156.patch::locator=react-native-iap%40workspace%3A.":
+  version: 0.36.1
+  resolution: "nitrogen@patch:nitrogen@npm%3A0.36.1#./.yarn/patches/nitrogen-npm-0.36.1-abe3b64156.patch::version=0.36.1&hash=e67457&locator=react-native-iap%40workspace%3A."
   dependencies:
     chalk: ^5.3.0
-    react-native-nitro-modules: ^0.35.10
+    react-native-nitro-modules: ^0.36.1
     ts-morph: ^28.0.0
     yargs: ^18.0.0
     zod: ^4.4.3
   bin:
     nitrogen: lib/index.js
-  checksum: bb0f4c202c701092f7587bc72ec3ab5a64f3d974e3b7f60737c3f58f7362116cae21d86a2d2c025ec9696c86764946fd7a7d04d98c28c59dcf12944e1cf27779
+  checksum: 1e0453ff5a9bd17c781d6f9b3d1789ba77c694ce426081c10fae9c29f7d4fbd71b9ff6f2b643277613bc646e5cb8ecac894e0a21585e0cc1aa970949fc26c861
   languageName: node
   linkType: hard
 
@@ -12315,12 +12315,12 @@ __metadata:
     husky: ^8.0.3
     jest: ^30.1.1
     lint-staged: ^15.2.0
-    nitrogen: ^0.35.10
+    nitrogen: ^0.36.1
     prettier: ^3.3.3
     react: 19.1.0
     react-native: 0.81.1
     react-native-builder-bob: ^0.38.4
-    react-native-nitro-modules: ^0.35.10
+    react-native-nitro-modules: ^0.36.1
     react-test-renderer: ^19.1.1
     typescript: ^5.9.2
   peerDependencies:
@@ -12328,7 +12328,7 @@ __metadata:
     "@amazon-devices/package-manager-lib": ~1.0.1767254401
     react: "*"
     react-native: "*"
-    react-native-nitro-modules: ^0.35.10
+    react-native-nitro-modules: ^0.36.1
   peerDependenciesMeta:
     "@amazon-devices/keplerscript-appstore-iap-lib":
       optional: true
@@ -12357,13 +12357,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-nitro-modules@npm:^0.35.10":
-  version: 0.35.10
-  resolution: "react-native-nitro-modules@npm:0.35.10"
+"react-native-nitro-modules@npm:^0.36.1":
+  version: 0.36.1
+  resolution: "react-native-nitro-modules@npm:0.36.1"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 9a657b0503fa549d3d35e275f14872950c5f798367e8a983e5386760460d2bdbac4bd107ea78e67aec08eb03a8244e60f684faf7d252703bd4b1931bfac1890f
+  checksum: f22f81591a1f9bfe53f12616cc4f7abf124eade3f5282e7c79c0d13b8351322bdbe8bae472262945341ade03f5e3e9a9fde27d902363c7d7a3d927bcff96224a
   languageName: node
   linkType: hard
 
@@ -12855,7 +12855,7 @@ __metadata:
     react-native: 0.81.1
     react-native-dotenv: ^3.4.11
     react-native-monorepo-config: ^0.1.9
-    react-native-nitro-modules: ^0.35.10
+    react-native-nitro-modules: ^0.36.1
     react-native-safe-area-context: ^5.6.1
     react-native-screens: ^4.15.4
     react-test-renderer: 19.1.0


### PR DESCRIPTION
## Summary

- Upgrade `react-native-nitro-modules` / `nitrogen` from `^0.35.10` to `^0.36.1` in `libraries/react-native-iap`
- Re-create the nitrogen yarn patch (Swift `isEquatable` workaround for swiftlang/swift#67410) against 0.36.1 — unpatched 0.36.1 still reproduces the Swift/C++ interop failure on Xcode 26.6, so the workaround remains required ([Nitro #1376](https://github.com/mrousavy/nitro/issues/1376))
- Keep the generated Nitro bridge **byte-identical** to 0.35.10's output, so no hand-written Swift/Kotlin/C++ changes are needed

## Changes

### Dependencies (`package.json`, `example/package.json`, `yarn.lock`)

- `react-native-nitro-modules` and `nitrogen` → `^0.36.1` (devDependencies, peerDependencies, and the example app; `scripts/check-nitro-versions.ts` passes)
- Yarn `resolutions` now points at `.yarn/patches/nitrogen-npm-0.36.1-abe3b64156.patch` (same two-hunk `ArrayType.isEquatable → false` workaround, re-created with `yarn patch`/`yarn patch-commit` on 0.36.1)

### Nitro spec (`src/specs/RnIap.nitro.ts`)

- Nitrogen 0.36 resolves union constituents from source syntax and keeps operand order when the variant "looseness" ranking ties. `boolean` and enum-array operands tie with `null`, so the previous null-last declarations (`boolean | null`, `InAppMessageCategoryAndroid[] | null`) would rename the generated types (`Variant_NullType_Bool` → `Variant_Bool_NullType`, etc.) and swap their `.first`/`.second` cases — breaking the hand-written native code that references them (`ios/RnIapHelper.swift`, `android/.../HybridRnIap.kt`)
- Flipped those 12 declarations to null-first (`null | boolean`), which is semantically identical TypeScript and keeps every generated name and case position exactly as before; documented the constraint in the spec's constraints banner
- With this, `yarn nitrogen` output on 0.36.1 differs from 0.35.10 only in the generated version-header comments (verified with a full directory diff of `nitrogen/generated`, 648 files)

## Yarn patch maintenance and removal criteria

- This PR replaces the existing Nitrogen 0.35.10 patch with its 0.36.1 equivalent; it does not add a second patch. The RNIAP patch directory continues to contain exactly one patch file.
- The patch is retained because an unpatched Nitrogen 0.36.1 generation fails the iOS build on Xcode 26.6 with `std::vector<...> has no member map`, while the patched generation succeeds.
- Nitrogen currently has no per-struct or module-level opt-out for generated `operator==`; adding dummy non-equatable fields would instead pollute the generated bridge model. See [Nitro #1376](https://github.com/mrousavy/nitro/issues/1376).
- On every future Nitro upgrade, remove the patch first and rerun the supported iOS build matrix. Delete the patch as soon as the unpatched generator passes; do not carry it forward by default.

## Test plan

- [x] `yarn install --immutable` (lockfile in sync, as CI runs it)
- [x] `yarn lint:tsc` and `yarn typecheck` pass
- [x] `yarn lint --fix` produces no changes
- [x] `yarn test:ci` — 13 suites, 398 tests pass
- [x] `yarn workspace rn-iap-example test` — 9 suites, 115 passed / 3 skipped
- [x] `yarn verify:consumer-install` smoke test passes (runs full `prepare`: check-nitro-versions + bob + nitrogen)
- [x] `nitrogen/generated` diff vs 0.35.10 baseline: byte-identical except `Generated by Nitrogen x.y.z` headers
- [x] Upstream 0.35.11→0.36.1 changes reviewed (thread-safety fixes, union-style enum codegen); `react-native-nitro-modules` podspec/gradle platform requirements and peerDependencies unchanged between 0.35.10 and 0.36.1

## RNIAP-only E2E review

- [x] Google Play / Pixel `HT79F1A00473`: build, install, launch, fetch 3 in-app products + 2 subscriptions, open the test purchase sheet, cancel without approval (`user-cancelled`)
- [x] FireOS / `GN43T503515200BA`: build, reinstall the test app after a signing mismatch, launch, fetch 3 in-app products + 2 subscriptions, cancel in Amazon SDK Test Client (`user-cancelled`)
- [x] Horizon: build-only
- [x] VegaOS / `G0733M085512021G`: debug + release builds, install/launch, fetch 3 in-app products + 2 subscriptions, open tester purchase UI and return with Back without approval
- [x] iOS: pods + generic Simulator build (`BUILD SUCCEEDED`)
- [ ] Physical iOS/store flow: blocked because the connected iPhone remained locked and DDI services were unavailable
- [ ] Purchase success / finish / restore: intentionally not run; no purchase was approved

> Preview recording: not applicable — dependency bump with no visual or interactive surface. The terminal proof above (byte-identical codegen diff + full test suite) is the verification evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated Nitro tooling and modules to version 0.36.1 across the package and example project.
  * Improved compatibility for nullable boolean and array values in purchase, product, billing, and messaging data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->