### PR TITLE
fix(ci): make release changelog pathspecs cwd-independent

### DIFF
--- a/.github/workflows/release-apple.yml
+++ b/.github/workflows/release-apple.yml
@@ -360,7 +360,7 @@ jobs:
           CHANGELOG="- Initial release"
         else
           echo "Generating changelog from $PREV_TAG to $RELEASE_REF"
-          CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- packages/apple/)
+          CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- ":(top)packages/apple/")
 
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="- No direct code changes in packages/apple/."

--- a/.github/workflows/release-expo.yml
+++ b/.github/workflows/release-expo.yml
@@ -338,7 +338,7 @@ jobs:
           fi
           PREV_TAG=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' 'refs/tags/expo-iap-*' | grep -v "$VERSION" | head -n 1)
           if [ -n "$PREV_TAG" ]; then
-            CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- libraries/expo-iap/ packages/google/ packages/apple/)
+            CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- ":(top)libraries/expo-iap/" ":(top)packages/google/" ":(top)packages/apple/")
           fi
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="- No direct code changes — picks up the latest openiap-google / openiap-apple native library updates. See the consolidated release notes for details."

--- a/.github/workflows/release-flutter.yml
+++ b/.github/workflows/release-flutter.yml
@@ -288,7 +288,7 @@ jobs:
           done
 
           if [ -n "$PREV_TAG" ]; then
-            PR_LINES=$(git log "${PREV_TAG}..HEAD" --merges --pretty=format:"%s" -- libraries/flutter_inapp_purchase/ packages/google/ packages/apple/ | \
+            PR_LINES=$(git log "${PREV_TAG}..HEAD" --merges --pretty=format:"%s" -- ":(top)libraries/flutter_inapp_purchase/" ":(top)packages/google/" ":(top)packages/apple/" | \
               sed -n 's/^Merge pull request #\([0-9]*\) from .*/\1/p')
             for PR_NUM in $PR_LINES; do
               PR_TITLE=$(git log --all --grep="Merge pull request #${PR_NUM}" --pretty=format:"%s" | head -1 | sed "s|Merge pull request #${PR_NUM} from [^ ]* ||")
@@ -297,7 +297,7 @@ jobs:
               fi
             done
             if [ -z "$CHANGES" ]; then
-              LOG_LINES=$(git log "${PREV_TAG}..HEAD" --no-merges --pretty=format:"- %s" -- libraries/flutter_inapp_purchase/ packages/google/ packages/apple/ | head -20)
+              LOG_LINES=$(git log "${PREV_TAG}..HEAD" --no-merges --pretty=format:"- %s" -- ":(top)libraries/flutter_inapp_purchase/" ":(top)packages/google/" ":(top)packages/apple/" | head -20)
               if [ -n "$LOG_LINES" ]; then
                 CHANGES="${LOG_LINES}\n"
               fi
@@ -366,7 +366,7 @@ jobs:
           fi
           PREV_TAG=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' 'refs/tags/flutter-iap-*' | grep -v "$VERSION" | head -n 1)
           if [ -n "$PREV_TAG" ]; then
-            CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- libraries/flutter_inapp_purchase/ packages/google/ packages/apple/)
+            CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- ":(top)libraries/flutter_inapp_purchase/" ":(top)packages/google/" ":(top)packages/apple/")
           fi
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="- No direct code changes — picks up the latest openiap-google / openiap-apple native library updates. See the consolidated release notes for details."

--- a/.github/workflows/release-godot.yml
+++ b/.github/workflows/release-godot.yml
@@ -457,7 +457,7 @@ jobs:
           fi
           PREV_TAG=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' 'refs/tags/godot-iap-*' | grep -v "$VERSION" | head -n 1)
           if [ -n "$PREV_TAG" ]; then
-            CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- libraries/godot-iap/ packages/google/)
+            CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- ":(top)libraries/godot-iap/" ":(top)packages/google/")
           fi
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="- No direct code changes — picks up the latest openiap-google native library updates. See the consolidated release notes for details."

--- a/.github/workflows/release-google.yml
+++ b/.github/workflows/release-google.yml
@@ -435,7 +435,7 @@ jobs:
           CHANGELOG="- Initial release"
         else
           echo "Generating changelog from $PREV_TAG to $RELEASE_REF"
