### PR TITLE
fix(android): support API 23 warning sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,17 @@ jobs:
         run: |
           "$GITHUB_WORKSPACE/scripts/ci/retry-gradle.sh" ./gradlew :openiap:assembleAmazonDebug
 
+      # Play lint covers the shared API-23 source set, and Horizon lint covers
+      # its flavor-specific implementation. Amazon lint currently crashes in
+      # the upstream Compose detector on Kotlin metadata 2.2; audit:parity
+      # guards the known API-24 set factory across every minSdk-23 source tree.
+      - name: Lint Android API compatibility
+        working-directory: packages/google
+        run: |
+          "$GITHUB_WORKSPACE/scripts/ci/retry-gradle.sh" ./gradlew \
+            :openiap:lintPlayDebug \
+            :openiap:lintHorizonDebug
+
   test-ios:
     name: Test iOS
     runs-on: macos-15

--- a/libraries/expo-iap/android/src/main/java/expo/modules/iap/ExpoIapLog.kt
+++ b/libraries/expo-iap/android/src/main/java/expo/modules/iap/ExpoIapLog.kt
@@ -3,12 +3,14 @@ package expo.modules.iap
 import android.util.Log
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.Collections
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
 internal object ExpoIapLog {
     private const val TAG = "ExpoIap"
-    private val emittedDeprecations = ConcurrentHashMap.newKeySet<String>()
+    private val emittedDeprecations: MutableSet<String> =
+        Collections.newSetFromMap(ConcurrentHashMap())
     private val SENSITIVE_KEY_FRAGMENTS =
         setOf(
             "token",

--- a/libraries/expo-iap/src/__tests__/native-log-redaction.test.js
+++ b/libraries/expo-iap/src/__tests__/native-log-redaction.test.js
@@ -34,8 +34,12 @@ describe('native log redaction', () => {
     expect(androidLog).toContain('isSensitiveKey');
     expect(iosLog).toContain('isSensitiveKey');
     expect(androidLog).toContain(
-      'private val emittedDeprecations = ConcurrentHashMap.newKeySet<String>()',
+      'private val emittedDeprecations: MutableSet<String>',
     );
+    expect(androidLog).toContain(
+      'Collections.newSetFromMap(ConcurrentHashMap())',
+    );
+    expect(androidLog).not.toContain('ConcurrentHashMap.newKeySet');
     expect(iosLog).toContain(
       'private static var emittedDeprecations = Set<String>()',
     );
@@ -113,9 +117,7 @@ describe('native log redaction', () => {
     expect(onsideModule).toMatch(
       /private func introductoryPricePaymentModeIOS\([\s\S]*?if offer\.price\.value == 0 \{\s+return \.freeTrial\s+\}[\s\S]*?return \.empty/,
     );
-    expect(onsideModule).toContain(
-      'PaymentModeIOS.empty.rawValue',
-    );
+    expect(onsideModule).toContain('PaymentModeIOS.empty.rawValue');
     expect(onsideModule).toContain('private func formatPriceIOS(');
     expect(onsideModule).toContain(
       'private func subscriptionPeriodComponentsIOS(',

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/RnIapLog.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/RnIapLog.kt
@@ -3,12 +3,14 @@ package com.margelo.nitro.iap
 import android.util.Log
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.Collections
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
 internal object RnIapLog {
     private const val TAG = "RnIap"
-    private val emittedDeprecations = ConcurrentHashMap.newKeySet<String>()
+    private val emittedDeprecations: MutableSet<String> =
+        Collections.newSetFromMap(ConcurrentHashMap())
     private val SENSITIVE_KEY_FRAGMENTS = setOf(
         "token",
         "apikey",

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-07-24T15:40:36.134Z
+> Generated: 2026-07-24T20:57:29.106Z
 
 ## Table of Contents
 1. Installation
@@ -31,10 +31,10 @@ cd ios && pod install
 ### Swift (iOS/macOS)
 ```swift
 // Swift Package Manager
-.package(url: "https://github.com/hyodotdev/openiap.git", from: "2.4.2")
+.package(url: "https://github.com/hyodotdev/openiap.git", from: "2.4.3")
 
 // CocoaPods
-pod 'openiap', '~> 2.4.2'
+pod 'openiap', '~> 2.4.3'
 ```
 
 ### Kotlin (Android)

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-07-24T15:40:36.134Z
+> Generated: 2026-07-24T20:57:29.106Z
 
 ## Installation
 
@@ -19,7 +19,7 @@ npm install react-native-iap
 ### Native
 ```swift
 // Swift Package Manager
-.package(url: "https://github.com/hyodotdev/openiap.git", from: "2.4.2")
+.package(url: "https://github.com/hyodotdev/openiap.git", from: "2.4.3")
 ```
 
 ```kotlin

--- a/packages/google/openiap/src/amazon/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/amazon/java/dev/hyo/openiap/OpenIapModule.kt
@@ -43,6 +43,7 @@ import java.lang.ref.WeakReference
 import java.text.NumberFormat
 import java.text.ParsePosition
 import java.util.Currency
+import java.util.Collections
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
@@ -415,14 +416,18 @@ class OpenIapModule
     private val purchaseUpdatesSession = AmazonPurchaseUpdatesSession()
     private val purchaseTypeByReceiptId = ConcurrentHashMap<String, AmazonProductType>()
     private val purchaseSkuByRequestId = ConcurrentHashMap<String, String>()
-    private val purchaseErrorsPublishedAtEnd = ConcurrentHashMap.newKeySet<String>()
+    private val purchaseErrorsPublishedAtEnd: MutableSet<String> =
+        Collections.newSetFromMap(ConcurrentHashMap())
     private val activePurchaseSku = AtomicReference<String?>(null)
     private val purchaseIssuance = AtomicReference<AmazonPurchaseIssuance?>(null)
-    private val purchaseIssuanceErrorsPublishedAtEnd = ConcurrentHashMap.newKeySet<String>()
+    private val purchaseIssuanceErrorsPublishedAtEnd: MutableSet<String> =
+        Collections.newSetFromMap(ConcurrentHashMap())
     private val productTypeBySku = ConcurrentHashMap<String, AmazonProductType>()
 
-    private val purchaseUpdateListeners = ConcurrentHashMap.newKeySet<OpenIapPurchaseUpdateListener>()
-    private val purchaseErrorListeners = ConcurrentHashMap.newKeySet<OpenIapPurchaseErrorListener>()
+    private val purchaseUpdateListeners: MutableSet<OpenIapPurchaseUpdateListener> =
+        Collections.newSetFromMap(ConcurrentHashMap())
+    private val purchaseErrorListeners: MutableSet<OpenIapPurchaseErrorListener> =
+        Collections.newSetFromMap(ConcurrentHashMap())
 
     private fun ensureRegistered() {
         synchronized(registrationLock) {

--- a/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
@@ -63,6 +63,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.lang.ref.WeakReference
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -76,7 +77,8 @@ private val LEGACY_HORIZON_APP_ID_META_DATA = listOf(
     "com.meta.horizon.platform.ovr.HORIZON_APP_ID",
     "com.oculus.vr.APP_ID"
 )
-private val emittedLegacyHorizonAppIdWarnings = ConcurrentHashMap.newKeySet<String>()
+private val emittedLegacyHorizonAppIdWarnings: MutableSet<String> =
+    Collections.newSetFromMap(ConcurrentHashMap())
 
 private fun warnLegacyHorizonAppIdKey(key: String) {
     if (!emittedLegacyHorizonAppIdWarnings.add(key)) return

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
@@ -65,11 +65,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 
 internal object OpenIapStorePurchaseRequestResolver {
     private const val LEGACY_ANDROID_WARNING_KEY = "OpenIapStore.requestPurchase.android"
-    private val emittedLegacyWarnings = ConcurrentHashMap.newKeySet<String>()
+    private val emittedLegacyWarnings: MutableSet<String> =
+        Collections.newSetFromMap(ConcurrentHashMap())
 
     fun sku(
         props: RequestPurchaseProps,

--- a/scripts/audit-android-api-compat.mjs
+++ b/scripts/audit-android-api-compat.mjs
@@ -1,0 +1,8 @@
+import { maskKotlinCommentsAndStrings } from "./audit-purchase-payload-parity.mjs";
+
+const API_24_CONCURRENT_KEY_SET =
+  /(?:java\.util\.concurrent\.)?ConcurrentHashMap\s*\.\s*newKeySet\s*(?:<[^>]*>)?\s*\(/;
+
+export function usesApi24ConcurrentKeySet(source) {
+  return API_24_CONCURRENT_KEY_SET.test(maskKotlinCommentsAndStrings(source));
+}

--- a/scripts/audit-android-api-compat.mjs
+++ b/scripts/audit-android-api-compat.mjs
@@ -1,7 +1,160 @@
-import { maskKotlinCommentsAndStrings } from "./audit-purchase-payload-parity.mjs";
+// Conservatively reserve this identifier in minSdk 23 Android sources. This
+// catches direct calls, static/aliased imports, and callable references without
+// requiring a full Java/Kotlin type resolver. Comments and literal text remain
+// valid because the scanner masks them before applying this check.
+const API_24_CONCURRENT_KEY_SET = /(?:\bnewKeySet\b|`newKeySet`)/;
 
-const API_24_CONCURRENT_KEY_SET = /\bnewKeySet\s*(?:<[^>]*>)?\s*\(/;
+function translateJavaUnicodeEscapes(source) {
+  let translated = "";
+  let trailingBackslashes = 0;
+  let lastResultWasUnicodeEscape = false;
+  let index = 0;
 
-export function usesApi24ConcurrentKeySet(source) {
-  return API_24_CONCURRENT_KEY_SET.test(maskKotlinCommentsAndStrings(source));
+  function append(character, fromUnicodeEscape) {
+    translated += character;
+    trailingBackslashes = character === "\\" ? trailingBackslashes + 1 : 0;
+    lastResultWasUnicodeEscape = fromUnicodeEscape;
+  }
+
+  while (index < source.length) {
+    const character = source[index];
+    if (character !== "\\") {
+      append(character, false);
+      index += 1;
+      continue;
+    }
+
+    const eligible =
+      lastResultWasUnicodeEscape || trailingBackslashes % 2 === 0;
+    const unicodeEscape = eligible
+      ? /^\\u+([0-9a-fA-F]{4})/.exec(source.slice(index))
+      : null;
+    if (unicodeEscape) {
+      append(String.fromCharCode(Number.parseInt(unicodeEscape[1], 16)), true);
+      index += unicodeEscape[0].length;
+      continue;
+    }
+
+    append(character, false);
+    index += 1;
+  }
+
+  return translated;
+}
+
+function maskCommentsAndLiteralText(source, isKotlin) {
+  const masked = Array.from(source, (character) =>
+    character === "\n" || character === "\r" ? character : " ",
+  );
+
+  function skipLineComment(start) {
+    let index = start + 2;
+    while (
+      index < source.length &&
+      source[index] !== "\n" &&
+      source[index] !== "\r"
+    ) {
+      index += 1;
+    }
+    return index;
+  }
+
+  function skipBlockComment(start) {
+    let index = start + 2;
+    let depth = 1;
+    while (index < source.length && depth > 0) {
+      if (isKotlin && source.startsWith("/*", index)) {
+        depth += 1;
+        index += 2;
+      } else if (source.startsWith("*/", index)) {
+        depth -= 1;
+        index += 2;
+      } else {
+        index += 1;
+      }
+    }
+    return index;
+  }
+
+  function scanString(start, delimiter, raw, interpolates) {
+    let index = start + delimiter.length;
+    while (index < source.length) {
+      if (source.startsWith(delimiter, index)) {
+        return index + delimiter.length;
+      }
+      if (!raw && source[index] === "\\") {
+        index += 2;
+        continue;
+      }
+      if (interpolates && source[index] === "$" && source[index + 1] === "{") {
+        index = scanCode(index + 2, true);
+        continue;
+      }
+      index += 1;
+    }
+    return source.length;
+  }
+
+  function scanCode(start, stopAtClosingBrace) {
+    let index = start;
+    let braceDepth = stopAtClosingBrace ? 1 : 0;
+    while (index < source.length) {
+      if (source.startsWith("//", index)) {
+        index = skipLineComment(index);
+        continue;
+      }
+      if (source.startsWith("/*", index)) {
+        index = skipBlockComment(index);
+        continue;
+      }
+      if (source.startsWith('"""', index)) {
+        index = scanString(index, '"""', isKotlin, isKotlin);
+        continue;
+      }
+      if (source[index] === '"') {
+        index = scanString(index, '"', false, isKotlin);
+        continue;
+      }
+      if (source[index] === "'") {
+        index = scanString(index, "'", false, false);
+        continue;
+      }
+      if (source[index] === "`") {
+        const end = source.indexOf("`", index + 1);
+        const closingIndex = end === -1 ? source.length - 1 : end;
+        if (source.slice(index, closingIndex + 1) === "`newKeySet`") {
+          for (
+            let identifierIndex = index;
+            identifierIndex <= closingIndex;
+            identifierIndex += 1
+          ) {
+            masked[identifierIndex] = source[identifierIndex];
+          }
+        }
+        index = closingIndex + 1;
+        continue;
+      }
+      masked[index] = source[index];
+      if (stopAtClosingBrace) {
+        if (source[index] === "{") {
+          braceDepth += 1;
+        } else if (source[index] === "}") {
+          braceDepth -= 1;
+          if (braceDepth === 0) return index + 1;
+        }
+      }
+      index += 1;
+    }
+    return index;
+  }
+
+  scanCode(0, false);
+  return masked.join("");
+}
+
+export function usesApi24ConcurrentKeySet(source, isKotlin = true) {
+  const lexicalSource = isKotlin ? source : translateJavaUnicodeEscapes(source);
+  return API_24_CONCURRENT_KEY_SET.test(
+    maskCommentsAndLiteralText(lexicalSource, isKotlin),
+  );
 }

--- a/scripts/audit-android-api-compat.mjs
+++ b/scripts/audit-android-api-compat.mjs
@@ -5,6 +5,8 @@
 const API_24_CONCURRENT_KEY_SET = /(?:\bnewKeySet\b|`newKeySet`)/;
 
 function translateJavaUnicodeEscapes(source) {
+  // JLS §3.3: a raw backslash is eligible after an even contiguous run, or
+  // when the previous result character itself came from a Unicode escape.
   let translated = "";
   let trailingBackslashes = 0;
   let lastResultWasUnicodeEscape = false;
@@ -120,6 +122,8 @@ function maskCommentsAndLiteralText(source, isKotlin) {
         continue;
       }
       if (source[index] === "`") {
+        // Kotlin backticks delimit executable identifiers. Preserve the exact
+        // forbidden name while masking unrelated escaped-identifier text.
         const end = source.indexOf("`", index + 1);
         const closingIndex = end === -1 ? source.length - 1 : end;
         if (source.slice(index, closingIndex + 1) === "`newKeySet`") {

--- a/scripts/audit-android-api-compat.mjs
+++ b/scripts/audit-android-api-compat.mjs
@@ -1,7 +1,6 @@
 import { maskKotlinCommentsAndStrings } from "./audit-purchase-payload-parity.mjs";
 
-const API_24_CONCURRENT_KEY_SET =
-  /(?:java\.util\.concurrent\.)?ConcurrentHashMap\s*\.\s*newKeySet\s*(?:<[^>]*>)?\s*\(/;
+const API_24_CONCURRENT_KEY_SET = /\bnewKeySet\s*(?:<[^>]*>)?\s*\(/;
 
 export function usesApi24ConcurrentKeySet(source) {
   return API_24_CONCURRENT_KEY_SET.test(maskKotlinCommentsAndStrings(source));

--- a/scripts/audit-android-api-compat.test.mjs
+++ b/scripts/audit-android-api-compat.test.mjs
@@ -30,6 +30,74 @@ test("detects the API 24 concurrent set factory", () => {
     ),
     true,
   );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "Set<String> warnings = ConcurrentHashMap.<String>newKeySet();",
+      false,
+    ),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "/* ignored /* */ Set<String> warnings = ConcurrentHashMap.newKeySet();",
+      false,
+    ),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      'val explanation = "${ConcurrentHashMap.newKeySet<String>()}"',
+    ),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "val warnings = ConcurrentHashMap.`newKeySet`<String>()",
+    ),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "import java.util.concurrent.ConcurrentHashMap.newKeySet as makeSet\n" +
+        "val warnings = makeSet<String>()",
+    ),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "val warnings = ConcurrentHashMap.newKeySet<(String) -> Int>()",
+    ),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet("val factory = ConcurrentHashMap::`newKeySet`"),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet("fun newKeySet(): Set<String> = emptySet()"),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "var warnings = ConcurrentHashMap.\\u006eewKeySet();",
+      false,
+    ),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "var warnings = ConcurrentHashMap.n\\u0065wKeySet();",
+      false,
+    ),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "// ignored\\u000aConcurrentHashMap.newKeySet();",
+      false,
+    ),
+    true,
+  );
 });
 
 test("ignores API 24 factory decoys in comments and strings", () => {
@@ -37,6 +105,40 @@ test("ignores API 24 factory decoys in comments and strings", () => {
     usesApi24ConcurrentKeySet(
       "// ConcurrentHashMap.newKeySet<String>()\n" +
         'val explanation = "ConcurrentHashMap.newKeySet<String>()"',
+    ),
+    false,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      'String explanation = "${ConcurrentHashMap.newKeySet()}";',
+      false,
+    ),
+    false,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      'String explanation = """\n\\\""" ConcurrentHashMap.newKeySet()\n""";',
+      false,
+    ),
+    false,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      'String explanation = "\\\\u006eewKeySet";',
+      false,
+    ),
+    false,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "\\u0022ConcurrentHashMap.newKeySet()\\u0022",
+      false,
+    ),
+    false,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "val `// newKeySet()` = 1\nval warnings = mutableSetOf<String>()",
     ),
     false,
   );

