### PR TITLE
fix(kit): preserve Android package name casing

### DIFF
--- a/packages/kit/convex/projects/mutation.test.ts
+++ b/packages/kit/convex/projects/mutation.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeAppAppleId } from "./mutation";
+import { normalizeAndroidPackageName, normalizeAppAppleId } from "./mutation";
+
+describe("normalizeAndroidPackageName", () => {
+  it("trims whitespace without changing capitalization", () => {
+    expect(normalizeAndroidPackageName("  com.markhub.Markly  ")).toBe(
+      "com.markhub.Markly",
+    );
+  });
+
+  it("allows correcting capitalization for a saved package name", () => {
+    expect(
+      normalizeAndroidPackageName("com.markhub.Markly", "com.markhub.markly"),
+    ).toBe("com.markhub.Markly");
+  });
+
+  it("rejects changing a saved project to a different package name", () => {
+    expect(() =>
+      normalizeAndroidPackageName("com.example.Other", "com.markhub.markly"),
+    ).toThrow(
+      "Android package name can only be updated to correct capitalization once saved.",
+    );
+  });
+});
 
 describe("normalizeAppAppleId", () => {
   it("accepts positive safe integers", () => {

--- a/packages/kit/convex/projects/mutation.ts
+++ b/packages/kit/convex/projects/mutation.ts
@@ -28,7 +28,10 @@ const projectPlatformValidator = v.union(
   v.literal("other"),
 );
 
-function normalizeAndroidPackageName(input: string): string {
+export function normalizeAndroidPackageName(
+  input: string,
+  currentPackageName?: string,
+): string {
   const normalized = input.trim();
   if (!normalized) {
     throw createError(
@@ -45,7 +48,18 @@ function normalizeAndroidPackageName(input: string): string {
     );
   }
 
-  return normalized.toLowerCase();
+  const normalizedCurrent = currentPackageName?.trim();
+  if (
+    normalizedCurrent &&
+    normalizedCurrent.toLowerCase() !== normalized.toLowerCase()
+  ) {
+    throw createError(
+      ErrorCode.INVALID_INPUT,
+      "Android package name can only be updated to correct capitalization once saved.",
+    );
+  }
+
+  return normalized;
 }
 
 function normalizeIosBundleId(input: string): string {
@@ -348,6 +362,7 @@ export const updateProject = mutation({
     if (args.androidPackageName !== undefined) {
       updates.androidPackageName = normalizeAndroidPackageName(
         args.androidPackageName,
+        project.androidPackageName,
       );
     }
     if (args.iosBundleId !== undefined) {

--- a/packages/kit/src/pages/auth/organization/project/settings.test.tsx
+++ b/packages/kit/src/pages/auth/organization/project/settings.test.tsx
@@ -13,6 +13,16 @@ const mocks = vi.hoisted(() => ({
   fetch: vi.fn(),
   generateUploadUrl: vi.fn(),
   otherMutation: vi.fn(),
+  project: {
+    _id: "projects_test",
+    organizationId: "organizations_test",
+    name: "Test Project",
+    slug: "test-project",
+    iosBundleId: "com.example.test",
+    iosAppStoreIssuerId: "12345678-ABCD-1234-ABCD-1234567890AB",
+    iosAppStoreKeyId: "ABCDE12345",
+    androidPackageName: "com.markhub.markly",
+  },
   saveFile: vi.fn(),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
@@ -53,14 +63,7 @@ function pngBytesWithTransparencyChunk(): Uint8Array {
 
 vi.mock("react-router-dom", () => ({
   useOutletContext: () => ({
-    project: {
-      _id: "projects_test",
-      organizationId: "organizations_test",
-      name: "Test Project",
-      slug: "test-project",
-      iosBundleId: "com.example.test",
-      androidPackageName: "com.example.test",
-    },
+    project: mocks.project,
   }),
 }));
 
@@ -112,7 +115,7 @@ const TARGET_PENDING_MESSAGE =
 const AUTHORIZATION_LOST_MESSAGE =
   "The file was not saved because your access changed during the upload. Please sign in and try again.";
 
-describe("ProjectSettings credential uploads", () => {
+describe("ProjectSettings", () => {
   beforeEach(() => {
     mocks.downloadFile.mockReset();
     mocks.fetch.mockReset();
@@ -145,6 +148,51 @@ describe("ProjectSettings credential uploads", () => {
     cleanup();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  it("allows correcting a stored Android package name with exact capitalization", async () => {
+    mocks.otherMutation.mockResolvedValueOnce(undefined);
+    render(<ProjectSettings />);
+
+    const input =
+      screen.getByLabelText<HTMLInputElement>(/Android package name/);
+    expect(input.disabled).toBe(false);
+
+    fireEvent.change(input, { target: { value: "com.markhub.Markly" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save identifiers" }));
+
+    await waitFor(() => {
+      expect(mocks.otherMutation).toHaveBeenCalledWith({
+        projectId: "projects_test",
+        androidPackageName: "com.markhub.Markly",
+        iosBundleId: "com.example.test",
+        iosAppStoreIssuerId: "12345678-ABCD-1234-ABCD-1234567890AB",
+        iosAppStoreKeyId: "ABCDE12345",
+      });
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Identifiers updated successfully",
+    );
+  });
+
+  it("prevents replacing a stored Android package name", () => {
+    render(<ProjectSettings />);
+
+    fireEvent.change(
+      screen.getByLabelText<HTMLInputElement>(/Android package name/),
+      { target: { value: "com.example.Other" } },
+    );
+
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", {
+        name: "Save identifiers",
+      }).disabled,
+    ).toBe(true);
+    expect(
+      screen.getByText(
+        "A saved Android package name can only be updated to correct capitalization.",
+      ),
+    ).toBeTruthy();
   });
 
   it.each([

--- a/packages/kit/src/pages/auth/organization/project/settings.tsx
+++ b/packages/kit/src/pages/auth/organization/project/settings.tsx
@@ -397,7 +397,6 @@ export default function ProjectSettings() {
   const iosAppleIdLocked = Boolean(originalIosAppleIdString);
   const iosIssuerLocked = Boolean(originalIosIssuerId);
   const iosKeyLocked = Boolean(originalIosKeyId);
-  const androidPackageLocked = Boolean(originalAndroidPackageName);
   const isIosP8Provided = hasIosFile || iosFileUploaded;
 
   const derivedAppleSupport =
@@ -435,7 +434,7 @@ export default function ProjectSettings() {
   }
 
   const applePlatformsLocked = iosBundleLocked || iosAppleIdLocked;
-  const androidPlatformsLocked = androidPackageLocked;
+  const androidPlatformsLocked = Boolean(originalAndroidPackageName);
 
   const showAppleSection = applePlatformsSelected;
   const showAndroidSection = androidPlatformsSelected;
@@ -444,11 +443,16 @@ export default function ProjectSettings() {
       ? "md:grid-cols-2"
       : "md:grid-cols-1";
 
+  const isAndroidPackageFormatValid =
+    trimmedAndroidPackageName.length > 0 &&
+    androidPackagePattern.test(trimmedAndroidPackageName);
+  const isAndroidPackageIdentityValid =
+    !originalAndroidPackageName ||
+    trimmedAndroidPackageName.toLowerCase() ===
+      originalAndroidPackageName.toLowerCase();
   const isAndroidPackageValid =
     !showAndroidSection ||
-    androidPackageLocked ||
-    (trimmedAndroidPackageName.length > 0 &&
-      androidPackagePattern.test(trimmedAndroidPackageName));
+    (isAndroidPackageFormatValid && isAndroidPackageIdentityValid);
   const isIosBundleValid =
     !showAppleSection ||
     iosBundleLocked ||
@@ -1837,7 +1841,10 @@ export default function ProjectSettings() {
                     form's metadata save. The JSON file upload below is
                     a separate flow. */}
                   <div>
-                    <label className="block text-sm font-medium mb-2">
+                    <label
+                      htmlFor="android-package-name"
+                      className="block text-sm font-medium mb-2"
+                    >
                       {"Android package name"}{" "}
                       <span className="text-destructive" aria-hidden="true">
                         *
@@ -1845,6 +1852,7 @@ export default function ProjectSettings() {
                       <span className="sr-only">{"Required"}</span>
                     </label>
                     <input
+                      id="android-package-name"
                       type="text"
                       value={androidPackageName}
                       onChange={(event) =>
@@ -1854,23 +1862,32 @@ export default function ProjectSettings() {
                       placeholder="com.example.app"
                       spellCheck={false}
                       aria-invalid={!isAndroidPackageValid}
-                      disabled={androidPackageLocked}
                     />
                     <p className="text-sm text-muted-foreground mt-1">
                       {
-                        "Use the exact package name from the Google Play Console (e.g., com.example.app)."
+                        "Package names are case-sensitive. Use the exact value from the Google Play Console (e.g., com.example.app)."
                       }
                     </p>
-                    {androidPackageLocked && (
+                    {originalAndroidPackageName && (
                       <p className="text-sm text-muted-foreground mt-1">
-                        {"Android package names can’t be edited once saved."}
+                        {
+                          "You can correct capitalization, but changing to a different package name requires a new project."
+                        }
                       </p>
                     )}
-                    {!isAndroidPackageValid && (
+                    {!isAndroidPackageFormatValid && (
                       <p className="text-sm text-destructive mt-1">
                         {"Enter a valid Android package name."}
                       </p>
                     )}
+                    {isAndroidPackageFormatValid &&
+                      !isAndroidPackageIdentityValid && (
+                        <p className="text-sm text-destructive mt-1">
+                          {
+                            "A saved Android package name can only be updated to correct capitalization."
+                          }
+                        </p>
+                      )}
                   </div>
 
                   <div className="pt-4 border-t border-border/60">


### PR DESCRIPTION
## Summary

- preserve Android package-name casing when IAPKit stores project identifiers
- allow existing projects to correct capitalization without allowing reassignment to a different Android application
- add backend and dashboard regression coverage for case preservation and correction

## Root cause

`normalizeAndroidPackageName` lowercased every valid identifier before persistence, while the dashboard disabled the field after the first save. A valid mixed-case Google Play package name therefore became unrecoverable and all verification requests used the wrong application identifier.

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun audit:parity`
- [x] `bun run audit:release-state`
- [x] IAPKit lint, Convex typecheck, and ESLint
- [x] IAPKit Prettier check
- [x] IAPKit test suite: 72 files / 864 tests
- [x] Compiled server and browser smoke probes on an isolated local port

Closes #259


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android package name validation and formatting guidance.
  * Users can correct capitalization of an existing package name, while changes to a different package name are blocked.
  * Added clearer validation messages and disabled saving when the package name is invalid.
* **Tests**
  * Added coverage for package name trimming, capitalization corrections, identity protection, and save behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->