### PR TITLE
fix(flutter): validate Apple release paths

### DIFF
--- a/.github/workflows/release-flutter.yml
+++ b/.github/workflows/release-flutter.yml
@@ -111,6 +111,13 @@ jobs:
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
+      - name: Select CocoaPods fallback
+        run: |
+          perl -0pi -e \
+            's/enable-swift-package-manager: true/enable-swift-package-manager: false/' \
+            example/pubspec.yaml
+          grep -Fq "enable-swift-package-manager: false" example/pubspec.yaml
+
       - name: Install dependencies
         run: flutter pub get
 
@@ -124,7 +131,9 @@ jobs:
 
       - name: Install CocoaPods dependencies
         working-directory: libraries/flutter_inapp_purchase/example/ios
-        run: pod install --repo-update
+        run: |
+          pod install --repo-update
+          grep -Eq '^[[:space:]]+- openiap ' Podfile.lock
 
       - name: Build iOS
         working-directory: libraries/flutter_inapp_purchase/example/ios
@@ -138,8 +147,32 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             COMPILER_INDEX_STORE_ENABLE=NO
 
+  validate-apple-swiftpm:
+    needs: [release-branch]
+    runs-on: xcode-27
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: libraries/flutter_inapp_purchase
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version: "3.44.0"
+          cache: true
+
+      - name: Build Apple examples with SwiftPM
+        run: bash scripts/verify-apple-swiftpm-consumer-build.sh
+
   deploy:
-    needs: [validate-android, validate-ios]
+    needs: [validate-android, validate-ios, validate-apple-swiftpm]
     permissions:
       contents: write
       id-token: write

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-07-30T11:44:25.606Z
+> Generated: 2026-07-30T18:42:59.387Z
 
 ## Table of Contents
 1. Installation
@@ -31,22 +31,22 @@ cd ios && pod install
 ### Swift (iOS/macOS)
 ```swift
 // Swift Package Manager
-.package(url: "https://github.com/hyodotdev/openiap.git", from: "2.4.4")
+.package(url: "https://github.com/hyodotdev/openiap.git", from: "3.0.0")
 
 // CocoaPods
-pod 'openiap', '~> 2.4.4'
+pod 'openiap', '~> 3.0.0'
 ```
 
 ### Kotlin (Android)
 ```kotlin
 // Gradle (build.gradle.kts)
-implementation("io.github.hyochan.openiap:openiap-google:2.5.2")
+implementation("io.github.hyochan.openiap:openiap-google:3.0.0")
 
 // For Meta Horizon OS
-implementation("io.github.hyochan.openiap:openiap-google-horizon:2.5.2")
+implementation("io.github.hyochan.openiap:openiap-google-horizon:3.0.0")
 
 // For Fire OS (Amazon Appstore)
-implementation("io.github.hyochan.openiap:openiap-google-amazon:2.5.2")
+implementation("io.github.hyochan.openiap:openiap-google-amazon:3.0.0")
 ```
 
 ### Flutter

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-07-30T11:44:25.606Z
+> Generated: 2026-07-30T18:42:59.387Z
 
 ## Installation
 