--- a/scripts/audit-android-api-compat.test.mjs
+++ b/scripts/audit-android-api-compat.test.mjs
@@ -16,6 +16,20 @@ test("detects the API 24 concurrent set factory", () => {
     ),
     true,
   );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "import java.util.concurrent.ConcurrentHashMap as CHM\n" +
+        "val listeners = CHM.newKeySet<Listener>()",
+    ),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "import static java.util.concurrent.ConcurrentHashMap.newKeySet;\n" +
+        "Set<String> warnings = newKeySet();",
+    ),
+    true,
+  );
 });
 
 test("ignores API 24 factory decoys in comments and strings", () => {

--- a/scripts/audit-android-api-compat.test.mjs
+++ b/scripts/audit-android-api-compat.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { usesApi24ConcurrentKeySet } from "./audit-android-api-compat.mjs";
+
+test("detects the API 24 concurrent set factory", () => {
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "private val warnings = ConcurrentHashMap.newKeySet<String>()",
+    ),
+    true,
+  );
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "val listeners = java.util.concurrent.ConcurrentHashMap\n" +
+        "  .newKeySet<Listener>()",
+    ),
+    true,
+  );
+});
+
+test("ignores API 24 factory decoys in comments and strings", () => {
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "// ConcurrentHashMap.newKeySet<String>()\n" +
+        'val explanation = "ConcurrentHashMap.newKeySet<String>()"',
+    ),
+    false,
+  );
+});
+
+test("accepts the API 23 compatible concurrent set factory", () => {
+  assert.equal(
+    usesApi24ConcurrentKeySet(
+      "val warnings: MutableSet<String> =\n" +
+        "  Collections.newSetFromMap(ConcurrentHashMap())",
+    ),
+    false,
+  );
+});

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -975,6 +975,7 @@ function expectNoApi24ConcurrentKeySets() {
     "packages/google/openiap/src",
     "libraries/expo-iap/android/src",
     "libraries/flutter_inapp_purchase/android/src",
+    "libraries/flutter_inapp_purchase/example/android/app/src",
     "libraries/godot-iap/android/src",
     "libraries/react-native-iap/android/src",
   ];
