### PR TITLE
refactor(kit): prefer webhook events for dedup

### DIFF
--- a/packages/kit/convex/schema.ts
+++ b/packages/kit/convex/schema.ts
@@ -610,6 +610,16 @@ const schema = defineSchema({
     .index("by_project_and_notification_id", [
       "projectId",
       "sourceNotificationId",
+    ])
+    // Source-aware lookup used for ingestion dedup. Keep this separate from
+    // `by_project_and_notification_id`: SSE reconnects only send the stable
+    // sourceNotificationId in Last-Event-ID and therefore cannot supply a
+    // source discriminator, while ingestion must preserve the full
+    // (projectId, source, sourceNotificationId) natural key.
+    .index("by_project_and_source_and_notification_id", [
+      "projectId",
+      "source",
+      "sourceNotificationId",
     ]),
 
   // Dedup table for webhook payloads. Insertion uses

--- a/packages/kit/convex/subscriptions/horizonInternal.test.ts
+++ b/packages/kit/convex/subscriptions/horizonInternal.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { recordHorizonStatus as registeredRecordHorizonStatus } from "./horizonInternal";
+import { testableFunction } from "../test.setup";
+
+const recordHorizonStatus = testableFunction(registeredRecordHorizonStatus);
+
+interface TestRow {
+  _id: string;
+  [field: string]: unknown;
+}
+
+class EqualityBuilder {
+  readonly filters: Array<[field: string, value: unknown]> = [];
+
+  eq(field: string, value: unknown): this {
+    this.filters.push([field, value]);
+    return this;
+  }
+}
+
+function indexedUniqueQuery(rows: TestRow[]) {
+  return {
+    withIndex(
+      _indexName: string,
+      configure: (builder: EqualityBuilder) => unknown,
+    ) {
+      const builder = new EqualityBuilder();
+      configure(builder);
+      const matches = rows.filter((row) =>
+        builder.filters.every(([field, value]) => row[field] === value),
+      );
+      return {
+        unique: async (): Promise<TestRow | null> => {
+          if (matches.length > 1) {
+            throw new Error(
+              `Expected at most one row, received ${matches.length}`,
+            );
+          }
+          return matches[0] ?? null;
+        },
+      };
+    },
+  };
+}
+
+function createHorizonHarness(eventRows: TestRow[], lastEventId: string) {
+  const organization: TestRow = { _id: "organization_a" };
+  const project: TestRow = {
+    _id: "project_a",
+    organizationId: organization._id,
+  };
+  const subscription: TestRow = {
+    _id: "subscription_a",
+    projectId: project._id,
+    purchaseToken: "purchase_token",
+    productId: "premium_monthly",
+    platform: "Android",
+    state: "Expired",
+    lastEventId,
+  };
+  const events = eventRows.map((row) => ({ ...row }));
+  const insert = vi.fn(
+    async (table: string, value: Record<string, unknown>): Promise<string> => {
+      if (table !== "webhookEvents") {
+        throw new Error(`Unexpected insert table: ${table}`);
+      }
+      const id = "event_meta_new";
+      events.push({ _id: id, ...value });
+      return id;
+    },
+  );
+  const patch = vi.fn(
+    async (id: string, value: Record<string, unknown>): Promise<void> => {
+      if (id !== subscription._id) {
+        throw new Error(`Unexpected patch row: ${id}`);
+      }
+      Object.assign(subscription, value);
+    },
+  );
+  const get = vi.fn(async (id: string): Promise<TestRow | null> => {
+    if (id === organization._id) return organization;
+    if (id === project._id) return project;
+    if (id === subscription._id) return subscription;
+    return events.find((event) => event._id === id) ?? null;
+  });
+  const query = vi.fn((table: string) => {
+    if (table === "subscriptions") return indexedUniqueQuery([subscription]);
+    if (table === "webhookEvents") return indexedUniqueQuery(events);
+    throw new Error(`Unexpected query table: ${table}`);
+  });
+
+  return {
+    db: { get, insert, patch, query },
+    events,
+    insert,
+    subscription,
+  };
+}
+
+const horizonArgs = {
+  projectId: "project_a" as never,
+  purchaseToken: "purchase_token",
+  userId: "user_a",
+  productId: "premium_monthly",
+  eventType: "SubscriptionExpired" as const,
+};
+const horizonNotificationId =
+  "meta-horizon-SubscriptionExpired-purchase_token-premium_monthly";
+
+describe("recordHorizonStatus source-aware dedup", () => {
+  it("does not reuse another source's event with the same notification id", async () => {
+    const harness = createHorizonHarness(
+      [
+        {
+          _id: "event_apple",
+          projectId: "project_a",
+          source: "AppleAppStoreServerNotificationsV2",
+          sourceNotificationId: horizonNotificationId,
+        },
+      ],
+      "event_apple",
+    );
+
+    await expect(
+      recordHorizonStatus._handler({ db: harness.db }, horizonArgs),
+    ).resolves.toBe("subscription_a");
+
+    expect(harness.insert).toHaveBeenCalledTimes(1);
+    expect(harness.events).toEqual([
+      expect.objectContaining({ _id: "event_apple" }),
+      expect.objectContaining({
+        _id: "event_meta_new",
+        projectId: "project_a",
+        source: "MetaHorizonReconciler",
+        sourceNotificationId: horizonNotificationId,
+      }),
+    ]);
+    expect(harness.subscription.lastEventId).toBe("event_meta_new");
+  });
+
+  it("reuses the Meta event when another source has the same notification id", async () => {
+    const harness = createHorizonHarness(
+      [
+        {
+          _id: "event_apple",
+          projectId: "project_a",
+          source: "AppleAppStoreServerNotificationsV2",
+          sourceNotificationId: horizonNotificationId,
+        },
+        {
+          _id: "event_meta",
+          projectId: "project_a",
+          source: "MetaHorizonReconciler",
+          sourceNotificationId: horizonNotificationId,
+        },
+      ],
+      "event_meta",
+    );
+
+    await expect(
+      recordHorizonStatus._handler({ db: harness.db }, horizonArgs),
+    ).resolves.toBe("subscription_a");
+
+    expect(harness.insert).not.toHaveBeenCalled();
+    expect(harness.events).toHaveLength(2);
+    expect(harness.subscription.lastEventId).toBe("event_meta");
+  });
+});

--- a/packages/kit/convex/subscriptions/horizonInternal.ts
+++ b/packages/kit/convex/subscriptions/horizonInternal.ts
@@ -227,9 +227,10 @@ export const recordHorizonStatus = internalMutation({
     // when one is already on file.
     const existingEvent = await ctx.db
       .query("webhookEvents")
-      .withIndex("by_project_and_notification_id", (q) =>
+      .withIndex("by_project_and_source_and_notification_id", (q) =>
         q
           .eq("projectId", args.projectId)
+          .eq("source", "MetaHorizonReconciler")
           .eq("sourceNotificationId", sourceNotificationId),
       )
       .unique();

--- a/packages/kit/convex/test.setup.ts
+++ b/packages/kit/convex/test.setup.ts
@@ -1,11 +1,17 @@
-import type { RegisteredMutation, RegisteredQuery } from "convex/server";
+import type {
+  RegisteredAction,
+  RegisteredMutation,
+  RegisteredQuery,
+} from "convex/server";
 
 type RegisteredFunctionHandler<T> =
   T extends RegisteredQuery<infer _Visibility, infer Args, infer Returns>
     ? (ctx: unknown, args: Args) => Returns
     : T extends RegisteredMutation<infer _Visibility, infer Args, infer Returns>
       ? (ctx: unknown, args: Args) => Returns
-      : never;
+      : T extends RegisteredAction<infer _Visibility, infer Args, infer Returns>
+        ? (ctx: unknown, args: Args) => Returns
+        : never;
 
 type TestableRegisteredFunction<T> = T & {
   _handler: RegisteredFunctionHandler<T>;
@@ -14,10 +20,10 @@ type TestableRegisteredFunction<T> = T & {
 /**
  * Restore Convex's runtime-only handler seam for focused unit tests.
  *
- * Convex deliberately strips `_handler` from its published declarations, even
- * though registered queries and mutations retain it at runtime. Keeping the
- * assertion here makes that test-only dependency explicit while preserving
- * each function's validated argument and return types.
+ * Convex deliberately strips `_handler` from some published declarations, even
+ * though registered queries, mutations, and actions retain it at runtime.
+ * Keeping the assertion here makes that test-only dependency explicit while
+ * preserving each function's validated argument and return types.
  */
 function assertHasTestHandler<T>(
   registeredFunction: T,

--- a/packages/kit/convex/webhooks/google.test.ts
+++ b/packages/kit/convex/webhooks/google.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ingestGoogleRtdn as registeredIngestGoogleRtdn } from "./google";
+import { testableFunction } from "../test.setup";
+
+const ingestGoogleRtdn = testableFunction(registeredIngestGoogleRtdn);
+
+describe("ingestGoogleRtdn preflight", () => {
+  it("returns an existing event before Play enrichment or mutations", async () => {
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce({
+        _id: "project_a",
+        androidPackageName: "dev.openiap.test",
+      })
+      .mockResolvedValueOnce("event_existing");
+    const runAction = vi.fn();
+    const runMutation = vi.fn();
+
+    const result = await ingestGoogleRtdn._handler(
+      { runAction, runMutation, runQuery },
+      {
+        apiKey: "test_key",
+        rawMessage: "raw",
+        payload: {
+          messageId: "message_existing",
+          packageName: "dev.openiap.test",
+          eventTimeMillis: 1_000,
+          subscriptionNotification: {
+            notificationType: 2,
+            purchaseToken: "purchase_token",
+            subscriptionId: "premium_monthly",
+          },
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      eventId: "event_existing",
+      type: "WebhookEvent",
+      deduped: true,
+    });
+    expect(runQuery).toHaveBeenCalledTimes(2);
+    expect(runQuery.mock.calls[1]?.[1]).toEqual({
+      projectId: "project_a",
+      source: "google",
+      sourceNotificationId: "message_existing",
+    });
+    expect(runAction).not.toHaveBeenCalled();
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit/convex/webhooks/google.ts
+++ b/packages/kit/convex/webhooks/google.ts
@@ -146,9 +146,10 @@ export const ingestGoogleRtdn = action({
       });
     }
 
-    // Pre-flight idempotency probe: if this messageId is already in
-    // `webhookIdempotencyKeys`, this is a Pub/Sub redelivery for an
-    // event we already processed. Short-circuit BEFORE
+    // Pre-flight idempotency probe: if this messageId already resolves through
+    // the source-aware webhookEvents index (or the phase-1 idempotency-key
+    // fallback), this is a Pub/Sub redelivery for an event we already
+    // processed. Short-circuit BEFORE
     // maybeFetchSubscriptionInfo so retries don't burn Play Developer
     // API quota on every redelivery — kit's webhook receiver becomes a
     // multiplier of Play API calls otherwise (one Pub/Sub retry per

--- a/packages/kit/convex/webhooks/internal.test.ts
+++ b/packages/kit/convex/webhooks/internal.test.ts
@@ -1,9 +1,146 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { recordWebhookEvent as registeredRecordWebhookEvent } from "./internal";
+import {
+  lookupExistingEvent as registeredLookupExistingEvent,
+  recordWebhookEvent as registeredRecordWebhookEvent,
+} from "./internal";
 import { testableFunction } from "../test.setup";
 
+const lookupExistingEvent = testableFunction(registeredLookupExistingEvent);
 const recordWebhookEvent = testableFunction(registeredRecordWebhookEvent);
+
+interface TestRow {
+  _id: string;
+  [field: string]: unknown;
+}
+
+class TestIndexBuilder {
+  constructor(
+    private readonly filters: Array<[field: string, value: unknown]>,
+  ) {}
+
+  eq(field: string, value: unknown): this {
+    this.filters.push([field, value]);
+    return this;
+  }
+}
+
+class TestQuery {
+  private readonly filters: Array<[field: string, value: unknown]> = [];
+
+  constructor(private readonly rows: TestRow[]) {}
+
+  withIndex(
+    _indexName: string,
+    configure: (builder: TestIndexBuilder) => unknown,
+  ): this {
+    configure(new TestIndexBuilder(this.filters));
+    return this;
+  }
+
+  async unique(): Promise<TestRow | null> {
+    const matches = this.matchingRows();
+    if (matches.length > 1) {
+      throw new Error(`Expected at most one row, received ${matches.length}`);
+    }
+    return matches[0] ?? null;
+  }
+
+  async collect(): Promise<TestRow[]> {
+    return this.matchingRows();
+  }
+
+  private matchingRows(): TestRow[] {
+    return this.rows.filter((row) =>
+      this.filters.every(([field, value]) => row[field] === value),
+    );
+  }
+}
+
+class TestDb {
+  private nextId = 1;
+  private readonly tables = new Map<string, TestRow[]>();
+
+  constructor(seed: Record<string, TestRow[]>) {
+    for (const [table, rows] of Object.entries(seed)) {
+      this.tables.set(
+        table,
+        rows.map((row) => ({ ...row })),
+      );
+    }
+  }
+
+  query(table: string): TestQuery {
+    return new TestQuery(this.table(table));
+  }
+
+  async get(id: string): Promise<TestRow | null> {
+    for (const rows of this.tables.values()) {
+      const match = rows.find((row) => row._id === id);
+      if (match) return match;
+    }
+    return null;
+  }
+
+  async insert(table: string, value: Record<string, unknown>): Promise<string> {
+    const id = `${table}_${this.nextId++}`;
+    this.table(table).push({ _id: id, ...value });
+    return id;
+  }
+
+  async patch(id: string, value: Record<string, unknown>): Promise<void> {
+    const row = await this.get(id);
+    if (!row) throw new Error(`Unknown row: ${id}`);
+    Object.assign(row, value);
+  }
+
+  rows(table: string): TestRow[] {
+    return this.table(table);
+  }
+
+  private table(name: string): TestRow[] {
+    const existing = this.tables.get(name);
+    if (existing) return existing;
+    const rows: TestRow[] = [];
+    this.tables.set(name, rows);
+    return rows;
+  }
+}
+
+function createWritableDb(extra: Record<string, TestRow[]> = {}): TestDb {
+  return new TestDb({
+    organizations: [{ _id: "organization_a" }, { _id: "organization_b" }],
+    projects: [
+      { _id: "project_a", organizationId: "organization_a" },
+      { _id: "project_b", organizationId: "organization_b" },
+    ],
+    webhookEvents: [],
+    webhookIdempotencyKeys: [],
+    ...extra,
+  });
+}
+
+function webhookArgs(
+  projectId: string,
+  source: "apple" | "google",
+  sourceNotificationId: string,
+) {
+  const apple = source === "apple";
+  return {
+    projectId: projectId as never,
+    source,
+    sourceNotificationId,
+    event: {
+      type: "SubscriptionStarted" as const,
+      sourceFull: apple
+        ? ("AppleAppStoreServerNotificationsV2" as const)
+        : ("GooglePlayRealTimeDeveloperNotifications" as const),
+      platform: apple ? ("IOS" as const) : ("Android" as const),
+      environment: "Sandbox" as const,
+      occurredAt: 1_000,
+    },
+  };
+}
 
 describe("recordWebhookEvent pending-deletion guard", () => {
   for (const pendingOwner of ["project", "organization"] as const) {
@@ -50,4 +187,169 @@ describe("recordWebhookEvent pending-deletion guard", () => {
       expect(insert).not.toHaveBeenCalled();
     });
   }
+});
+
+describe("webhook event-first dedup migration", () => {
+  it("dedups a replay by the source-aware event index while retaining key writes", async () => {
+    const db = createWritableDb();
+    const args = webhookArgs("project_a", "apple", "notification_same");
+
+    const first = await recordWebhookEvent._handler({ db }, args);
+    expect(db.rows("webhookIdempotencyKeys")).toHaveLength(1);
+    db.rows("webhookIdempotencyKeys").splice(0);
+    const replay = await recordWebhookEvent._handler({ db }, args);
+
+    expect(first.deduped).toBe(false);
+    expect(replay).toEqual({ eventId: first.eventId, deduped: true });
+    expect(db.rows("webhookEvents")).toHaveLength(1);
+    expect(db.rows("webhookIdempotencyKeys")).toHaveLength(0);
+  });
+
+  it("keeps equal notification ids from Apple and Google separate", async () => {
+    const db = createWritableDb();
+
+    const apple = await recordWebhookEvent._handler(
+      { db },
+      webhookArgs("project_a", "apple", "shared_notification"),
+    );
+    const google = await recordWebhookEvent._handler(
+      { db },
+      webhookArgs("project_a", "google", "shared_notification"),
+    );
+
+    expect(apple.deduped).toBe(false);
+    expect(google.deduped).toBe(false);
+    expect(google.eventId).not.toBe(apple.eventId);
+    expect(db.rows("webhookEvents").map((row) => row.source)).toEqual([
+      "AppleAppStoreServerNotificationsV2",
+      "GooglePlayRealTimeDeveloperNotifications",
+    ]);
+  });
+
+  it("keeps equal source notification ids from different projects separate", async () => {
+    const db = createWritableDb();
+
+    const firstProject = await recordWebhookEvent._handler(
+      { db },
+      webhookArgs("project_a", "google", "shared_message"),
+    );
+    const secondProject = await recordWebhookEvent._handler(
+      { db },
+      webhookArgs("project_b", "google", "shared_message"),
+    );
+
+    expect(firstProject.deduped).toBe(false);
+    expect(secondProject.deduped).toBe(false);
+    expect(secondProject.eventId).not.toBe(firstProject.eventId);
+    expect(db.rows("webhookEvents").map((row) => row.projectId)).toEqual([
+      "project_a",
+      "project_b",
+    ]);
+  });
+
+  it("uses the event row for the Google preflight before the key fallback", async () => {
+    const db = createWritableDb({
+      webhookEvents: [
+        {
+          _id: "event_google",
+          projectId: "project_a",
+          source: "GooglePlayRealTimeDeveloperNotifications",
+          sourceNotificationId: "message_a",
+        },
+        {
+          _id: "event_apple",
+          projectId: "project_a",
+          source: "AppleAppStoreServerNotificationsV2",
+          sourceNotificationId: "message_a",
+        },
+      ],
+      webhookIdempotencyKeys: [],
+    });
+
+    await expect(
+      lookupExistingEvent._handler(
+        { db },
+        {
+          projectId: "project_a" as never,
+          source: "google",
+          sourceNotificationId: "message_a",
+        },
+      ),
+    ).resolves.toBe("event_google");
+  });
+
+  it("retains the project-keyed preflight fallback during phase 1", async () => {
+    const db = createWritableDb({
+      webhookIdempotencyKeys: [
+        {
+          _id: "key_existing",
+          projectId: "project_a",
+          source: "google",
+          sourceNotificationId: "message_from_key",
+          eventId: "event_from_key",
+        },
+      ],
+    });
+
+    await expect(
+      lookupExistingEvent._handler(
+        { db },
+        {
+          projectId: "project_a" as never,
+          source: "google",
+          sourceNotificationId: "message_from_key",
+        },
+      ),
+    ).resolves.toBe("event_from_key");
+  });
+
+  it("adopts a half-written legacy key when no event row exists", async () => {
+    const db = createWritableDb({
+      webhookIdempotencyKeys: [
+        {
+          _id: "legacy_key",
+          source: "google",
+          sourceNotificationId: "legacy_message",
+          firstSeenAt: 500,
+        },
+      ],
+    });
+
+    const result = await recordWebhookEvent._handler(
+      { db },
+      webhookArgs("project_a", "google", "legacy_message"),
+    );
+
+    expect(result.deduped).toBe(false);
+    expect(db.rows("webhookEvents")).toHaveLength(1);
+    expect(db.rows("webhookIdempotencyKeys")).toEqual([
+      expect.objectContaining({
+        _id: "legacy_key",
+        eventId: result.eventId,
+        firstSeenAt: 500,
+      }),
+    ]);
+  });
+
+  it("rejects a short and stored source mismatch before writing", async () => {
+    const db = createWritableDb();
+    const args = webhookArgs("project_a", "apple", "mismatched_source");
+
+    await expect(
+      recordWebhookEvent._handler(
+        { db },
+        {
+          ...args,
+          event: {
+            ...args.event,
+            sourceFull: "GooglePlayRealTimeDeveloperNotifications",
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      "Webhook source mismatch: apple cannot store GooglePlayRealTimeDeveloperNotifications",
+    );
+    expect(db.rows("webhookEvents")).toHaveLength(0);
+    expect(db.rows("webhookIdempotencyKeys")).toHaveLength(0);
+  });
 });

--- a/packages/kit/convex/webhooks/internal.ts
+++ b/packages/kit/convex/webhooks/internal.ts
@@ -12,6 +12,19 @@ import { assertProjectWritable } from "../projects/writable";
 // reads naturally.
 export const WEBHOOK_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
+type WebhookDedupSource = "apple" | "google";
+type StoredWebhookSource =
+  | "AppleAppStoreServerNotificationsV2"
+  | "GooglePlayRealTimeDeveloperNotifications";
+
+function storedSourceForDedupSource(
+  source: WebhookDedupSource,
+): StoredWebhookSource {
+  return source === "apple"
+    ? "AppleAppStoreServerNotificationsV2"
+    : "GooglePlayRealTimeDeveloperNotifications";
+}
+
 // Cheap pre-flight dedup probe used by webhooks/google.ts to avoid
 // burning Play Developer API quota on Pub/Sub retries. Returns the
 // existing eventId if the (projectId, source, sourceNotificationId)
@@ -21,10 +34,11 @@ export const WEBHOOK_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 // already-processed messageId can short-circuit before
 // `purchases.subscriptionsv2.get` ever fires.
 //
-// Note: this only checks the new project-keyed index. Legacy rows
-// (projectId == null) aren't checked here — they can still slip a
-// duplicate Play API call through, but the legacy fallback is rare
-// and `recordWebhookEvent` will still dedup the actual event row.
+// Phase 1 of issue #241 treats webhookEvents as the authoritative fast path
+// while retaining the project-keyed idempotency row as a rollback fallback.
+// Legacy rows (projectId == null) aren't checked here — they can still slip a
+// duplicate Play API call through, but `recordWebhookEvent` retains the legacy
+// fallback and will still dedup the actual event row.
 export const lookupExistingEvent = internalQuery({
   args: {
     projectId: v.id("projects"),
@@ -33,7 +47,18 @@ export const lookupExistingEvent = internalQuery({
   },
   returns: v.union(v.null(), v.id("webhookEvents")),
   handler: async (ctx, args) => {
-    const existing = await ctx.db
+    const existingEvent = await ctx.db
+      .query("webhookEvents")
+      .withIndex("by_project_and_source_and_notification_id", (q) =>
+        q
+          .eq("projectId", args.projectId)
+          .eq("source", storedSourceForDedupSource(args.source))
+          .eq("sourceNotificationId", args.sourceNotificationId),
+      )
+      .unique();
+    if (existingEvent) return existingEvent._id;
+
+    const existingKey = await ctx.db
       .query("webhookIdempotencyKeys")
       .withIndex("by_project_and_source_and_id", (q) =>
         q
@@ -42,12 +67,12 @@ export const lookupExistingEvent = internalQuery({
           .eq("sourceNotificationId", args.sourceNotificationId),
       )
       .unique();
-    return existing?.eventId ?? null;
+    return existingKey?.eventId ?? null;
   },
 });
 
 // Insert a normalized webhook event with idempotency on
-// `(source, sourceNotificationId)`. Returns the existing event id
+// `(projectId, source, sourceNotificationId)`. Returns the existing event id
 // (and `deduped: true`) if Apple/Google retries the same notification.
 //
 // This is the only path that writes to `webhookEvents` /
@@ -134,15 +159,29 @@ export const recordWebhookEvent = internalMutation({
     // on transient 5xx, and Google Pub/Sub guarantees at-least-once
     // delivery — both are normal, both must result in HTTP 200 here.
     //
-    // DEFERRED(schema-cleanup): the `webhookIdempotencyKeys` table is
-    // arguably redundant with `webhookEvents.by_project_and_notification_id`
-    // — that index already enforces uniqueness on
-    // `(projectId, sourceNotificationId)`. We could fold the dedup
-    // check into a direct lookup against webhookEvents and drop
-    // this table entirely, halving the per-webhook write
-    // amplification. Deferred to a separate PR because removing
-    // the table requires a migration step + careful coordination
-    // with the existing prune cron.
+    // Issue #241 phase 1: read the source-aware webhookEvents index first,
+    // but keep the idempotency-key fallback and writes below. That makes the
+    // event table the exercised dedup path before phase 2 stops writing keys,
+    // while preserving rollback compatibility and the legacy-row drain.
+    const storedSource = storedSourceForDedupSource(args.source);
+    if (args.event.sourceFull !== storedSource) {
+      throw new Error(
+        `Webhook source mismatch: ${args.source} cannot store ${args.event.sourceFull}`,
+      );
+    }
+    const existingEvent = await ctx.db
+      .query("webhookEvents")
+      .withIndex("by_project_and_source_and_notification_id", (q) =>
+        q
+          .eq("projectId", args.projectId)
+          .eq("source", storedSource)
+          .eq("sourceNotificationId", args.sourceNotificationId),
+      )
+      .unique();
+    if (existingEvent) {
+      return { eventId: existingEvent._id, deduped: true };
+    }
+
     // Scope dedup by projectId because Google Pub/Sub's messageId is
     // only guaranteed unique *within a topic* — different kit
     // projects can receive notifications with the same messageId
@@ -231,7 +270,7 @@ export const recordWebhookEvent = internalMutation({
     const eventId: Id<"webhookEvents"> = await ctx.db.insert("webhookEvents", {
       projectId: args.projectId,
       type: args.event.type,
-      source: args.event.sourceFull,
+      source: storedSource,
       platform: args.event.platform,
       environment: args.event.environment,
       purchaseToken: args.event.purchaseToken,

--- a/packages/kit/convex/webhooks/internal.ts
+++ b/packages/kit/convex/webhooks/internal.ts
@@ -1,6 +1,7 @@
 import { internalMutation, internalQuery } from "../_generated/server";
 import { v } from "convex/values";
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
+import type { QueryCtx } from "../_generated/server";
 import { assertProjectWritable } from "../projects/writable";
 
 // Retention window for `webhookEvents` and `webhookIdempotencyKeys`.
@@ -16,6 +17,13 @@ type WebhookDedupSource = "apple" | "google";
 type StoredWebhookSource =
   | "AppleAppStoreServerNotificationsV2"
   | "GooglePlayRealTimeDeveloperNotifications";
+type WebhookEventReader = Pick<QueryCtx["db"], "query">;
+
+interface WebhookEventDedupKey {
+  projectId: Id<"projects">;
+  source: StoredWebhookSource;
+  sourceNotificationId: string;
+}
 
 function storedSourceForDedupSource(
   source: WebhookDedupSource,
@@ -23,6 +31,21 @@ function storedSourceForDedupSource(
   return source === "apple"
     ? "AppleAppStoreServerNotificationsV2"
     : "GooglePlayRealTimeDeveloperNotifications";
+}
+
+async function findWebhookEventByDedupKey(
+  db: WebhookEventReader,
+  key: WebhookEventDedupKey,
+): Promise<Doc<"webhookEvents"> | null> {
+  return await db
+    .query("webhookEvents")
+    .withIndex("by_project_and_source_and_notification_id", (q) =>
+      q
+        .eq("projectId", key.projectId)
+        .eq("source", key.source)
+        .eq("sourceNotificationId", key.sourceNotificationId),
+    )
+    .unique();
 }
 
 // Cheap pre-flight dedup probe used by webhooks/google.ts to avoid
@@ -47,15 +70,11 @@ export const lookupExistingEvent = internalQuery({
   },
   returns: v.union(v.null(), v.id("webhookEvents")),
   handler: async (ctx, args) => {
-    const existingEvent = await ctx.db
-      .query("webhookEvents")
-      .withIndex("by_project_and_source_and_notification_id", (q) =>
-        q
-          .eq("projectId", args.projectId)
-          .eq("source", storedSourceForDedupSource(args.source))
-          .eq("sourceNotificationId", args.sourceNotificationId),
-      )
-      .unique();
+    const existingEvent = await findWebhookEventByDedupKey(ctx.db, {
+      projectId: args.projectId,
+      source: storedSourceForDedupSource(args.source),
+      sourceNotificationId: args.sourceNotificationId,
+    });
     if (existingEvent) return existingEvent._id;
 
     const existingKey = await ctx.db
@@ -169,15 +188,11 @@ export const recordWebhookEvent = internalMutation({
         `Webhook source mismatch: ${args.source} cannot store ${args.event.sourceFull}`,
       );
     }
-    const existingEvent = await ctx.db
-      .query("webhookEvents")
-      .withIndex("by_project_and_source_and_notification_id", (q) =>
-        q
-          .eq("projectId", args.projectId)
-          .eq("source", storedSource)
-          .eq("sourceNotificationId", args.sourceNotificationId),
-      )
-      .unique();
+    const existingEvent = await findWebhookEventByDedupKey(ctx.db, {
+      projectId: args.projectId,
+      source: storedSource,
+      sourceNotificationId: args.sourceNotificationId,
+    });
     if (existingEvent) {
       return { eventId: existingEvent._id, deduped: true };
     }


### PR DESCRIPTION
## Summary

- add a source-aware webhookEvents index for the full project/source/notification natural key while preserving the source-less SSE cursor index
- prefer webhookEvents for Apple, Google, Google preflight, and Horizon dedup while retaining legacy key fallback and writes
- cover cross-source and cross-project collisions, legacy adoption, Google preflight, Horizon, and source mismatch guards

## Rollout

This is phase 1 of the staged migration in #241. It intentionally keeps webhookIdempotencyKeys reads, writes, pruning, and deletion cascades for rollback and retention drain. A later deploy can stop key writes after production observation; table removal must wait at least WEBHOOK_RETENTION_MS and an explicit zero-row check. The webhook event retention cron remains required.

Refs #241

## Verification

- Kit lint: TypeScript, Convex typecheck, ESLint
- Kit tests: 63 files, 705 tests
- Kit Prettier check
- Kit production/server build and smoke probes
- SDK parity audit
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook deduplication using a source-aware, project-scoped lookup so Apple, Google, and Meta notifications with the same id are no longer conflated.
  * Added phase-1 dedup behavior that can reuse an existing webhook event row when the source and notification id match.
  * Rejected source mismatches early to prevent incorrect inserts/updates.
  * Fixed Horizon status recording to reuse or insert events correctly based on notification source.
* **Tests**
  * Added and expanded automated coverage for source-aware deduplication, preflight/idempotency behavior, and mismatch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->