-          CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- packages/google/)
+          CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- ":(top)packages/google/")
 
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="- No direct code changes in packages/google/."

--- a/.github/workflows/release-kmp.yml
+++ b/.github/workflows/release-kmp.yml
@@ -322,7 +322,7 @@ jobs:
           fi
           PREV_TAG=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' 'refs/tags/kmp-iap-*' | grep -v "$VERSION" | head -n 1)
           if [ -n "$PREV_TAG" ]; then
-            CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- libraries/kmp-iap/ packages/google/ packages/apple/)
+            CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- ":(top)libraries/kmp-iap/" ":(top)packages/google/" ":(top)packages/apple/")
           fi
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="- No direct code changes — picks up the latest openiap-google / openiap-apple native library updates. See the consolidated release notes for details."

--- a/.github/workflows/release-react-native.yml
+++ b/.github/workflows/release-react-native.yml
@@ -334,7 +334,7 @@ jobs:
           fi
           PREV_TAG=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' 'refs/tags/react-native-iap-*' | grep -v "$VERSION" | head -n 1)
           if [ -n "$PREV_TAG" ]; then
-            CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- libraries/react-native-iap/ packages/google/ packages/apple/)
+            CHANGELOG=$(git log "$PREV_TAG..$RELEASE_REF" --pretty=format:"- %s ([\`%h\`](https://github.com/hyodotdev/openiap/commit/%H))" -- ":(top)libraries/react-native-iap/" ":(top)packages/google/" ":(top)packages/apple/")
           fi
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="- No direct code changes — picks up the latest openiap-google / openiap-apple native library updates. See the consolidated release notes for details."

--- a/packages/docs/src/generated/version-metadata.json
+++ b/packages/docs/src/generated/version-metadata.json
@@ -1,7 +1,7 @@
 {
   "_generatedBy": "scripts/sync-versions.sh",
   "expoPackageVersion": "4.6.0",
-  "reactNativePackageVersion": "15.5.3",
+  "reactNativePackageVersion": "15.5.4",
   "flutterPackageVersion": "9.5.1",
   "godotPackageVersion": "2.5.2",
   "kmpPackageVersion": "2.6.0",


### PR DESCRIPTION
## Summary

- Every package release note has been falling back to "No direct code changes — picks up the latest openiap-google / openiap-apple native library updates", even when the release contained real fixes (e.g. `react-native-iap-15.5.4`, which ships the #238 fix).
- Root cause: the release deploy jobs set the package directory as the default `working-directory`, so the cwd-relative pathspecs passed to `git log` (e.g. `libraries/react-native-iap/`) resolved to non-existent paths like `libraries/react-native-iap/libraries/react-native-iap/` and matched nothing. Reproduced locally: the same `git log` range returns the fix commits from the repo root and nothing from the package directory.
- Fix: use git's `":(top)"` pathspec magic in all seven release workflows (apple, google, react-native, expo, flutter, godot, kmp) so changelog paths resolve from the repo root regardless of the step's working directory.
- Also syncs `packages/docs/src/generated/version-metadata.json` to the react-native-iap 15.5.4 bump via `scripts/sync-versions.sh` (the pre-commit parity audit requires it after the release commit on `main`).

After merge, re-dispatching `release-react-native.yml` with `version=current` regenerates the 15.5.4 GitHub release body with the real changelog (tag is reused and npm publish is skipped since the version already exists).

## Test plan

- [x] Reproduced the empty-changelog bug locally and verified `":(top)"` pathspecs return the expected commits from inside the package directory
- [x] `bun audit:parity` passes (pre-commit CI mirror)
- [x] Docs typecheck, `audit:docs`, and Prettier pass (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154xivm4YeCVS9yxk54bHL6

---
_Generated by [Claude Code](https://claude.ai/code/session_0154xivm4YeCVS9yxk54bHL6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release note generation across Apple, Expo, Flutter, Godot, Google, KMP, and React Native releases.
  - Release notes now more reliably include changes associated with the correct platform and package areas.
  - Helps ensure “What’s Changed” sections are accurately scoped and contain relevant updates for each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->