@@ -982,10 +983,11 @@ function expectNoApi24ConcurrentKeySets() {
     for (const file of walk(abs(searchRoot))) {
       if (!/\.(?:java|kt)$/.test(file)) continue;
       const source = fs.readFileSync(file, "utf8");
-      if (usesApi24ConcurrentKeySet(source)) {
+      if (usesApi24ConcurrentKeySet(source, file.endsWith(".kt"))) {
         fail(
-          `Android minSdk 23 source uses ConcurrentHashMap.newKeySet (API 24+); ` +
-            `use Collections.newSetFromMap instead: ${path.relative(root, file)}`,
+          `Android minSdk 23 source uses the reserved newKeySet identifier ` +
+            `(ConcurrentHashMap.newKeySet is API 24+); use ` +
+            `Collections.newSetFromMap instead: ${path.relative(root, file)}`,
         );
       }
     }

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { GENERATED_SYNC_MANIFEST } from "../packages/gql/generated-sync-manifest.mjs";
 import { collectGeneratedSyncDrift } from "../packages/gql/scripts/verify-generated-sync.mjs";
 import { collectDeprecationScheduleDrift } from "./audit-deprecation-schedule.mjs";
+import { usesApi24ConcurrentKeySet } from "./audit-android-api-compat.mjs";
 import { assertSpecMatchesNativeFloor } from "./release-branch-policy.mjs";
 import {
   collectPurchasePayloadParityFailures,
@@ -29,6 +30,11 @@ execFileSync(
 execFileSync(
   process.execPath,
   ["--test", path.resolve(root, "scripts/audit-deprecation-schedule.test.mjs")],
+  { stdio: "inherit" },
+);
+execFileSync(
+  process.execPath,
+  ["--test", path.resolve(root, "scripts/audit-android-api-compat.test.mjs")],
   { stdio: "inherit" },
 );
 execFileSync(
@@ -957,6 +963,29 @@ function expectNoExampleStorefrontIOS() {
       if (text.includes("getStorefrontIOS(")) {
         fail(
           `example uses getStorefrontIOS instead of getStorefront: ${path.relative(root, file)}`,
+        );
+      }
+    }
+  }
+}
+
+function expectNoApi24ConcurrentKeySets() {
+  const androidSourceRoots = [
+    "packages/google/Example/src",
+    "packages/google/openiap/src",
+    "libraries/expo-iap/android/src",
+    "libraries/flutter_inapp_purchase/android/src",
+    "libraries/godot-iap/android/src",
+    "libraries/react-native-iap/android/src",
+  ];
+  for (const searchRoot of androidSourceRoots) {
+    for (const file of walk(abs(searchRoot))) {
+      if (!/\.(?:java|kt)$/.test(file)) continue;
+      const source = fs.readFileSync(file, "utf8");
+      if (usesApi24ConcurrentKeySet(source)) {
+        fail(
+          `Android minSdk 23 source uses ConcurrentHashMap.newKeySet (API 24+); ` +
+            `use Collections.newSetFromMap instead: ${path.relative(root, file)}`,
         );
       }
     }
@@ -6245,6 +6274,7 @@ checkBillingChoiceFieldBindings();
 checkFrameworkDependencyHygiene();
 checkReleaseNoteGroupingGuidance();
 expectNoExampleStorefrontIOS();
+expectNoApi24ConcurrentKeySets();
 
 if (failures.length > 0) {
   console.error(


### PR DESCRIPTION
## Summary

- replace API 24-only `ConcurrentHashMap.newKeySet()` usage with the API 23-compatible `Collections.newSetFromMap(...)` across Google, React Native, and Expo Android sources
- add a fault-tested parity guard covering all minSdk 23 Android source trees
- run Play and Horizon Android lint in pull request CI so API compatibility failures are caught before release

## Context

The Google 2.5.1 release validation failed before publishing because Android lint detected an API 24 call while the library supports minSdk 23: [failed release run](https://github.com/hyodotdev/openiap/actions/runs/30125011468). No Google version commit, tag, or Maven artifact was created.

## Verification

- `:openiap:build` (287 tasks; all Google flavors, unit tests, Play lint)
- `:openiap:lintHorizonDebug`
- Expo native log regression test (8 tests)
- Android API compatibility fault tests (3 tests)
- `bun run audit:parity`
- `bun run audit:release-state`
- workflow YAML parse and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android compatibility and de-duplication reliability by switching concurrent set initialization to an API 23–compatible approach across the IAP and OpenIAP modules.
  - Maintained existing “emit once” behavior for warning/deprecation logging.

- **Tests**
  - Added Android API-compat auditing to detect disallowed `ConcurrentHashMap.newKeySet` patterns, with expanded unit coverage.
  - Extended CI validation to run Android lint for additional debug variants.

- **Documentation**
  - Updated generated docs timestamps and bumped the OpenIAP Swift dependency to `2.4.3`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->