@@ -19,14 +19,14 @@ npm install react-native-iap
 ### Native
 ```swift
 // Swift Package Manager
-.package(url: "https://github.com/hyodotdev/openiap.git", from: "2.4.4")
+.package(url: "https://github.com/hyodotdev/openiap.git", from: "3.0.0")
 ```
 
 ```kotlin
 // Gradle
-implementation("io.github.hyochan.openiap:openiap-google:2.5.2")
-implementation("io.github.hyochan.openiap:openiap-google-horizon:2.5.2")
-implementation("io.github.hyochan.openiap:openiap-google-amazon:2.5.2")
+implementation("io.github.hyochan.openiap:openiap-google:3.0.0")
+implementation("io.github.hyochan.openiap:openiap-google-horizon:3.0.0")
+implementation("io.github.hyochan.openiap:openiap-google-amazon:3.0.0")
 ```
 
 ```bash

--- a/packages/docs/src/generated/version-metadata.json
+++ b/packages/docs/src/generated/version-metadata.json
@@ -1,7 +1,7 @@
 {
   "_generatedBy": "scripts/sync-versions.sh",
-  "expoPackageVersion": "4.7.2",
-  "reactNativePackageVersion": "15.6.2",
+  "expoPackageVersion": "5.0.0",
+  "reactNativePackageVersion": "16.0.0",
   "flutterPackageVersion": "9.6.2",
   "godotPackageVersion": "2.6.2",
   "kmpPackageVersion": "2.7.2",

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -6545,16 +6545,38 @@ function checkXcode27StoreKitCoverage() {
       `${workflowPath} Xcode 27 scene lifecycle build`,
     );
   }
+  for (const workflowPath of [
+    ".github/workflows/ci-flutter-inapp-purchase.yml",
+    ".github/workflows/release-flutter.yml",
+  ]) {
+    expectIncludes(
+      workflowPath,
+      [
+        'flutter-version: "3.44.0"',
+        "bash scripts/verify-apple-swiftpm-consumer-build.sh",
+      ],
+      `${workflowPath} Flutter Xcode 27 SwiftPM example build`,
+    );
+  }
   expectIncludes(
     ".github/workflows/ci-flutter-inapp-purchase.yml",
     [
-      'flutter-version: "3.44.0"',
-      "bash scripts/verify-apple-swiftpm-consumer-build.sh",
       "packages/apple/Sources/**",
       "packages/apple/Package.swift",
       "openiap-versions.json",
     ],
-    "Flutter Xcode 27 SwiftPM example build",
+    "Flutter Xcode 27 SwiftPM trigger coverage",
+  );
+  expectIncludes(
+    ".github/workflows/release-flutter.yml",
+    [
+      "Select CocoaPods fallback",
+      "enable-swift-package-manager: false",
+      "grep -Eq '^[[:space:]]+- openiap ' Podfile.lock",
+      "validate-apple-swiftpm",
+      "needs: [validate-android, validate-ios, validate-apple-swiftpm]",
+    ],
+    "Flutter release Apple dependency-manager coverage",
   );
   expectIncludes(
     "libraries/flutter_inapp_purchase/example/pubspec.yaml",
@@ -6565,7 +6587,7 @@ function checkXcode27StoreKitCoverage() {
     "libraries/flutter_inapp_purchase/scripts/verify-apple-swiftpm-consumer-build.sh",
     [
       'xcode_version_output="$(xcodebuild -version)"',
-      'xcode_version="${xcode_version_output%%$\'\\n\'*}"',
+      "xcode_version=\"${xcode_version_output%%$'\\n'*}\"",
       '[[ "$xcode_version" != "Xcode 27"* ]]',
       "flutter build ios --config-only --simulator",
       "flutter build macos --config-only",

--- a/scripts/release-branch-policy.test.mjs
+++ b/scripts/release-branch-policy.test.mjs
@@ -25,7 +25,7 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const releaseWorkflows = {
   apple: { filename: "release-apple.yml", guardedJobs: 1 },
   expo: { filename: "release-expo.yml", guardedJobs: 2 },
-  flutter: { filename: "release-flutter.yml", guardedJobs: 2 },
+  flutter: { filename: "release-flutter.yml", guardedJobs: 3 },
   godot: { filename: "release-godot.yml", guardedJobs: 2 },
   google: { filename: "release-google.yml", guardedJobs: 1 },
   kmp: { filename: "release-kmp.yml", guardedJobs: 2 },


### PR DESCRIPTION
## Summary

- validate the Flutter release with the CocoaPods fallback on Flutter 3.41/Xcode 16
- add a separate Flutter 3.44/Xcode 27 SwiftPM release gate
- block publication until both Apple integration paths pass
- synchronize the docs metadata for the already released React Native 16 and Expo 5 packages

## Context

The first Flutter 10.0.0 release attempt stopped before versioning or publication because Flutter 3.41 generated an iOS 13 SwiftPM consumer for a package whose new minimum is iOS 15. This keeps that toolchain on its supported CocoaPods fallback while validating the documented Flutter 3.44+ SwiftPM path separately.

## Verification

- `bun run audit:parity`
- `bun run audit:docs`
- `bun run audit:release-state`
- Prettier, YAML parse, and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple release validation to support both Swift Package Manager and CocoaPods configurations, including lockfile-based CocoaPods checks.
  * Strengthened verification for Flutter-based Apple consumer builds.

* **New Features**
  * Added a dedicated SwiftPM validation job for Apple consumer examples and wired it into the main deploy flow.

* **Documentation**
  * Updated installation examples to reference OpenIAP version **3.0.0**.

* **Tests / Chores**
  * Updated release-branch policy assertions to match new guarded dependency expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->